### PR TITLE
docs: simplify simple_api.py example to focus on tracing

### DIFF
--- a/examples/simple_api.py
+++ b/examples/simple_api.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Simple examples using pysimple API."""
+"""Simple particle tracing example using pysimple API."""
 
 import pysimple
 
@@ -12,14 +12,5 @@ particles = pysimple.sample_surface(32, s=0.3)
 results = pysimple.trace_parallel(particles, integrator='midpoint')
 
 n_lost = (results['loss_times'] < 5e-5).sum()
-print(f"Traced 32 particles: {n_lost} lost")
-
-pysimple.init(vmec_file, deterministic=True, trace_time=1e-4, ntestpart=16)
-
-particles = pysimple.sample_surface(16, s=0.4)
-
-results = pysimple.classify_fast(particles, nturns=8)
-
-n_passing = results['passing'].sum()
-n_trapped = (~results['passing']).sum()
-print(f"Fast classification of 16 particles: {n_passing} passing, {n_trapped} trapped")
+n_confined = (results['loss_times'] >= 5e-5).sum()
+print(f"Traced 32 particles: {n_confined} confined, {n_lost} lost")


### PR DESCRIPTION
### **User description**
## Summary
Removes redundant `classify_fast()` call from `simple_api.py` example to eliminate overlap with the dedicated `classify_fast.py` example.

## Changes
- Removed second `init()` and `classify_fast()` section from `simple_api.py`
- Example now focuses solely on basic particle tracing with `trace_parallel()`
- Added confined particle count to output for completeness

## Rationale
The `simple_api.py` example was demonstrating `classify_fast()`, which is already covered in the dedicated `classify_fast.py` example. This creates unnecessary redundancy in the documentation.

## Example Structure After Change
Each example now demonstrates one distinct API feature:
- **simple_api.py**: Basic particle tracing with `trace_parallel()`
- **classify_fast.py**: Fast classification (jpar + topology)
- **classify_fractal.py**: Fractal classification (minkowski dimension)  
- **orbit_macro.py**: Single particle trajectory output with `trace_orbit()`

## Testing
✅ Example tested and runs successfully
✅ Output: `Traced 32 particles: 12 confined, 20 lost`


___

### **PR Type**
Documentation


___

### **Description**
- Removes redundant `classify_fast()` call from example

- Simplifies `simple_api.py` to focus on `trace_parallel()`

- Adds confined particle count to output statistics

- Eliminates overlap with dedicated `classify_fast.py` example


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["simple_api.py<br/>with redundant<br/>classify_fast()"] -->|Remove classify_fast<br/>section| B["simple_api.py<br/>focused on<br/>trace_parallel()"]
  B -->|Add confined<br/>particle count| C["Enhanced output<br/>with confinement<br/>statistics"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>simple_api.py</strong><dd><code>Remove classify_fast() and focus on trace_parallel()</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/simple_api.py

<ul><li>Updated module docstring to specify particle tracing focus<br> <li> Removed second <code>init()</code> call and entire <code>classify_fast()</code> section<br> <li> Added calculation of confined particles (<code>n_confined</code>)<br> <li> Updated output to display both confined and lost particle counts</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/186/files#diff-0ea7960c95be3defeeb1fe8337bed391a33db9a801be61876ac0a40b7189a5fb">+3/-12</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

