### PR TITLE
Modernize type declarations in classification.f90

### DIFF
--- a/src/classification.f90
+++ b/src/classification.f90
@@ -15,6 +15,9 @@ use check_orbit_type_sub, only : check_orbit_type
 
 implicit none
 
+! Define real(dp) kind parameter
+integer, parameter :: dp = kind(1.0d0)
+
   ! output files:
   ! iaaa_bou - trapped-passing boundary
   ! iaaa_pnt - forced regular passing
@@ -48,30 +51,30 @@ subroutine trace_orbit_with_classifiers(anorb, ipart)
     type(Tracer), intent(inout) :: anorb
     integer, intent(in) :: ipart
     integer :: ierr, ierr_coll
-    double precision, dimension(5) :: z
-    double precision :: bmod,sqrtg
-    double precision, dimension(3) :: bder, hcovar, hctrvr, hcurl
+    real(dp), dimension(5) :: z
+    real(dp) :: bmod,sqrtg
+    real(dp), dimension(3) :: bder, hcovar, hctrvr, hcurl
     integer :: it, ktau
     integer(8) :: kt
     logical :: passing
 
     integer                                       :: ifp_tip,ifp_per
     integer,          dimension(:),   allocatable :: ipoi
-    double precision, dimension(:),   allocatable :: xp
-    double precision, dimension(:,:), allocatable :: coef,orb_sten
-    double precision, dimension(:,:), allocatable :: zpoipl_tip,zpoipl_per,dummy2d
-    double precision, dimension(n_tip_vars)       :: var_tip
-    double precision :: phiper, alam_prev, par_inv
+    real(dp), dimension(:),   allocatable :: xp
+    real(dp), dimension(:,:), allocatable :: coef,orb_sten
+    real(dp), dimension(:,:), allocatable :: zpoipl_tip,zpoipl_per,dummy2d
+    real(dp), dimension(n_tip_vars)       :: var_tip
+    real(dp) :: phiper, alam_prev, par_inv
     integer :: iper, itip, kper, nfp_tip, nfp_per
 
-    double precision :: fraction
-    double precision :: r,theta_vmec,varphi_vmec
+    real(dp) :: fraction
+    real(dp) :: r,theta_vmec,varphi_vmec
     logical :: regular
 
     ! Variables and settings for classification by J_parallel and ideal orbit condition:
     integer, parameter :: nfp_dim=3, nturns=8
     integer :: nfp_cot,ideal,ijpar,ierr_cot,iangvar
-    double precision, dimension(nfp_dim) :: fpr_in
+    real(dp), dimension(nfp_dim) :: fpr_in
 
     zend(:,ipart) = 0d0
     !


### PR DESCRIPTION
### **User description**
## Summary
- Add dp (double precision kind) parameter to classification module
- Replace all double precision declarations with real(dp)  
- Maintains consistency with modernization pattern across codebase

## Test plan
- [x] Build successful with no new warnings
- [x] All existing functionality preserved

Resolves #109

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `dp` kind parameter for double precision consistency

- Replace all `double precision` declarations with `real(dp)`

- Modernize type system following codebase standards


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Add dp parameter"] --> B["Replace double precision"]
  B --> C["Modernized type system"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>classification.f90</strong><dd><code>Modernize Fortran type declarations with dp parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/classification.f90

<ul><li>Add <code>dp</code> kind parameter definition at module level<br> <li> Replace 15+ <code>double precision</code> declarations with <code>real(dp)</code><br> <li> Update variable declarations in <code>trace_orbit_with_classifiers</code> <br>subroutine<br> <li> Maintain all existing functionality with modern type system</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/134/files#diff-e7b1e6818e87f0e1ba5d09af90b9789a5bcdbe4eed76947a87c8afec37349e0b">+14/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

