### PR TITLE
format: Clean up comment formatting in orbit_symplectic_base.f90 (#110 Part 1)

### DIFF
--- a/src/orbit_symplectic_base.f90
+++ b/src/orbit_symplectic_base.f90
@@ -7,7 +7,7 @@ implicit none
 
 logical, parameter :: extrap_field = .True.  ! do extrapolation after final iteration
 
-! Integration methods
+  ! Integration methods
 integer, parameter :: RK45 = 0, EXPL_IMPL_EULER = 1, IMPL_EXPL_EULER = 2, &
   MIDPOINT = 3, GAUSS1 = 4, GAUSS2 = 5, GAUSS3 = 6, GAUSS4 = 7, LOBATTO3 = 15
 
@@ -15,7 +15,7 @@ type :: SymplecticIntegrator
   double precision :: atol
   double precision :: rtol
 
-! Current phase-space coordinates z and old pth
+  ! Current phase-space coordinates z and old pth
   double precision, dimension(4) :: z  ! z = (r, th, ph, pphi)
   double precision :: pthold
 
@@ -25,10 +25,10 @@ type :: SymplecticIntegrator
   double precision :: pabs
 end type SymplecticIntegrator
 
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!
-! Composition method with 2s internal stages according to Hairer, 2002 V.3.1
-!
+  !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+  !
+  ! Composition method with 2s internal stages according to Hairer, 2002 V.3.1
+  !
 integer, parameter :: S_MAX = 32
 type :: MultistageIntegrator
   integer :: s
@@ -175,10 +175,10 @@ subroutine coeff_rk_lobatto(n, a, ahat, b, c)
 end subroutine coeff_rk_lobatto
 
 
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!
-! Lobatto (IIIA)-(IIIB) Runge-Kutta method with s internal stages (n=4*s variables)
-!
+  !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+  !
+  ! Lobatto (IIIA)-(IIIB) Runge-Kutta method with s internal stages (n=4*s variables)
+  !
 subroutine f_rk_lobatto(si, fs, s, x, fvec, jactype)
   !
   type(SymplecticIntegrator), intent(inout) :: si


### PR DESCRIPTION
### **User description**
Part 1 of issue #110 - Pure formatting changes only.

## Changes
- Indent comment lines with spaces instead of starting at column 1
- No logic changes, pure formatting

## Testing
- Build passes ✓

This is the first PR in the 3-PR series for issue #110.


___

### **PR Type**
Other


___

### **Description**
- Indent comment lines with spaces instead of column 1

- Pure formatting changes with no logic modifications


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>orbit_symplectic_base.f90</strong><dd><code>Comment indentation formatting cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/orbit_symplectic_base.f90

<ul><li>Indent comment lines with 2 spaces instead of starting at column 1<br> <li> Apply consistent formatting to block comments and inline comments<br> <li> No functional or logic changes made</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/122/files#diff-9f5262093f1073e5c77fbe36420318730ece27aed1883d88a2fd0b53b429b609">+10/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

