### PR TITLE
Add Meiss VMEC golden record regression

### DIFF
--- a/test/golden_record/meiss/simple.in
+++ b/test/golden_record/meiss/simple.in
@@ -1,0 +1,9 @@
+&config
+multharm = 3             ! reduced spline order for speed
+trace_time = 1d-4        ! short integration time for fast golden test
+sbeg = 0.3d0             ! starting normalized toroidal flux
+ntestpart = 32           ! number of test particles
+netcdffile = 'wout.nc'   ! VMEC equilibrium used for golden record
+isw_field_type = 3       ! Meiss canonical field evaluation
+deterministic = .true.   ! ensure reproducible random seeds
+/


### PR DESCRIPTION
## Summary
- add a fast Meiss canonical golden record case that uses the existing VMEC 
- no changes to scripts required; the new case is auto-discovered by the golden record harness

## Testing
- Running tests for: /Users/ert/code/SIMPLE
Output directory: /tmp/run_meiss
Test cases: boozer
canonical
classifier
classifier_fast
meiss
Running test case: boozer
Test case boozer completed successfully
Running test case: canonical
Test case canonical completed successfully
Running test case: classifier
Test case classifier completed successfully
Running test case: classifier_fast
Test case classifier_fast completed successfully
Running test case: meiss
Test case meiss completed successfully
All tests completed successfully
