### PR TITLE
Fix startmode=5 axis singularity by adding s_min=0.01

### DIFF
--- a/src/samplers.f90
+++ b/src/samplers.f90
@@ -90,7 +90,8 @@ module samplers
 
     real(dp), intent(in) :: s_inner
     real(dp), intent(in) :: s_outer
-    real(dp) :: tmp_rand
+    real(dp), parameter :: s_min = 0.01d0
+    real(dp) :: tmp_rand, s_lo, s_hi
     real(dp) :: r,vartheta,varphi
     real(dp), dimension(:,:), intent(inout) :: zstart
     integer :: ipart
@@ -101,9 +102,13 @@ module samplers
       num_surf = 2
     endif
 
+    ! Clamp lower bound to s_min to avoid axis singularity
+    s_lo = max(s_inner, s_min)
+    s_hi = max(s_outer, s_min)
+
     do ipart=1,size(zstart,2)
       call random_number(tmp_rand)
-      r = tmp_rand * (s_outer - s_inner) + s_inner
+      r = tmp_rand * (s_hi - s_lo) + s_lo
 
       call random_number(tmp_rand)
       vartheta=twopi*tmp_rand


### PR DESCRIPTION
### **User description**
## Summary

Fix volume sampling (startmode=5) crash when particles start near the magnetic axis.

## Problem

Volume sampling with `num_surf=1` samples from the axis (`s=0`) to `sbeg`. Particles starting very close to the axis can cross through during orbit integration, causing `r<0` errors.

## Solution

Add `s_min = 0.01` parameter in `sample_volume_single()` to clamp the lower bound of the sampling region. This matches the reset value already used in the orbit integration code.

## Test plan

- [x] All 36 tests pass
- [x] Verified fix prevents `r<0` errors with Tyler's QI stellarator VMEC file
- [x] `startmode=1` continues to work correctly

Closes #203


___

### **PR Type**
Bug fix


___

### **Description**
- Prevents axis singularity crash in volume sampling (startmode=5)

- Clamps lower sampling bound to s_min=0.01 parameter

- Avoids r<0 errors when particles start near magnetic axis

- Matches existing orbit integration reset value


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Volume Sampling<br/>startmode=5"] -->|"Previously: s=0"| B["Axis Singularity<br/>r&lt;0 errors"]
  A -->|"Now: s_min=0.01"| C["Clamped Lower Bound<br/>Safe sampling region"]
  C --> D["Orbit Integration<br/>Completes successfully"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>samplers.f90</strong><dd><code>Add s_min parameter to clamp volume sampling bounds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/samplers.f90

<ul><li>Added <code>s_min = 0.01d0</code> parameter to prevent axis singularity<br> <li> Introduced <code>s_lo</code> and <code>s_hi</code> variables to clamp sampling bounds<br> <li> Modified random sampling calculation to use clamped bounds instead of <br>raw input values<br> <li> Ensures lower bound never goes below s_min threshold</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/204/files#diff-7023d1a71951e3a1cb1ad648add1e81e6632de2b9ee2ac94a65feb57e4728c23">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

