### PR TITLE
Allow operation with non-stellarator-symmetric vmec files

### DIFF
--- a/SRC/canonical_coordinates_mod.f90
+++ b/SRC/canonical_coordinates_mod.f90
@@ -9,7 +9,7 @@
   end module parmot_mod
 !
   module new_vmec_stuff_mod
-    character*32     :: netcdffile
+    character*1000   :: netcdffile
     integer          :: nsurfm,nstrm,nper,kpar
     integer          :: multharm,n_theta,n_phi
     integer          :: ns_A=5  !<- spline order for vector potential

--- a/SRC/canonical_coordinates_mod.f90
+++ b/SRC/canonical_coordinates_mod.f90
@@ -18,7 +18,8 @@
     double precision :: rmajor,h_theta,h_phi
     double precision, dimension(:),     allocatable :: axm,axn,soa
     double precision, dimension(:),     allocatable :: aiota,s,sps,phi
-    double precision, dimension(:,:),   allocatable :: almn,rmn,zmn
+    double precision, dimension(:,:),   allocatable :: almnc,rmnc,zmnc
+    double precision, dimension(:,:),   allocatable :: almns,rmns,zmns
 !
     double precision, dimension(:,:,:,:,:,:), allocatable :: sR,sZ,slam
   end module new_vmec_stuff_mod

--- a/SRC/new_vmec_allocation_stuff.f90
+++ b/SRC/new_vmec_allocation_stuff.f90
@@ -25,7 +25,8 @@
 !
   allocate(axm(nstrm),axn(nstrm),soa(0:kpar))
   allocate(aiota(0:kpar),sps(0:kpar),phi(0:kpar),s(0:kpar))
-  allocate(rmn(nstrm,0:kpar),zmn(nstrm,0:kpar),almn(nstrm,0:kpar))
+  allocate(rmnc(nstrm,0:kpar),zmnc(nstrm,0:kpar),almnc(nstrm,0:kpar))
+  allocate(rmns(nstrm,0:kpar),zmns(nstrm,0:kpar),almns(nstrm,0:kpar))
 !
   end subroutine new_allocate_vmec_stuff
 !
@@ -37,6 +38,6 @@
 !
   implicit none
 !
-  deallocate(axm,axn,soa,aiota,sps,phi,s,rmn,zmn,almn)
+  deallocate(axm,axn,soa,aiota,sps,phi,s,rmnc,zmnc,almnc,rmns,zmns,almns)
 !
   end subroutine new_deallocate_vmec_stuff

--- a/SRC/spline_vmec_data.f90
+++ b/SRC/spline_vmec_data.f90
@@ -11,14 +11,15 @@
   double precision :: twopi,cosphase,sinphase
   complex(8)   :: base_exp_imt,base_exp_inp,base_exp_inp_inv,expphase
   double precision, dimension(:,:), allocatable :: splcoe
-  double precision, dimension(:,:), allocatable :: almn_rho,rmn_rho,zmn_rho
+  double precision, dimension(:,:), allocatable :: almnc_rho,rmnc_rho,zmnc_rho
+  double precision, dimension(:,:), allocatable :: almns_rho,rmns_rho,zmns_rho
   complex(8),   dimension(:),   allocatable :: exp_imt,exp_inp
 !
   print *,'Splining VMEC data: ns_A = ',ns_A,'  ns_s = ',ns_s,'  ns_tp = ',ns_tp
 !
   call new_allocate_vmec_stuff
 !
-  call vmecin(rmn,zmn,almn,aiota,phi,sps,axm,axn,s,    &
+  call vmecin(rmnc,zmns,almns,rmns,zmnc,almnc,aiota,phi,sps,axm,axn,s,    &
               nsurfm,nstrm,kpar,torflux)
 !
   ns=kpar+1
@@ -26,7 +27,8 @@
   hs=s(2)-s(1)
 !
   nrho=ns
-  allocate(almn_rho(nstrm,0:nrho-1),rmn_rho(nstrm,0:nrho-1),zmn_rho(nstrm,0:nrho-1))
+  allocate(almnc_rho(nstrm,0:nrho-1),rmnc_rho(nstrm,0:nrho-1),zmnc_rho(nstrm,0:nrho-1))
+  allocate(almns_rho(nstrm,0:nrho-1),rmns_rho(nstrm,0:nrho-1),zmns_rho(nstrm,0:nrho-1))
 !
   do i=1,nstrm
 !
@@ -34,11 +36,17 @@
 !
     nheal=min(m, 4)
 !
-    call s_to_rho_healaxis(m,ns,nrho,nheal,rmn(i,:),rmn_rho(i,:))
+    call s_to_rho_healaxis(m,ns,nrho,nheal,rmnc(i,:),rmnc_rho(i,:))
 !
-    call s_to_rho_healaxis(m,ns,nrho,nheal,zmn(i,:),zmn_rho(i,:))
+    call s_to_rho_healaxis(m,ns,nrho,nheal,zmnc(i,:),zmnc_rho(i,:))
 !
-    call s_to_rho_healaxis(m,ns,nrho,nheal,almn(i,:),almn_rho(i,:))
+    call s_to_rho_healaxis(m,ns,nrho,nheal,almnc(i,:),almnc_rho(i,:))
+!
+    call s_to_rho_healaxis(m,ns,nrho,nheal,rmns(i,:),rmns_rho(i,:))
+!
+    call s_to_rho_healaxis(m,ns,nrho,nheal,zmns(i,:),zmns_rho(i,:))
+!
+    call s_to_rho_healaxis(m,ns,nrho,nheal,almns(i,:),almns_rho(i,:))
 !
   enddo
 !
@@ -130,11 +138,14 @@
         sinphase=aimag(expphase)
         do is=1,ns
           sR(1,1,1,is,i_theta,i_phi) = sR(1,1,1,is,i_theta,i_phi)      &
-                                     + rmn_rho(i,is-1)*cosphase
+                                     + rmnc_rho(i,is-1)*cosphase       &
+                                     + rmns_rho(i,is-1)*sinphase
           sZ(1,1,1,is,i_theta,i_phi) = sZ(1,1,1,is,i_theta,i_phi)      &
-                                     + zmn_rho(i,is-1)*sinphase
+                                     + zmnc_rho(i,is-1)*cosphase       &
+                                     + zmns_rho(i,is-1)*sinphase
           slam(1,1,1,is,i_theta,i_phi) = slam(1,1,1,is,i_theta,i_phi)  &
-                                       + almn_rho(i,is-1)*sinphase
+                                       + almnc_rho(i,is-1)*cosphase    &
+                                       + almns_rho(i,is-1)*sinphase
         enddo
       enddo
     enddo


### PR DESCRIPTION
In this pull request I've attempted to modify SIMPLE so non-stellarator-symmetric vmec wout files can be used. For stellarator-symmetric wout files, the changes in this pull request do not change the results in `confined_fraction.dat`. It would be good to do other tests to confirm that the orbits are correct in detail for `lasym=.true.`