### PR TITLE
Modernize double precision declarations in collis_alphas.f90

### DIFF
--- a/src/collis_alphas.f90
+++ b/src/collis_alphas.f90
@@ -1,9 +1,9 @@
   !
 module collis_alp
-  use iso_fortran_env, only: real64
   implicit none
 
-  integer, parameter :: wp = real64
+  ! Define real(wp) kind parameter
+  integer, parameter :: wp = kind(1.0d0)
   integer, parameter :: nsorts=3
   real(wp), dimension(nsorts) :: efcolf,velrat,enrat
 

--- a/src/collis_alphas.f90
+++ b/src/collis_alphas.f90
@@ -1,9 +1,11 @@
   !
 module collis_alp
+  use iso_fortran_env, only: real64
   implicit none
 
+  integer, parameter :: wp = real64
   integer, parameter :: nsorts=3
-  double precision, dimension(nsorts) :: efcolf,velrat,enrat
+  real(wp), dimension(nsorts) :: efcolf,velrat,enrat
 
   contains
   !
@@ -28,7 +30,7 @@ module collis_alp
   !                         deviation in Fokker-Planck eq.)
   !
   integer :: i
-  double precision :: p,dpp,dhh,fpeff,plim,xbeta,dp,dh,dpd
+  real(wp) :: p,dpp,dhh,fpeff,plim,xbeta,dp,dh,dpd
   !
   plim=max(p,1.d-8)
   !
@@ -62,10 +64,10 @@ module collis_alp
   implicit none
   !
   ! square root of pi
-  double precision, parameter :: sqp=1.7724538d0
+  real(wp), parameter :: sqp=1.7724538d0
   ! cons=4./(3.*sqrt(pi))
-  double precision, parameter :: cons=.75225278d0
-  double precision :: v,dp,dh,dpd,v2,v3,ex,er
+  real(wp), parameter :: cons=.75225278d0
+  real(wp) :: v,dp,dh,dpd,v2,v3,ex,er
   !
   v2=v**2
   v3=v2*v
@@ -133,10 +135,10 @@ module collis_alp
   !                enrat  - ratio of initial alpha particle energy to the background species
   !                         energy
   !
-  double precision :: am1,am2,Z1,Z2,densi1,densi2,tempi1,tempi2,tempe,ealpha,dense
-  double precision :: v0,dchichi,slowrate,dchichi_norm,slowrate_norm,vti1,vti2,vte
-  double precision :: pi,pmass,emass,e,ev,alame,frecol_base,alami1,alami2
-  double precision :: p,dpp,dhh,fpeff
+  real(wp) :: am1,am2,Z1,Z2,densi1,densi2,tempi1,tempi2,tempe,ealpha,dense
+  real(wp) :: v0,dchichi,slowrate,dchichi_norm,slowrate_norm,vti1,vti2,vte
+  real(wp) :: pi,pmass,emass,e,ev,alame,frecol_base,alami1,alami2
+  real(wp) :: p,dpp,dhh,fpeff
   !
   pi=3.14159265358979d0
   pmass=1.6726d-24
@@ -206,9 +208,9 @@ module collis_alp
   !                   prescribed minimum, reflection was performed.
   !
   integer :: iswmode,ierr
-  double precision, parameter :: pmin=1.e-8
-  double precision :: dtauc,p,dpp,dhh,fpeff,alam,dalam,coala
-  double precision, dimension(5) :: z
+  real(wp), parameter :: pmin=1.e-8
+  real(wp) :: dtauc,p,dpp,dhh,fpeff,alam,dalam,coala
+  real(wp), dimension(5) :: z
   real :: ur
   !
   p=z(4)


### PR DESCRIPTION
### **User description**
## Summary
- Replace all 'double precision' declarations with 'real(wp)' using iso_fortran_env standard
- Use 'wp' (working precision) instead of 'dp' to avoid naming conflict with existing variable 'dp' in the module
- Add appropriate use statement and wp parameter for consistent precision handling
- Maintain full backward compatibility while following modern Fortran standards

## Test plan
- [x] Build completes successfully
- [x] All warnings are expected and unrelated to type modernization
- [x] No functionality changes, only type declaration modernization

Fixes #102

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement


___

### **Description**
- Replace `double precision` with `real(wp)` using modern Fortran standards

- Add `iso_fortran_env` import and `wp` parameter for consistent precision

- Maintain backward compatibility while modernizing type declarations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["double precision declarations"] --> B["iso_fortran_env import"]
  B --> C["wp parameter definition"]
  C --> D["real(wp) declarations"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>collis_alphas.f90</strong><dd><code>Modernize precision declarations to real(wp)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/collis_alphas.f90

<ul><li>Add <code>iso_fortran_env</code> import and <code>wp</code> parameter definition<br> <li> Replace all <code>double precision</code> declarations with <code>real(wp)</code><br> <li> Update variable declarations in subroutines and module variables<br> <li> Maintain existing functionality with modern Fortran standards</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/127/files#diff-8584e4a3240a1b485338a99c8a6fd1dc45f4d5dacbdc9ac8271ac54e906fd005">+14/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

