### PR TITLE
Modernize double precision declarations in get_canonical_coordinates.F90

### DIFF
--- a/src/get_canonical_coordinates.F90
+++ b/src/get_canonical_coordinates.F90
@@ -1,9 +1,12 @@
 
 module exchange_get_cancoord_mod
+   use iso_fortran_env, only: real64
    implicit none
 
+   integer, parameter :: dp = real64
+
    logical :: onlytheta
-   double precision :: vartheta_c, varphi_c, sqg, aiota, Bcovar_vartheta, &
+   real(dp) :: vartheta_c, varphi_c, sqg, aiota, Bcovar_vartheta, &
       Bcovar_varphi, A_theta, A_phi, theta, Bctrvr_vartheta, Bctrvr_varphi
   !$omp threadprivate(onlytheta, vartheta_c, varphi_c, sqg, aiota)
   !$omp threadprivate(Bcovar_vartheta,Bcovar_varphi,A_theta,A_phi,theta,Bctrvr_vartheta,Bctrvr_varphi)
@@ -11,12 +14,15 @@ end module exchange_get_cancoord_mod
 
 module get_can_sub
 
+   use iso_fortran_env, only: real64
    use spl_three_to_five_sub
    use stencil_utils
    use field, only: MagneticField
    use field_newton, only: newton_theta_from_canonical
 
    implicit none
+
+   integer, parameter :: dp = real64
 
   ! Module variable to store the field for use in subroutines
    class(MagneticField), allocatable :: current_field
@@ -86,14 +92,14 @@ contains
       implicit none
 
       logical :: fullset
-      double precision, parameter :: relerr = 1d-10
+      real(dp), parameter :: relerr = 1d-10
       integer :: i_theta, i_phi, i_sten, ndim, is_beg
       integer, dimension(:), allocatable :: ipoi_t, ipoi_p
-      double precision, dimension(:), allocatable :: y, dy
-      double precision :: dstencil_theta(-nh_stencil:nh_stencil), &
+      real(dp), dimension(:), allocatable :: y, dy
+      real(dp) :: dstencil_theta(-nh_stencil:nh_stencil), &
          dstencil_phi(-nh_stencil:nh_stencil)
 
-      double precision :: r, r1, r2, G_beg, dG_c_dt, dG_c_dp
+      real(dp) :: r, r1, r2, G_beg, dG_c_dt, dG_c_dp
       integer :: is
       integer :: i_ctr ! for nice counting in parallel
 
@@ -246,14 +252,14 @@ contains
 
       implicit none
 
-      double precision, parameter :: epserr = 1.d-14
+      real(dp), parameter :: epserr = 1.d-14
       integer :: iter
-      double precision :: s, varphi, A_theta, A_phi, dA_theta_ds, dA_phi_ds, &
+      real(dp) :: s, varphi, A_theta, A_phi, dA_theta_ds, dA_phi_ds, &
          alam, dl_ds, dl_dt, dl_dp, Bctrvr_vartheta, Bctrvr_varphi, Bcovar_r
       logical :: converged
 
-      double precision :: r, vartheta, daiota_ds, deltheta
-      double precision, dimension(1) :: y, dy
+      real(dp) :: r, vartheta, daiota_ds, deltheta
+      real(dp), dimension(1) :: y, dy
 
       s = r**2
 
@@ -332,7 +338,7 @@ contains
       logical :: fullset
       integer :: k, is, i_theta, i_phi, i_qua
       integer :: iss, ist, isp
-      double precision, dimension(:, :), allocatable :: splcoe
+      real(dp), dimension(:, :), allocatable :: splcoe
 
       if (.not. allocated(s_sqg_Bt_Bp)) &
          allocate (s_sqg_Bt_Bp(3, ns_s_c + 1, ns_tp_c + 1, ns_tp_c + 1, ns_c, n_theta_c, n_phi_c))
@@ -479,7 +485,7 @@ contains
 
       implicit none
 
-      double precision, parameter :: twopi = 2.d0*3.14159265358979d0
+      real(dp), parameter :: twopi = 2.d0*3.14159265358979d0
 
       logical :: fullset
 
@@ -487,7 +493,7 @@ contains
       integer :: k, is, i_theta, i_phi
       integer :: iss, ist, isp
 
-      double precision :: r, vartheta_c, varphi_c, &
+      real(dp) :: r, vartheta_c, varphi_c, &
          A_phi, A_theta, dA_phi_dr, dA_theta_dr, d2A_phi_dr2, d3A_phi_dr3, &
          sqg_c, dsqg_c_dr, dsqg_c_dt, dsqg_c_dp, &
          B_vartheta_c, dB_vartheta_c_dr, dB_vartheta_c_dt, dB_vartheta_c_dp, &
@@ -495,16 +501,16 @@ contains
          d2sqg_rr, d2sqg_rt, d2sqg_rp, d2sqg_tt, d2sqg_tp, d2sqg_pp, &
          d2bth_rr, d2bth_rt, d2bth_rp, d2bth_tt, d2bth_tp, d2bth_pp, &
          d2bph_rr, d2bph_rt, d2bph_rp, d2bph_tt, d2bph_tp, d2bph_pp
-      double precision :: s, ds, dtheta, dphi, rho_tor, drhods, drhods2, d2rhods2m
+      real(dp) :: s, ds, dtheta, dphi, rho_tor, drhods, drhods2, d2rhods2m
 
-      double precision, dimension(ns_max)              :: sp_G
-      double precision, dimension(ns_max, ns_max)       :: stp_G
+      real(dp), dimension(ns_max)              :: sp_G
+      real(dp), dimension(ns_max, ns_max)       :: stp_G
 
-      double precision, dimension(n_qua)               :: qua, dqua_dr, dqua_dt, dqua_dp
-      double precision, dimension(n_qua)               :: d2qua_dr2, d2qua_drdt, d2qua_drdp, d2qua_dt2, d2qua_dtdp, d2qua_dp2
-      double precision, dimension(n_qua, ns_max)        :: sp_all, dsp_all_ds, dsp_all_dt
-      double precision, dimension(n_qua, ns_max)        :: d2sp_all_ds2, d2sp_all_dsdt, d2sp_all_dt2
-      double precision, dimension(n_qua, ns_max, ns_max) :: stp_all, dstp_all_ds, d2stp_all_ds2
+      real(dp), dimension(n_qua)               :: qua, dqua_dr, dqua_dt, dqua_dp
+      real(dp), dimension(n_qua)               :: d2qua_dr2, d2qua_drdt, d2qua_drdp, d2qua_dt2, d2qua_dtdp, d2qua_dp2
+      real(dp), dimension(n_qua, ns_max)        :: sp_all, dsp_all_ds, dsp_all_dt
+      real(dp), dimension(n_qua, ns_max)        :: d2sp_all_ds2, d2sp_all_dsdt, d2sp_all_dt2
+      real(dp), dimension(n_qua, ns_max, ns_max) :: stp_all, dstp_all_ds, d2stp_all_ds2
   !$omp atomic
       icounter = icounter + 1
       if (r .le. 0.d0) then
@@ -934,16 +940,16 @@ contains
 
       logical :: fullset
       integer :: mode_secders
-      double precision, intent(in) :: r, vartheta_c_in, varphi_c_in
-      double precision, intent(out) :: theta_vmec, varphi_vmec
-      double precision :: A_phi, A_theta, dA_phi_dr, dA_theta_dr, d2A_phi_dr2, d3A_phi_dr3, &
+      real(dp), intent(in) :: r, vartheta_c_in, varphi_c_in
+      real(dp), intent(out) :: theta_vmec, varphi_vmec
+      real(dp) :: A_phi, A_theta, dA_phi_dr, dA_theta_dr, d2A_phi_dr2, d3A_phi_dr3, &
          sqg_c, dsqg_c_dr, dsqg_c_dt, dsqg_c_dp, &
          B_vartheta_c, dB_vartheta_c_dr, dB_vartheta_c_dt, dB_vartheta_c_dp, &
          B_varphi_c, dB_varphi_c_dr, dB_varphi_c_dt, dB_varphi_c_dp, G_c, &
          d2sqg_rr, d2sqg_rt, d2sqg_rp, d2sqg_tt, d2sqg_tp, d2sqg_pp, &
          d2bth_rr, d2bth_rt, d2bth_rp, d2bth_tt, d2bth_tp, d2bth_pp, &
          d2bph_rr, d2bph_rt, d2bph_rp, d2bph_tt, d2bph_tp, d2bph_pp
-      double precision, dimension(1) :: y, dy
+      real(dp), dimension(1) :: y, dy
 
       fullset = .true.
       mode_secders = 0
@@ -997,12 +1003,12 @@ contains
 #endif
       implicit none
 
-      double precision, parameter :: epserr = 1.d-14
+      real(dp), parameter :: epserr = 1.d-14
       integer, parameter :: niter = 100
       integer          :: iter
-      double precision :: r, theta, varphi
-      double precision, intent(out) :: vartheta_c, varphi_c
-      double precision :: delthe, delphi, alam, dl_dt, vartheta
+      real(dp) :: r, theta, varphi
+      real(dp), intent(out) :: vartheta_c, varphi_c
+      real(dp) :: delthe, delphi, alam, dl_dt, vartheta
 
       if (allocated(current_field)) then
          call vmec_lambda_interpolate_with_field(current_field, r, theta, varphi, alam, dl_dt)
@@ -1040,19 +1046,19 @@ contains
 
          implicit none
 
-         double precision, parameter :: twopi = 2.d0*3.14159265358979d0
+         real(dp), parameter :: twopi = 2.d0*3.14159265358979d0
 
          integer :: nstp, ns_A_p1, ns_s_p1
          integer :: k, is, i_theta, i_phi
          integer :: iss, ist, isp
 
-         double precision :: A_phi, A_theta, dA_phi_dr, dA_theta_dr
-         double precision :: s, ds, dtheta, dphi, rho_tor, drhods, drhods2, d2rhods2m
-         double precision :: aiota, G_c, dG_c_dt, dG_c_dp
-         double precision :: ts, ps, dts_dtc, dts_dpc, dps_dtc, dps_dpc, det
+         real(dp) :: A_phi, A_theta, dA_phi_dr, dA_theta_dr
+         real(dp) :: s, ds, dtheta, dphi, rho_tor, drhods, drhods2, d2rhods2m
+         real(dp) :: aiota, G_c, dG_c_dt, dG_c_dp
+         real(dp) :: ts, ps, dts_dtc, dts_dpc, dps_dtc, dps_dpc, det
 
-         double precision, dimension(ns_max)              :: sp_G, dsp_G_dt
-         double precision, dimension(ns_max, ns_max)       :: stp_G
+         real(dp), dimension(ns_max)              :: sp_G, dsp_G_dt
+         real(dp), dimension(ns_max, ns_max)       :: stp_G
 
          if (r .le. 0.d0) then
             rnegflag = .true.
@@ -1159,10 +1165,10 @@ contains
 #else
       use vmec_field_eval
 #endif
-      double precision, intent(in) :: s, theta, varphi
-      double precision, intent(out) :: Rcyl, Zcyl
+      real(dp), intent(in) :: s, theta, varphi
+      real(dp), intent(out) :: Rcyl, Zcyl
 
-      double precision :: A_phi, A_theta, dA_phi_ds, dA_theta_ds, aiota, &
+      real(dp) :: A_phi, A_theta, dA_phi_ds, dA_theta_ds, aiota, &
          R, Z, alam, dR_ds, dR_dt, dR_dp, dZ_ds, dZ_dt, dZ_dp, dl_ds, dl_dt, dl_dp
 
       if (allocated(current_field)) then


### PR DESCRIPTION
## Summary
- Replace all 'double precision' declarations with 'real(dp)' using iso_fortran_env standard
- Modernize both modules in the file: exchange_get_cancoord_mod and get_can_sub
- Add appropriate use statements and dp parameters for consistent precision handling
- Maintain full backward compatibility while following modern Fortran standards

## Test plan
- [x] Build completes successfully
- [x] All warnings are expected and unrelated to type modernization
- [x] No functionality changes, only type declaration modernization

Fixes #100

🤖 Generated with [Claude Code](https://claude.ai/code)