### PR TITLE
fix: CI artifact permissions issue causing BAD_COMMAND errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,15 @@ jobs:
         with:
           name: repository
 
+      - name: Restore executable permissions
+        run: |
+          chmod +x test/golden_record_sanity/*.sh
+          chmod +x test/golden_record/*.sh 2>/dev/null || true
+          chmod +x test/test_data/*.sh 2>/dev/null || true
+          chmod +x scripts/*.sh 2>/dev/null || true
+          chmod +x tools/*.sh 2>/dev/null || true
+          chmod +x *.sh 2>/dev/null || true
+
       - name: Build SIMPLE
         run: |
           make clean
@@ -67,6 +76,15 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: repository
+
+      - name: Restore executable permissions
+        run: |
+          chmod +x test/golden_record_sanity/*.sh
+          chmod +x test/golden_record/*.sh 2>/dev/null || true
+          chmod +x test/test_data/*.sh 2>/dev/null || true
+          chmod +x scripts/*.sh 2>/dev/null || true
+          chmod +x tools/*.sh 2>/dev/null || true
+          chmod +x *.sh 2>/dev/null || true
 
       - name: Build LaTeX documents
         run: |


### PR DESCRIPTION
### **User description**
## Problem
The CI has been intermittently failing with 'BAD_COMMAND' errors for the golden_record_sanity test. Investigation shows the error message:
```
Process not started
/home/ert/actions-runner-3/_work/SIMPLE/SIMPLE/test/golden_record_sanity/test_golden_record_sanity_simple.sh
[permission denied]
```

## Root Cause
GitHub Actions' `upload-artifact` and `download-artifact` actions **do not preserve file permissions**. This is a known limitation documented in [actions/upload-artifact#38](https://github.com/actions/upload-artifact/issues/38).

When the repository is uploaded as an artifact and then downloaded in parallel jobs:
- All files lose their executable permissions
- Scripts that should be executable (755) become regular files (644)
- CTest fails to execute the test scripts, resulting in BAD_COMMAND errors

## Solution
Add a "Restore executable permissions" step after downloading the artifact that explicitly sets the executable bit on all shell scripts using `chmod +x`.

## Changes
- Added permission restoration step to both `test` and `build-docs` jobs
- Restores permissions for:
  - `test/golden_record_sanity/*.sh` (critical for the failing test)
  - `test/golden_record/*.sh`
  - `test/test_data/*.sh`
  - Any other shell scripts in the repository

## Testing
This should fix the intermittent CI failures. The permission restoration is idempotent and safe - it only affects shell scripts and ignores missing directories.

## Alternative Solutions Considered
The official workaround is to tar the files before upload to preserve permissions, but that would require more extensive changes to the workflow. The current solution is simpler and sufficient for our needs.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix CI artifact permissions causing BAD_COMMAND errors

- Restore executable permissions for shell scripts after download

- Add permission restoration to test and build-docs jobs

- Prevent intermittent golden_record_sanity test failures


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Actions upload-artifact"] --> B["File permissions lost"]
  B --> C["download-artifact in parallel jobs"]
  C --> D["Shell scripts not executable"]
  D --> E["BAD_COMMAND errors"]
  F["chmod +x restoration step"] --> G["Executable permissions restored"]
  G --> H["Tests run successfully"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.yml</strong><dd><code>Add executable permission restoration steps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/main.yml

<ul><li>Added "Restore executable permissions" step to test job<br> <li> Added identical permission restoration to build-docs job<br> <li> Restores executable permissions for shell scripts in multiple <br>directories<br> <li> Uses error suppression for missing directories with <code>2>/dev/null || </code><br><code>true</code></ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/144/files#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

