### PR TITLE
ci: Use self-hosted runners for GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   test:
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     if: github.event_name == 'push' || github.event_name == 'pull_request'
 
     steps:
@@ -64,7 +64,7 @@ jobs:
 
   build-docs:
     name: Build Documentation
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     container:
       image: texlive/texlive:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,9 +43,6 @@ jobs:
     name: Build Documentation
     runs-on: self-hosted
 
-    container:
-      image: texlive/texlive:latest
-
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,33 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            gfortran \
-            cmake \
-            ninja-build \
-            libnetcdf-dev \
-            libnetcdff-dev \
-            liblapack-dev \
-            libblas-dev \
-            python3-pip \
-            python3-numpy \
-            python3-scipy \
-            python3-matplotlib \
-            python3-netcdf4 \
-            openmpi-bin \
-            libopenmpi-dev \
-            libgsl-dev \
-            libfftw3-dev
-          pip3 install --user scikit-build-core git+https://github.com/jameskermode/f90wrap simsopt
-
       - name: Build SIMPLE
         run: |
           make clean
           make
-          pip3 install -e . --no-build-isolation
 
       - name: Run Fast Tests
         run: make test-fast

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,13 +8,31 @@ on:
   workflow_dispatch:
 
 jobs:
+  checkout:
+    name: Checkout Code
+    runs-on: self-hosted
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Upload repository as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: repository
+          path: .
+          retention-days: 1
+
   test:
     name: Run Tests
     runs-on: self-hosted
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
-
+    needs: checkout
+    
     steps:
-      - uses: actions/checkout@v4
+      - name: Download repository
+        uses: actions/download-artifact@v4
+        with:
+          name: repository
 
       - name: Build SIMPLE
         run: |
@@ -42,9 +60,13 @@ jobs:
   build-docs:
     name: Build Documentation
     runs-on: self-hosted
+    needs: checkout
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Download repository
+        uses: actions/download-artifact@v4
+        with:
+          name: repository
 
       - name: Install LyX
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,12 +68,6 @@ jobs:
         with:
           name: repository
 
-      - name: Install LyX
-        run: |
-          echo "LyX installation"
-          apt-get update
-          apt-get install -y lyx
-
       - name: Build LaTeX documents
         run: |
           cd DOC


### PR DESCRIPTION
### **User description**
## Summary

This PR updates our GitHub Actions workflow to use self-hosted runners instead of GitHub-hosted runners.

## Changes

- Updated  to  for the test job
- Updated  to  for the build-docs job

## Benefits

- Utilize our own infrastructure for CI/CD
- Potentially faster builds with pre-configured environments
- More control over the runner environment

## Notes

The self-hosted runners should have all required dependencies pre-installed or the workflow may need adjustments to handle dependency installation differently.


___

### **PR Type**
Other


___

### **Description**
- Switch CI/CD infrastructure from GitHub-hosted to self-hosted runners

- Update both test and build-docs jobs to use internal infrastructure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub-hosted runners"] -- "migrate to" --> B["Self-hosted runners"]
  B --> C["Test job"]
  B --> D["Build-docs job"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.yml</strong><dd><code>Update runners to self-hosted infrastructure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/main.yml

<ul><li>Replace <code>ubuntu-latest</code> with <code>self-hosted</code> for test job runner<br> <li> Replace <code>ubuntu-latest</code> with <code>self-hosted</code> for build-docs job runner</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/140/files#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

