### PR TITLE
Restore CODE env usage for golden/deterministic builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,32 +42,32 @@ test-regression: build-deterministic-nopy
 	$(CTEST_CMD) -L "regression"
 
 # Build with deterministic floating-point for regression tests
-# Unsets CODE to force FetchContent for libneo (ensures consistent builds)
+# Keeps CODE intact so local dependency paths are respected
 # Patches libneo to also use deterministic FP (no -ffast-math)
 build-deterministic:
-	@echo "Building with deterministic FP (CODE unset to use FetchContent for libneo)..."
-	unset CODE && cmake -S . -B$(BUILD_DIR) -GNinja -DCMAKE_BUILD_TYPE=$(CONFIG) -DSIMPLE_DETERMINISTIC_FP=ON -DCMAKE_COLOR_DIAGNOSTICS=ON $(FLAGS)
+	@echo "Building with deterministic FP..."
+	cmake -S . -B$(BUILD_DIR) -GNinja -DCMAKE_BUILD_TYPE=$(CONFIG) -DSIMPLE_DETERMINISTIC_FP=ON -DCMAKE_COLOR_DIAGNOSTICS=ON $(FLAGS)
 	@LIBNEO_CMAKE="$(BUILD_DIR)/_deps/libneo-src/CMakeLists.txt"; \
 	if [ -f "$$LIBNEO_CMAKE" ] && grep -q "\-ffast-math" "$$LIBNEO_CMAKE" 2>/dev/null; then \
 		echo "Patching libneo for deterministic FP..."; \
 		sed 's/-ffast-math[[:space:]]*-ffp-contract=fast/-ffp-contract=off/g' "$$LIBNEO_CMAKE" > "$$LIBNEO_CMAKE.tmp" && mv "$$LIBNEO_CMAKE.tmp" "$$LIBNEO_CMAKE"; \
 		sed 's/-ffast-math/-ffp-contract=off/g' "$$LIBNEO_CMAKE" > "$$LIBNEO_CMAKE.tmp" && mv "$$LIBNEO_CMAKE.tmp" "$$LIBNEO_CMAKE"; \
 		echo "Reconfiguring after libneo patch..."; \
-		unset CODE && cmake -S . -B$(BUILD_DIR) -GNinja -DCMAKE_BUILD_TYPE=$(CONFIG) -DSIMPLE_DETERMINISTIC_FP=ON -DCMAKE_COLOR_DIAGNOSTICS=ON $(FLAGS); \
+		cmake -S . -B$(BUILD_DIR) -GNinja -DCMAKE_BUILD_TYPE=$(CONFIG) -DSIMPLE_DETERMINISTIC_FP=ON -DCMAKE_COLOR_DIAGNOSTICS=ON $(FLAGS); \
 	fi
 	cmake --build $(BUILD_DIR) --config $(CONFIG)
 
 # Deterministic build matching golden record reference configuration (Python OFF)
 build-deterministic-nopy:
 	@echo "Building with deterministic FP and Python interface OFF (golden record reference)..."
-	unset CODE && cmake -S . -B$(BUILD_DIR) -GNinja -DCMAKE_BUILD_TYPE=$(CONFIG) -DSIMPLE_DETERMINISTIC_FP=ON -DENABLE_PYTHON_INTERFACE=OFF -DCMAKE_COLOR_DIAGNOSTICS=ON $(FLAGS)
+	cmake -S . -B$(BUILD_DIR) -GNinja -DCMAKE_BUILD_TYPE=$(CONFIG) -DSIMPLE_DETERMINISTIC_FP=ON -DENABLE_PYTHON_INTERFACE=OFF -DCMAKE_COLOR_DIAGNOSTICS=ON $(FLAGS)
 	@LIBNEO_CMAKE="$(BUILD_DIR)/_deps/libneo-src/CMakeLists.txt"; \
 	if [ -f "$$LIBNEO_CMAKE" ] && grep -q "\-ffast-math" "$$LIBNEO_CMAKE" 2>/dev/null; then \
 		echo "Patching libneo for deterministic FP..."; \
 		sed 's/-ffast-math[[:space:]]*-ffp-contract=fast/-ffp-contract=off/g' "$$LIBNEO_CMAKE" > "$$LIBNEO_CMAKE.tmp" && mv "$$LIBNEO_CMAKE.tmp" "$$LIBNEO_CMAKE"; \
 		sed 's/-ffast-math/-ffp-contract=off/g' "$$LIBNEO_CMAKE" > "$$LIBNEO_CMAKE.tmp" && mv "$$LIBNEO_CMAKE.tmp" "$$LIBNEO_CMAKE"; \
 		echo "Reconfiguring after libneo patch..."; \
-		unset CODE && cmake -S . -B$(BUILD_DIR) -GNinja -DCMAKE_BUILD_TYPE=$(CONFIG) -DSIMPLE_DETERMINISTIC_FP=ON -DENABLE_PYTHON_INTERFACE=OFF -DCMAKE_COLOR_DIAGNOSTICS=ON $(FLAGS); \
+		cmake -S . -B$(BUILD_DIR) -GNinja -DCMAKE_BUILD_TYPE=$(CONFIG) -DSIMPLE_DETERMINISTIC_FP=ON -DENABLE_PYTHON_INTERFACE=OFF -DCMAKE_COLOR_DIAGNOSTICS=ON $(FLAGS); \
 	fi
 	cmake --build $(BUILD_DIR) --config $(CONFIG)
 

--- a/test/golden_record/golden_record.sh
+++ b/test/golden_record/golden_record.sh
@@ -182,7 +182,7 @@ build() {
     # Enable deterministic floating-point for reproducible golden record tests
     CMAKE_OPTS="$CMAKE_OPTS -DSIMPLE_DETERMINISTIC_FP=ON"
 
-    unset CODE && cmake -S . -Bbuild -GNinja $CMAKE_OPTS > $PROJECT_ROOT/configure.log 2>&1
+    cmake -S . -Bbuild -GNinja $CMAKE_OPTS > $PROJECT_ROOT/configure.log 2>&1
     if [ $? -ne 0 ]; then
         echo "CMake configuration failed. Check $PROJECT_ROOT/configure.log"
         return 1
@@ -194,7 +194,7 @@ build() {
     if [ -f "$LIBNEO_CMAKE" ]; then
         if patch_libneo_for_deterministic_fp "$LIBNEO_CMAKE"; then
             echo "Reconfiguring after libneo patch..."
-            unset CODE && cmake -S . -Bbuild -GNinja $CMAKE_OPTS >> $PROJECT_ROOT/configure.log 2>&1
+            cmake -S . -Bbuild -GNinja $CMAKE_OPTS >> $PROJECT_ROOT/configure.log 2>&1
         fi
     fi
 


### PR DESCRIPTION
### **User description**
This PR restores use of the `CODE` environment variable during deterministic/regression and golden-record builds.

Changes:
- Stop forcing `unset CODE` in `make build-deterministic` and `make build-deterministic-nopy`.
- Stop forcing `unset CODE` in `test/golden_record/golden_record.sh`.

Validation (local):
- `make test-fast` (log: `/tmp/SIMPLE_test_fast_20251215_173851.log`)
- `make test-regression` (log: `/tmp/SIMPLE_test_regression_20251215_174005.log`)


___

### **PR Type**
Bug fix


___

### **Description**
- Remove forced `unset CODE` from deterministic and golden record builds

- Allow local dependency paths to be respected during builds

- Update build comments to reflect CODE environment variable preservation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Deterministic Build Process"] -->|Previously| B["CODE env unset<br/>FetchContent forced"]
  A -->|Now| C["CODE env preserved<br/>Local paths respected"]
  D["Golden Record Build"] -->|Previously| B
  D -->|Now| C
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Remove CODE env unsetting from deterministic builds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

<ul><li>Removed <code>unset CODE</code> from <code>build-deterministic</code> target cmake commands<br> <li> Removed <code>unset CODE</code> from <code>build-deterministic-nopy</code> target cmake commands<br> <li> Updated build comments to reflect that CODE env is now preserved<br> <li> Simplified echo messages to remove FetchContent-specific language</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/228/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>golden_record.sh</strong><dd><code>Preserve CODE env in golden record build script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/golden_record/golden_record.sh

<ul><li>Removed <code>unset CODE</code> from initial cmake configuration command<br> <li> Removed <code>unset CODE</code> from cmake reconfiguration after libneo patching<br> <li> Allows local CODE environment variable to be used during golden record <br>builds</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/228/files#diff-e5ee2add113c5e167c012c72f54e799e851393855c67b304dfbbd022be818fcf">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

