### PR TITLE
refactor: normalize B before matmul in hcov computation

### DIFF
--- a/src/field/field_coils.f90
+++ b/src/field/field_coils.f90
@@ -69,7 +69,7 @@ subroutine evaluate_direct(self, x, Acov, hcov, Bmod, sqgBctr)
 
     Bmod = sqrt(Bcart(1)**2 + Bcart(2)**2 + Bcart(3)**2)
 
-    hcov = matmul(Bcart, dxcart_dxvmec)/Bmod
+    hcov = matmul(Bcart/Bmod, dxcart_dxvmec)
     hcov(1) = hcov(1)*ds_dr
 
     if (present(sqgBctr)) then


### PR DESCRIPTION
### **User description**
## Summary
- Change hcov computation order from `matmul(B,J)/|B|` to `matmul(B/|B|,J)`
- Both are mathematically equivalent but the new form is cleaner as it explicitly transforms the unit vector h = B/|B| to covariant components

## Breaking Change
This will cause golden record tests to fail due to floating-point rounding differences at the ~1e-12 level. The golden record references need to be regenerated after this merge.

## Rationale
The new computation order matches the refactored `field_splined.f90` approach used in the coordinate system refactoring (issue-206). This change on main ensures consistency when that branch is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Reorder hcov computation from `matmul(Bcart, dxcart_dxvmec)/Bmod` to `matmul(Bcart/Bmod, dxcart_dxvmec)`

- Mathematically equivalent but cleaner form explicitly normalizing unit vector first

- Aligns with refactored `field_splined.f90` approach for consistency

- May cause minor floating-point differences (~1e-12) in golden record tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Bcart, dxcart_dxvmec, Bmod"] -->|Old: divide after| B["matmul result / Bmod"]
  A -->|New: divide before| C["Bcart / Bmod"]
  C -->|matmul| D["hcov result"]
  B -->|Same result| E["hcov"]
  D -->|Cleaner form| E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>field_coils.f90</strong><dd><code>Reorder hcov computation normalization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/field/field_coils.f90

<ul><li>Changed hcov computation order from <code>matmul(Bcart, dxcart_dxvmec)/Bmod</code> <br>to <code>matmul(Bcart/Bmod, dxcart_dxvmec)</code><br> <li> Normalizes magnetic field vector before matrix multiplication instead <br>of after<br> <li> Improves code clarity by explicitly computing unit vector h = <br>Bcart/Bmod first<br> <li> Maintains mathematical equivalence while aligning with refactored <br>field computation approach</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/211/files#diff-506936420a91b8ee484fc97a4ed0139e109912750985a06b4eef66afb773ea15">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

