### PR TITLE
Fix pip install and pysimple backend runtime

### DIFF
--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -682,9 +682,10 @@ contains
             ! Fill trajectory arrays with NaN since we're not tracing this particle
             orbit_traj = ieee_value(0.0d0, ieee_quiet_nan)
             orbit_times = ieee_value(0.0d0, ieee_quiet_nan)
-!$omp critical
-            confpart_pass = confpart_pass + 1.d0
-!$omp end critical
+            do it = 1, ntimstep
+!$omp atomic update
+                confpart_pass(it) = confpart_pass(it) + 1.d0
+            end do
             return
         end if
 


### PR DESCRIPTION
Fixes `pip install .` failing due to invalid `pyproject.toml` keys and avoids clobbering the repo `build/` dir by scikit-build.

Also declares `f90wrap` as a runtime dependency for `pysimple` and improves import error messages when `f90wrap` or `_simple_backend` is missing.

Test: `make test` (log: `/tmp/simple_make_test2.log`)
