### PR TITLE
feat: Add timing diagnostics for execution phases (#142)

### DIFF
--- a/app/simple.f90
+++ b/app/simple.f90
@@ -4,11 +4,15 @@ program neo_orb_main
     integmode, params_init
   use simple_main, only : init_field, run, write_output
   use simple, only : Tracer
+  use timing, only : init_timer, print_phase_time
 
   implicit none
 
   character(256) :: config_file
   type(Tracer) :: norb
+
+  ! Initialize timing
+  call init_timer()
 
   ! read configuration file name from command line arguments
   if (command_argument_count() == 0) then
@@ -16,12 +20,22 @@ program neo_orb_main
   else
     call get_command_argument(1, config_file)
   end if
+  call print_phase_time('Command line parsing completed')
 
   ! Must be called in this order. TODO: Fix
   call read_config(config_file)
+  call print_phase_time('Configuration reading completed')
+  
   call init_field(norb, netcdffile, ns_s, ns_tp, multharm, integmode)
+  call print_phase_time('Field initialization completed')
+  
   call params_init
+  call print_phase_time('Parameter initialization completed')
+  
   call run(norb)
+  call print_phase_time('Main simulation run completed')
+  
   call write_output
+  call print_phase_time('Output writing completed')
 
 end program neo_orb_main

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SOURCES
     sorting.f90
     check_orbit_type.f90
     find_bminmax.f90
+    timing.f90
     simple_main.f90
 )
 

--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -46,14 +46,23 @@ module simple_main
   subroutine run(norb)
     use magfie_sub, only : init_magfie, VMEC
     use samplers, only: sample, START_FILE
+    use timing, only : print_phase_time
     type(Tracer), intent(inout) :: norb
     integer :: i
 
     call print_parameters
-    if (swcoll) call init_collisions
+    call print_phase_time('Parameter printing completed')
+    
+    if (swcoll) then
+      call init_collisions
+      call print_phase_time('Collision initialization completed')
+    endif
 
     call init_magfie(VMEC)
+    call print_phase_time('VMEC magnetic field initialization completed')
+    
     call init_starting_surf
+    call print_phase_time('Starting surface initialization completed')
 
     !sample starting positions
     if (1 == startmode) then
@@ -88,13 +97,16 @@ module simple_main
     else
       print *, 'Unknown startmode: ', startmode
     endif
+    call print_phase_time('Particle sampling completed')
 
 
     if (generate_start_only) stop 'stopping after generating start.dat'
 
     call init_magfie(isw_field_type)
+    call print_phase_time('Field type initialization completed')
 
     call init_counters
+    call print_phase_time('Counter initialization completed')
 
     !$omp parallel firstprivate(norb)
     !$omp do
@@ -107,9 +119,11 @@ module simple_main
     end do
     !$omp end do
     !$omp end parallel
+    call print_phase_time('Parallel particle tracing completed')
 
     confpart_pass=confpart_pass/ntestpart
     confpart_trap=confpart_trap/ntestpart
+    call print_phase_time('Statistics normalization completed')
 
   end subroutine run
 

--- a/src/timing.f90
+++ b/src/timing.f90
@@ -1,0 +1,32 @@
+module timing
+  implicit none
+  
+  ! Define real(dp) kind parameter
+  integer, parameter :: dp = kind(1.0d0)
+  
+  ! Timer variables
+  real(dp) :: program_start_time
+  real(dp) :: phase_start_time
+  
+contains
+
+  subroutine init_timer()
+    call cpu_time(program_start_time)
+    phase_start_time = program_start_time
+  end subroutine init_timer
+  
+  subroutine print_phase_time(phase_name)
+    character(*), intent(in) :: phase_name
+    real(dp) :: current_time, elapsed_ms, total_ms
+    
+    call cpu_time(current_time)
+    elapsed_ms = (current_time - phase_start_time) * 1000.0_dp
+    total_ms = (current_time - program_start_time) * 1000.0_dp
+    
+    write(*,'(A,A,F12.3,A,F12.3,A)') 'INFO: ', phase_name, elapsed_ms, &
+      ' ms (Total: ', total_ms, ' ms)'
+    
+    phase_start_time = current_time
+  end subroutine print_phase_time
+
+end module timing


### PR DESCRIPTION
### **User description**
Closes #142

## Summary
Adds comprehensive timing diagnostics to track execution time of each phase in the SIMPLE program.

## Changes
- Created new  module with CPU time tracking functionality
- Added timing output after each major execution phase
- Reports both individual phase time and cumulative time since program start
- All times reported in milliseconds for easy readability

## Phases Tracked
Main program phases:
- Command line parsing
- Configuration reading  
- Field initialization
- Parameter initialization
- Main simulation run
- Output writing

Within simulation run:
- Parameter printing
- Collision initialization (when enabled)
- VMEC magnetic field initialization
- Starting surface initialization
- Particle sampling
- Field type initialization
- Counter initialization
- Parallel particle tracing
- Statistics normalization

## Output Format
Each phase outputs:
```
INFO: <phase_name> <phase_time> ms (Total: <total_time> ms)
```

## Testing
- Successfully builds with CMake/Ninja
- Timing module properly integrated into build system
- No impact on existing functionality

## Benefits
- Helps identify performance bottlenecks
- Useful for optimization efforts
- Non-intrusive INFO level output
- Easy to extend with additional timing points


___

### **PR Type**
Enhancement


___

### **Description**
- Add comprehensive timing diagnostics module for performance tracking

- Instrument main program phases with CPU time measurements

- Report phase and cumulative execution times in milliseconds

- Enable performance bottleneck identification across simulation workflow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["timing module"] --> B["init_timer()"]
  B --> C["Command line parsing"]
  C --> D["Configuration reading"]
  D --> E["Field initialization"]
  E --> F["Parameter initialization"]
  F --> G["Main simulation run"]
  G --> H["Output writing"]
  A --> I["print_phase_time()"]
  I --> J["Phase timing output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>simple.f90</strong><dd><code>Instrument main program with timing diagnostics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/simple.f90

<ul><li>Import timing module and initialize timer at program start<br> <li> Add timing calls after each major execution phase<br> <li> Track command line parsing, config reading, field/parameter init, <br>simulation run, and output writing</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/143/files#diff-7417078aa826912351db9a219a18656a2c51cbd0831d74f9df4818943e12dce9">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>simple_main.f90</strong><dd><code>Add detailed timing to simulation phases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/simple_main.f90

<ul><li>Add granular timing within run() subroutine for detailed performance <br>tracking<br> <li> Time parameter printing, collision init, VMEC field init, particle <br>sampling, and parallel tracing<br> <li> Include statistics normalization timing measurement</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/143/files#diff-c78f285478234040906afe001ba1cdbc1462c4b2a2befb90ef005ce6214689ab">+15/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>timing.f90</strong><dd><code>New timing module for performance diagnostics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/timing.f90

<ul><li>Create new timing module with CPU time tracking functionality<br> <li> Implement init_timer() and print_phase_time() subroutines<br> <li> Report both individual phase time and cumulative time in milliseconds</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/143/files#diff-ff65327c8369b6145b6a20c4c6dbc22f25b1400e5517cc858d62d72a9d030d03">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Include timing module in build configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/CMakeLists.txt

- Add timing.f90 to SOURCES list for build system integration


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/143/files#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

