### PR TITLE
fix: update coordinate_system_t to use evaluate_cart/evaluate_cyl

### DIFF
--- a/src/coordinates/cartesian_coordinates.f90
+++ b/src/coordinates/cartesian_coordinates.f90
@@ -11,7 +11,8 @@ module cartesian_coordinates
 
     type, extends(coordinate_system_t) :: cartesian_coordinate_system_t
     contains
-        procedure :: evaluate_point => cartesian_evaluate_point
+        procedure :: evaluate_cart => cartesian_evaluate_cart
+        procedure :: evaluate_cyl => cartesian_evaluate_cyl
         procedure :: covariant_basis => cartesian_covariant_basis
         procedure :: metric_tensor => cartesian_metric_tensor
         procedure :: from_cyl => cartesian_from_cyl
@@ -19,14 +20,23 @@ module cartesian_coordinates
 
 contains
 
-    subroutine cartesian_evaluate_point(self, u, x)
+    subroutine cartesian_evaluate_cart(self, u, x)
+        !> Return Cartesian position (identity for Cartesian coords).
+        class(cartesian_coordinate_system_t), intent(in) :: self
+        real(dp), intent(in) :: u(3)
+        real(dp), intent(out) :: x(3)
+
+        x = u
+    end subroutine cartesian_evaluate_cart
+
+    subroutine cartesian_evaluate_cyl(self, u, x)
         !> Convert Cartesian to cylindrical.
         class(cartesian_coordinate_system_t), intent(in) :: self
         real(dp), intent(in) :: u(3)
         real(dp), intent(out) :: x(3)
 
         call cart_to_cyl(u, x)
-    end subroutine cartesian_evaluate_point
+    end subroutine cartesian_evaluate_cyl
 
     subroutine cartesian_covariant_basis(self, u, e_cov)
         !> Covariant basis for Cartesian: identity matrix.
@@ -35,10 +45,10 @@ contains
         real(dp), intent(in) :: u(3)
         real(dp), intent(out) :: e_cov(3, 3)
 
-        e_cov = 0d0
-        e_cov(1, 1) = 1d0
-        e_cov(2, 2) = 1d0
-        e_cov(3, 3) = 1d0
+        e_cov = 0.0_dp
+        e_cov(1, 1) = 1.0_dp
+        e_cov(2, 2) = 1.0_dp
+        e_cov(3, 3) = 1.0_dp
     end subroutine cartesian_covariant_basis
 
     subroutine cartesian_metric_tensor(self, u, g, ginv, sqrtg)
@@ -47,13 +57,13 @@ contains
         real(dp), intent(in) :: u(3)
         real(dp), intent(out) :: g(3, 3), ginv(3, 3), sqrtg
 
-        g = 0d0
-        g(1, 1) = 1d0
-        g(2, 2) = 1d0
-        g(3, 3) = 1d0
+        g = 0.0_dp
+        g(1, 1) = 1.0_dp
+        g(2, 2) = 1.0_dp
+        g(3, 3) = 1.0_dp
 
         ginv = g
-        sqrtg = 1d0
+        sqrtg = 1.0_dp
     end subroutine cartesian_metric_tensor
 
     subroutine cartesian_from_cyl(self, xcyl, u, ierr)

--- a/test/tests/magfie/test_magfie_coils.f90
+++ b/test/tests/magfie/test_magfie_coils.f90
@@ -126,7 +126,7 @@ contains
 
         ! Convert spline coords (r, theta, phi) to VMEC coords (s, theta, phi)
         x_vmec = [x_spline(1)**2, x_spline(2), x_spline(3)]
-        call ref_coords%evaluate_point(x_vmec, x_cyl)
+        call ref_coords%evaluate_cyl(x_vmec, x_cyl)
         call cyl_to_cart(x_cyl, x_cart)
         call field%evaluate(x_cart, Acov, hcov, Bmod)
     end subroutine evaluate_raw_at_ref

--- a/test/tests/test_coordinate_refactoring.f90
+++ b/test/tests/test_coordinate_refactoring.f90
@@ -218,7 +218,7 @@ contains
 
       ! Convert to VMEC coords (s, theta, phi) for ref_coords
       x_vmec = [x_spline(1)**2, x_spline(2), x_spline(3)]
-      call ref_coords%evaluate_point(x_vmec, x_cyl)
+      call ref_coords%evaluate_cyl(x_vmec, x_cyl)
       call cyl_to_cart(x_cyl, x_cart)
       call raw_coils%evaluate(x_cart, Acov_direct, hcov_direct, Bmod_direct)
 

--- a/test/tests/test_refcoords_file_detection.f90
+++ b/test/tests/test_refcoords_file_detection.f90
@@ -145,16 +145,16 @@ contains
         end if
 
         u = [0.5_dp, 0.0_dp, 0.0_dp]
-        call ref_coords%evaluate_point(u, x)
+        call ref_coords%evaluate_cyl(u, x)
 
         if (x(1) <= 0.0_dp) then
-            print *, '  FAILED: chartmap evaluate_point returned invalid R=', x(1)
+            print *, '  FAILED: chartmap evaluate_cyl returned invalid R=', x(1)
             nerrors = nerrors + 1
             return
         end if
 
         print *, '  PASSED: ref_coords allocated and functional for chartmap file'
-        print *, '    evaluate_point([0.5, 0, 0]) -> x =', x
+        print *, '    evaluate_cyl([0.5, 0, 0]) -> x =', x
     end subroutine test_init_reference_coords_chartmap
 
 end program test_refcoords_file_detection


### PR DESCRIPTION
### **User description**
## Summary

Update SIMPLE to use the new libneo coordinate system interface (itpplasma/libneo#174) which replaces the ambiguous `evaluate_point` method with explicit `evaluate_cart` and `evaluate_cyl` methods.

## Background

libneo PR #174 changed the `coordinate_system_t` abstract interface:
- **Before**: `evaluate_point(u, x)` - returned different formats depending on implementation (VMEC: cylindrical, chartmap: Cartesian)
- **After**: `evaluate_cart(u, x)` and `evaluate_cyl(u, x)` - explicit methods for each output format

This broke SIMPLE's main branch because `cartesian_coordinate_system_t` still implemented the old interface.

## Changes

- `cartesian_coordinates.f90`: implement `evaluate_cart` (identity) and `evaluate_cyl` (convert via `cart_to_cyl`)
- Update test files to use `evaluate_cyl` instead of `evaluate_point`

## Test plan

- [x] Build succeeds
- [x] Non-golden-record tests pass
- [ ] Golden record tests will pass once this is merged to main (they clone main to compare against)


___

### **PR Type**
Bug fix


___

### **Description**
- Update `cartesian_coordinate_system_t` to implement new libneo interface

- Replace `evaluate_point` with explicit `evaluate_cart` and `evaluate_cyl` methods

- Update all test files to use `evaluate_cyl` instead of deprecated method

- Standardize numeric literals to use `_dp` suffix for consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Interface<br/>evaluate_point"] -->|"Replaced by"| B["New Interface"]
  B --> C["evaluate_cart<br/>Identity"]
  B --> D["evaluate_cyl<br/>Convert via cart_to_cyl"]
  E["Test Files"] -->|"Updated calls"| D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cartesian_coordinates.f90</strong><dd><code>Implement new coordinate system interface methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/coordinates/cartesian_coordinates.f90

<ul><li>Replaced <code>evaluate_point</code> procedure with two explicit methods: <br><code>evaluate_cart</code> (identity transform) and <code>evaluate_cyl</code> (Cartesian to <br>cylindrical conversion)<br> <li> Added documentation comments for new methods<br> <li> Standardized numeric literals from <code>0d0</code>/<code>1d0</code> format to <code>0.0_dp</code>/<code>1.0_dp</code> <br>format throughout the file</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/230/files#diff-365089f5feea95027c445a671763b386fc90b37c849074e8a2d897487f525057">+22/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_magfie_coils.f90</strong><dd><code>Update test to use evaluate_cyl method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/tests/magfie/test_magfie_coils.f90

<ul><li>Updated call from <code>evaluate_point</code> to <code>evaluate_cyl</code> in <br><code>evaluate_raw_at_ref</code> helper subroutine<br> <li> Maintains same functionality with explicit method name</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/230/files#diff-1130f29c6c4850cd2373c659a762e798da006532830ef0359f93799c893b6a09">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_coordinate_refactoring.f90</strong><dd><code>Update test to use evaluate_cyl method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/tests/test_coordinate_refactoring.f90

<ul><li>Updated call from <code>evaluate_point</code> to <code>evaluate_cyl</code> in <br><code>test_splined_field_accuracy</code> test<br> <li> Maintains same functionality with explicit method name</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/230/files#diff-0b5ca8221963d50f475bdc01522e67a70494264f29ca5a625061234bb5d703aa">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_refcoords_file_detection.f90</strong><dd><code>Update test and messages for evaluate_cyl method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/tests/test_refcoords_file_detection.f90

<ul><li>Updated call from <code>evaluate_point</code> to <code>evaluate_cyl</code> in <br><code>test_init_reference_coords_chartmap</code> subroutine<br> <li> Updated error message and print statement to reference <code>evaluate_cyl</code> <br>instead of <code>evaluate_point</code></ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/230/files#diff-ca2a30625219349dfeae91c537cde78908d2b08ac729cee9de0640a637e6d2e1">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

