### PR TITLE
Add tokamak TEST-field symplectic smoke test and plot

### DIFF
--- a/test/golden_record/compare_golden_results.sh
+++ b/test/golden_record/compare_golden_results.sh
@@ -124,14 +124,38 @@ compare_cases() {
     fi
 }
 
+compare_sympl_tokamak() {
+    local case_dir="sympl_tokamak"
+    local ref_dir="$REFERENCE_DIR/$case_dir"
+    local cur_dir="$CURRENT_DIR/$case_dir"
+
+    if [ ! -d "$ref_dir" ] || [ ! -d "$cur_dir" ]; then
+        echo "Skipping symplectic tokamak comparison (missing outputs)."
+        return 0
+    fi
+
+    echo "Comparing symplectic tokamak outputs..."
+    local files="tokamak_testfield_euler1.dat tokamak_testfield_euler2.dat tokamak_testfield_midpoint.dat tokamak_testfield_gauss4.dat"
+    python "$SCRIPT_DIR/compare_files_multi.py" "$ref_dir" "$cur_dir" --files $files
+    return $?
+}
+
 # Main execution
 compare_cases
 exit_code=$?
 
-if [ $exit_code -eq 0 ]; then
+sympl_exit=0
+compare_sympl_tokamak || sympl_exit=$?
+
+final_exit=$exit_code
+if [ $sympl_exit -ne 0 ]; then
+    final_exit=$sympl_exit
+fi
+
+if [ $final_exit -eq 0 ]; then
     echo "All tests passed!"
 else
     echo "Some tests failed or had missing files."
 fi
 
-exit $exit_code
+exit $final_exit

--- a/test/golden_record/run_golden_tests.sh
+++ b/test/golden_record/run_golden_tests.sh
@@ -38,6 +38,7 @@ fi
 echo "Running tests for: $PROJECT_ROOT"
 echo "Output directory: $RUN_DIR"
 echo "Test cases: $TEST_CASES"
+echo "Checking for optional symplectic tokamak regression..."
 
 # Download wout.nc if not present in test data directory
 WOUT_FILE="$TEST_DATA_DIR/wout.nc"
@@ -143,5 +144,24 @@ for test_case in $TEST_CASES; do
     
     echo "Test case $test_case completed successfully"
 done
+
+#
+# Optional symplectic tokamak regression (test_sympl_tok.x)
+#
+SYMP_TOK_BIN="$PROJECT_ROOT/build/test/tests/test_sympl_tok.x"
+SYMP_TOK_DIR="$RUN_DIR/sympl_tokamak"
+if [ -x "$SYMP_TOK_BIN" ]; then
+    echo "Running symplectic tokamak regression via test_sympl_tok.x"
+    mkdir -p "$SYMP_TOK_DIR"
+    cd "$SYMP_TOK_DIR"
+    "$SYMP_TOK_BIN" > sympl_tokamak.log 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Error: test_sympl_tok.x failed; see $SYMP_TOK_DIR/sympl_tokamak.log"
+        exit 1
+    fi
+    echo "Symplectic tokamak regression completed."
+else
+    echo "Skipping symplectic tokamak regression (binary not found at $SYMP_TOK_BIN)"
+fi
 
 echo "All tests completed successfully"

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -64,6 +64,20 @@ target_link_libraries(utility_test.x testing_utils)
 if (ENABLE_OPENMP)
     add_executable (test_sympl_tok.x test_sympl.f90)
     target_link_libraries(test_sympl_tok.x simple)
+    add_test(NAME test_sympl_tokamak
+        COMMAND test_sympl_tok.x
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    set_tests_properties(test_sympl_tokamak PROPERTIES
+        LABELS "integration")
+
+    add_test(NAME test_sympl_tokamak_plot
+        COMMAND ${CMAKE_COMMAND} -E env python3
+            ${CMAKE_CURRENT_SOURCE_DIR}/plot_tokamak_testfield.py
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    set_tests_properties(test_sympl_tokamak_plot PROPERTIES
+        DEPENDS test_sympl_tokamak
+        LABELS "integration;plot")
+
     add_executable (test_sympl.x test_sympl_stell.f90)
     target_link_libraries(test_sympl.x simple)
     add_executable (test_sympl_testfield.x test_sympl_testfield.f90)

--- a/test/tests/plot_tokamak_testfield.py
+++ b/test/tests/plot_tokamak_testfield.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Plot the canonical tokamak TEST-field orbit used in symplectic benchmarks."""
+
+from pathlib import Path
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+OUT_FILE = Path("tokamak_testfield_orbit.png")
+def load_orbit(path: Path):
+    data = np.loadtxt(path)
+    if data.ndim != 2 or data.shape[1] < 5:
+        raise ValueError(f"Unexpected layout in {path}")
+    r = data[:, 0]
+    theta = data[:, 1]
+    h = data[:, 4]
+    R = 1.0 + r * np.cos(theta)
+    Z = r * np.sin(theta)
+    return R, Z, h
+
+
+def main() -> int:
+    files = sorted(Path(".").glob("tokamak_testfield_*.dat"))
+    if not files:
+        print("No tokamak_testfield_*.dat files found; run test_sympl_tok.x first.")
+        return 1
+
+    fig, axes = plt.subplots(1, 2, figsize=(9, 4))
+    axes[0].set_xlabel("R/R0")
+    axes[0].set_ylabel("Z/R0")
+    axes[0].set_title("Tokamak TEST field orbits")
+
+    axes[1].set_xlabel("Step")
+    axes[1].set_ylabel("H/H0")
+    axes[1].set_title("Hamiltonian drift")
+
+    markers = ["o", "s", "^", "x", "d", "v"]
+
+    for idx, path in enumerate(files):
+        R, Z, h = load_orbit(path)
+        label = path.stem.replace("tokamak_testfield_", "")
+        marker = markers[idx % len(markers)]
+        axes[0].plot(R, Z, marker=marker, linestyle="none", markersize=2, label=label)
+        axes[1].plot(
+            h / h[0],
+            marker=marker,
+            linestyle="none",
+            markersize=2,
+            label=label,
+        )
+
+    axes[0].legend()
+    axes[1].legend()
+
+    fig.tight_layout()
+    fig.savefig(OUT_FILE, dpi=150)
+    print(f"Saved {OUT_FILE}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### **User description**
## Summary
- add multi-integrator tokamak TEST-field symplectic smoke test (euler1/euler2/midpoint/gauss4) with Hamiltonian drift checks
- emit per-integrator orbit data for quick inspection
- add marker-only overlay plot for those orbits and H/H0 drift

## Testing
- make test-fast


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Refactor tokamak TEST-field symplectic integrator test to focus on four core integrators

- Add Hamiltonian drift validation with mode-specific tolerances

- Implement automated orbit data output and visualization plotting

- Integrate test into CMake with dependency chain for orbit generation and plotting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["test_sympl.f90<br/>Simplified test"] -->|generates| B["tokamak_testfield_*.dat<br/>Orbit data"]
  B -->|consumed by| C["plot_tokamak_testfield.py<br/>Visualization"]
  C -->|produces| D["tokamak_testfield_orbit.png<br/>Plot output"]
  A -->|validates| E["Hamiltonian drift<br/>per integrator"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_sympl.f90</strong><dd><code>Streamline to 4-integrator test with Hamiltonian validation</code></dd></summary>
<hr>

test/tests/test_sympl.f90

<ul><li>Removed multi-integrator test suite (quasi, multistage, 8+ <br>integrators) and replaced with focused 4-integrator smoke test<br> <li> Consolidated test logic into single loop over euler1, euler2, <br>midpoint, and gauss4 modes<br> <li> Added per-integrator Hamiltonian drift tracking with mode-specific <br>tolerance thresholds<br> <li> Implemented automatic orbit file generation with standardized naming <br>convention <code>tokamak_testfield_*.dat</code><br> <li> Replaced manual output handling with cleaner allocatable array and <br>newunit file I/O</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/194/files#diff-6cc25952b51dd729449985801bc68c7eb40574afccc89a756783d1a2669cd354">+96/-282</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>plot_tokamak_testfield.py</strong><dd><code>Add orbit and Hamiltonian drift visualization script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/tests/plot_tokamak_testfield.py

<ul><li>New Python script to visualize tokamak TEST-field orbits from <br>generated data files<br> <li> Plots orbits in R-Z space with marker-only overlay for each integrator <br>mode<br> <li> Plots Hamiltonian drift (H/H0) across timesteps for drift comparison<br> <li> Includes error handling for missing data files and unexpected data <br>layout</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/194/files#diff-87ddea68b28927f8b0b14bb7778ab823a362ee304e4cd3a28a8c21f48577a1ee">+64/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Integrate tokamak test and plotting into CMake test suite</code></dd></summary>
<hr>

test/tests/CMakeLists.txt

<ul><li>Added <code>test_sympl_tokamak</code> test target that runs the Fortran executable<br> <li> Added <code>test_sympl_tokamak_plot</code> test target that runs the Python <br>plotting script<br> <li> Configured test dependency chain so plotting runs after orbit <br>generation<br> <li> Tagged both tests with appropriate labels for test categorization</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/194/files#diff-d4def2b0d5e31d605182011bbbbba821f19e58be523325d4f54368225d15d8e4">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

