### PR TITLE
format: Clean up comment formatting in field_can.f90 (#101 Part 1)

### DIFF
--- a/src/field_can.f90
+++ b/src/field_can.f90
@@ -19,7 +19,7 @@ implicit none
 
 procedure(evaluate_base), pointer :: evaluate => null()
 
-! Conversion to and from reference coordinates - currently VMEC coordinates (s, th, ph)
+  ! Conversion to and from reference coordinates - currently VMEC coordinates (s, th, ph)
 procedure(coordinate_transform), pointer :: can_to_ref => identity_transform
 procedure(coordinate_transform), pointer :: ref_to_can => identity_transform
 
@@ -182,13 +182,13 @@ subroutine FieldCan_init(f, mu, ro0, vpar)
 end subroutine FieldCan_init
 
 
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!
+  !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+  !
 subroutine get_val(f, pphi)
-!
-! computes values of H, pth and vpar at z=(r, th, ph, pphi)
-!
-!
+  !
+  ! computes values of H, pth and vpar at z=(r, th, ph, pphi)
+  !
+  !
   type(FieldCan), intent(inout) :: f
   double precision, intent(in) :: pphi
 
@@ -199,13 +199,13 @@ subroutine get_val(f, pphi)
 end subroutine get_val
 
 
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!
+  !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+  !
 subroutine get_derivatives(f, pphi)
-!
-! computes H, pth and vpar at z=(r, th, ph, pphi) and their derivatives
-!
-!
+  !
+  ! computes H, pth and vpar at z=(r, th, ph, pphi) and their derivatives
+  !
+  !
   type(FieldCan), intent(inout) :: f
   double precision, intent(in) :: pphi
 
@@ -223,15 +223,15 @@ subroutine get_derivatives(f, pphi)
 
 end subroutine get_derivatives
 
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!
+  !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+  !
 subroutine get_derivatives2(f, pphi)
-!
-! computes H, pth and vpar at z=(r, th, ph, pphi) up to 2nd derivatives
-! order of second derivatives:
-! d2dr2, d2drdth, d2drph, d2dth2, d2dthdph, d2dph2,
-! d2dpphdr, d2dpphdth, d2dpphdph, d2dpph2
-!
+  !
+  ! computes H, pth and vpar at z=(r, th, ph, pphi) up to 2nd derivatives
+  ! order of second derivatives:
+  ! d2dr2, d2drdth, d2drph, d2dth2, d2dthdph, d2dph2,
+  ! d2dpphdr, d2dpphdth, d2dpphdph, d2dpph2
+  !
   type(FieldCan), intent(inout) :: f
   double precision, intent(in) :: pphi
 


### PR DESCRIPTION
### **User description**
Part 1 of issue #101 - Pure formatting changes only.

## Changes
- Indent comment lines with spaces instead of starting at column 1
- No logic changes, pure formatting

## Testing
- Build passes ✓

This is the first PR in the 3-PR series for issue #101.


___

### **PR Type**
Other


___

### **Description**
- Indent comment lines with proper spacing

- Clean up comment block formatting

- No logic changes, pure formatting improvements


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>field_can.f90</strong><dd><code>Comment indentation formatting cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/field_can.f90

<ul><li>Indent comment lines with spaces instead of starting at column 1<br> <li> Format comment blocks for better readability<br> <li> No functional changes, only formatting improvements</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/116/files#diff-8b61764529d357e7d37b17c4b9190be5701f64d856e5cffb13710eadeb8bb53a">+21/-21</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

