### PR TITLE
format: Clean up comment formatting in classification.f90 (#109 Part 1)

### DIFF
--- a/src/classification.f90
+++ b/src/classification.f90
@@ -15,25 +15,25 @@ use check_orbit_type_sub, only : check_orbit_type
 
 implicit none
 
-! output files:
-! iaaa_bou - trapped-passing boundary
-! iaaa_pnt - forced regular passing
-! iaaa_prp - lossed passing
-! iaaa_prt - lossed trapped
-! iaaa_rep - regular passing
-! iaaa_ret - regular trapped
-! iaaa_stp - stochastic passing
-! iaaa_stt - stochastic trapped
+  ! output files:
+  ! iaaa_bou - trapped-passing boundary
+  ! iaaa_pnt - forced regular passing
+  ! iaaa_prp - lossed passing
+  ! iaaa_prt - lossed trapped
+  ! iaaa_rep - regular passing
+  ! iaaa_ret - regular trapped
+  ! iaaa_stp - stochastic passing
+  ! iaaa_stt - stochastic trapped
 integer, parameter :: iaaa_bou=20000, iaaa_pnt=10000, iaaa_prp=10001, iaaa_prt=10002, &
     iaaa_rep=10011, iaaa_ret=10012, iaaa_stp=10021, iaaa_stt=10022
 
-! output files:
-! iaaa_jre - regular trapped by J_parallel
-! iaaa_jst - stochastic trapped by J_parallel
-! iaaa_jer - non-classified trapped by J_parallel
-! iaaa_ire - ideal trapped by recurrences and monotonicity
-! iaaa_ist - non-ideal trapped by recurrences and monotonicity
-! iaaa_ier - non-classified trapped by recurrences and monotonicity
+  ! output files:
+  ! iaaa_jre - regular trapped by J_parallel
+  ! iaaa_jst - stochastic trapped by J_parallel
+  ! iaaa_jer - non-classified trapped by J_parallel
+  ! iaaa_ire - ideal trapped by recurrences and monotonicity
+  ! iaaa_ist - non-ideal trapped by recurrences and monotonicity
+  ! iaaa_ier - non-classified trapped by recurrences and monotonicity
 integer, parameter :: iaaa_jre=40012, iaaa_jst=40022, iaaa_jer=40032, &
     iaaa_ire=50012, iaaa_ist=50022, iaaa_ier=50032
 


### PR DESCRIPTION
### **User description**
Part 1 of issue #109 - Pure formatting changes only.

## Changes
- Indent comment lines with spaces instead of starting at column 1
- No logic changes, pure formatting

## Testing
- Build passes ✓

This is the first PR in the 3-PR series for issue #109.


___

### **PR Type**
Other


___

### **Description**
- Indent comment lines with proper spacing

- Clean up formatting for output file documentation

- No logic changes, pure formatting improvements


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>classification.f90</strong><dd><code>Comment indentation formatting cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/classification.f90

<ul><li>Indent comment lines with spaces instead of starting at column 1<br> <li> Apply consistent formatting to output file documentation comments<br> <li> No functional changes, pure formatting cleanup</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/121/files#diff-e7b1e6818e87f0e1ba5d09af90b9789a5bcdbe4eed76947a87c8afec37349e0b">+16/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

