### PR TITLE
SIMPLE to sample uniformly in s between sbeg(1) and sbeg(2) if num_surf=2

### DIFF
--- a/SRC/simple.f90
+++ b/SRC/simple.f90
@@ -786,10 +786,19 @@ subroutine init_starting_points_global
       if (0 == num_surf) then
         call random_number(xi)
         r = xi
-      else if (1 < num_surf) then
-        parts_per_s = int(ntestpart/num_surf)
-        s_idx = (ipart/parts_per_s)+1
+      else if (2 == num_surf) then
+        ! now we are just sampling between first two sbeg surfaces with a uniform distribution
+        call random_number(xi)
+        r = sbeg(1) + xi*(sbeg(2)-sbeg(1))
+      else if (3 < num_surf) then
+        ! This splits the particles into num_surf groups and launches parts_per_s particles from each group
+        parts_per_s = ntestpart / num_surf
+        s_idx = int(ipart / parts_per_s) + 1
         r = sbeg(s_idx)
+        if (r == 0) then
+          print *, "Error: The length of sbeg is less than required (num_surf + 1)."
+          stop
+        endif
       else ! Should not happen (as we are not in "local mode"), however let's catch it anyway.
         r = sbeg(1)
       endif

--- a/examples/classification/simple.in
+++ b/examples/classification/simple.in
@@ -1,10 +1,10 @@
 &config
 notrace_passing = 1      ! skip tracing passing prts if notrace_passing=1
-ntestpart = 36000        ! number of test particles
+ntestpart = 65536        ! number of test particles
 num_surf = 0             ! number of start surfaces, start points everywhere if 0. if 2: sample between two given surfaces as given from sbeg
 sbeg = 0.2               ! starting surface for some initializations. Can be comma sepearated array as well and if num_surf=2 and size(sbeg)==2 SIMPLE will uniformly launch particle between these two s values.
 npoiper2 = 128           ! integration steps per field period
-netcdffile = 'wout_best.nc'   ! name of VMEC file in NETCDF format
+netcdffile = 'wout_LandremanPaul2021_QH_reactorScale_lowres_reference.nc'   ! name of VMEC file in NETCDF format
 isw_field_type = 2       ! -1: Testing, 0: Canonical, 1: VMEC, 2: Boozer
 trace_time = 1.5d-2      ! tracing time
 tcut = 1d-2              ! time when to do cut for classification, usually 1d-1, or -1 if no cuts desired

--- a/examples/classification/simple.in
+++ b/examples/classification/simple.in
@@ -1,10 +1,10 @@
 &config
 notrace_passing = 1      ! skip tracing passing prts if notrace_passing=1
-ntestpart = 65536        ! number of test particles
-num_surf = 0             ! number of start surfaces, start points everywhere if 0
-sbeg = 0.2               ! starting surface for some initializations
+ntestpart = 36000        ! number of test particles
+num_surf = 0             ! number of start surfaces, start points everywhere if 0. if 2: sample between two given surfaces as given from sbeg
+sbeg = 0.2               ! starting surface for some initializations. Can be comma sepearated array as well and if num_surf=2 and size(sbeg)==2 SIMPLE will uniformly launch particle between these two s values.
 npoiper2 = 128           ! integration steps per field period
-netcdffile = 'wout_LandremanPaul2021_QH_reactorScale_lowres_reference.nc'   ! name of VMEC file in NETCDF format
+netcdffile = 'wout_best.nc'   ! name of VMEC file in NETCDF format
 isw_field_type = 2       ! -1: Testing, 0: Canonical, 1: VMEC, 2: Boozer
 trace_time = 1.5d-2      ! tracing time
 tcut = 1d-2              ! time when to do cut for classification, usually 1d-1, or -1 if no cuts desired


### PR DESCRIPTION
With this change, SIMPLE will start to uniformly sample between `sbeg(1)` and `sbeg(2)` if the user provides `num_surf=2` in the input file.

Happy to discuss different implementation of this feature @krystophny 