### PR TITLE
fix: Use explicit imports to avoid dp conflicts after type modernization

### DIFF
--- a/src/orbit_symplectic.f90
+++ b/src/orbit_symplectic.f90
@@ -1,7 +1,12 @@
 module orbit_symplectic
 
 use util, only: pi, twopi
-use orbit_symplectic_base
+use field_can_mod, only: FieldCan, get_val, get_derivatives, get_derivatives2, &
+  eval_field => evaluate
+use orbit_symplectic_base, only: SymplecticIntegrator, MultistageIntegrator, &
+  RK45, EXPL_IMPL_EULER, IMPL_EXPL_EULER, MIDPOINT, GAUSS1, GAUSS2, GAUSS3, GAUSS4, &
+  LOBATTO3, S_MAX, orbit_timestep_sympl_i, extrap_field, &
+  coeff_rk_gauss, coeff_rk_lobatto, f_rk_lobatto
 use orbit_symplectic_quasi, only: orbit_timestep_quasi, timestep_expl_impl_euler_quasi, &
   timestep_impl_expl_euler_quasi, timestep_midpoint_quasi, orbit_timestep_rk45, &
   timestep_rk_gauss_quasi, timestep_rk_lobatto_quasi

--- a/src/orbit_symplectic_quasi.f90
+++ b/src/orbit_symplectic_quasi.f90
@@ -1,7 +1,8 @@
 module orbit_symplectic_quasi
 
 use field_can_mod, only: eval_field => evaluate, FieldCan, get_derivatives
-use orbit_symplectic_base
+use orbit_symplectic_base, only: SymplecticIntegrator, MultistageIntegrator, &
+  orbit_timestep_quasi_i, coeff_rk_gauss, coeff_rk_lobatto, f_rk_lobatto
 use minpack_interfaces, only: hybrd1
 
 implicit none


### PR DESCRIPTION
### **User description**
## Description

After merging the type modernization PRs, the main branch was broken due to conflicts with the `dp` parameter when using wildcard imports.

## Changes

- **orbit_symplectic_quasi.f90**: Use explicit imports from orbit_symplectic_base (SymplecticIntegrator, MultistageIntegrator, etc.)
- **orbit_symplectic.f90**: Use explicit imports to avoid dp conflicts and import needed functions
- Each module now defines its own `dp` parameter as `integer, parameter :: dp = kind(1.0d0)`
- Import only needed types and functions, not entire modules

## Testing

- ✅ Build passes successfully
- ✅ All tests compile

This follows the pattern established in the type modernization PRs where each module defines its own dp parameter and uses explicit imports to avoid conflicts.


___

### **PR Type**
Bug fix


___

### **Description**
- Replace wildcard imports with explicit imports to resolve dp conflicts

- Add specific imports from orbit_symplectic_base and field_can_mod modules

- Fix build failures after type modernization merge


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Wildcard imports"] -- "Replace with" --> B["Explicit imports"]
  B --> C["Resolve dp conflicts"]
  C --> D["Fix build failures"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>orbit_symplectic.f90</strong><dd><code>Replace wildcard imports with explicit imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/orbit_symplectic.f90

<ul><li>Replace wildcard import from orbit_symplectic_base with explicit <br>imports<br> <li> Add specific imports for SymplecticIntegrator, MultistageIntegrator, <br>and other types<br> <li> Import field_can_mod functions explicitly (FieldCan, get_val, <br>get_derivatives, etc.)</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/139/files#diff-980447e6511bb28a77e20d9d75c52b357739f5f5283e555d2f599ba6efd1061f">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>orbit_symplectic_quasi.f90</strong><dd><code>Replace wildcard import with explicit imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/orbit_symplectic_quasi.f90

<ul><li>Replace wildcard import from orbit_symplectic_base with explicit <br>imports<br> <li> Add specific imports for SymplecticIntegrator, MultistageIntegrator, <br>and coefficient functions</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/139/files#diff-37a3ab6ba4fe46a7b1bb3f42b3148542d671f28f5d5e7fb5833e5ea64ca9d056">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

