### PR TITLE
test: bder from spline derivatives

### DIFF
--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -313,6 +313,15 @@ add_test(NAME test_splined_field_derivatives
 set_tests_properties(test_splined_field_derivatives PROPERTIES
     LABELS "integration")
 
+add_executable(test_bder_from_splines.x test_bder_from_splines.f90)
+target_link_libraries(test_bder_from_splines.x simple)
+add_dependencies(test_bder_from_splines.x ncsx_test_data)
+add_test(NAME test_bder_from_splines
+    COMMAND test_bder_from_splines.x
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+set_tests_properties(test_bder_from_splines PROPERTIES
+    LABELS "integration")
+
 add_executable(test_refcoords_file_detection.x test_refcoords_file_detection.f90)
 target_link_libraries(test_refcoords_file_detection.x simple)
 add_dependencies(test_refcoords_file_detection.x chartmap_test_data)

--- a/test/tests/test_bder_from_splines.f90
+++ b/test/tests/test_bder_from_splines.f90
@@ -1,0 +1,174 @@
+program test_bder_from_splines
+    !> Verify bder = d(log Bmod)/dx computed from spline derivatives.
+    !> Reference is a high-order finite-difference oracle of Bmod from evaluate().
+
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use simple, only: init_vmec
+    use util, only: twopi
+    use new_vmec_stuff_mod, only: nper
+    use field_coils, only: coils_field_t, create_coils_field
+    use field_splined, only: splined_field_t, create_splined_field
+    use reference_coordinates, only: init_reference_coordinates, ref_coords
+
+    implicit none
+
+    type(coils_field_t) :: raw_coils
+    type(splined_field_t) :: splined
+
+    real(dp) :: dummy
+    real(dp) :: phi_period
+    integer :: n_failed
+
+    integer, parameter :: n_points = 240
+    real(dp), parameter :: tol_rel = 5.0e-8_dp
+    real(dp), parameter :: tol_abs = 1.0e-10_dp
+    real(dp), parameter :: h_rho = 1.0e-4_dp
+    real(dp), parameter :: h_ang = 1.0e-5_dp
+
+    real(dp) :: max_rel(3)
+    integer :: i
+
+    n_failed = 0
+    max_rel = 0.0_dp
+
+    call init_vmec('wout_ncsx.nc', 5, 5, 5, dummy)
+    call init_reference_coordinates('wout_ncsx.nc')
+
+    call create_coils_field('coils.simple', raw_coils)
+    call create_splined_field(raw_coils, ref_coords, splined)
+
+    phi_period = twopi/real(nper, dp)
+
+    do i = 1, n_points
+        call check_point(i, phi_period, splined, max_rel, n_failed)
+    end do
+
+    if (n_failed > 0) then
+        call print_summary(max_rel)
+        print *, '================================'
+        print *, 'FAILED: ', n_failed, ' bder mismatch(es)'
+        print *, '================================'
+        error stop 1
+    end if
+
+    call print_summary(max_rel)
+    print *, '================================'
+    print *, 'PASSED: bder from splines matches FD oracle'
+    print *, '================================'
+
+contains
+
+    subroutine check_point(i, phi_period, f, max_rel, n_failed)
+        integer, intent(in) :: i
+        real(dp), intent(in) :: phi_period
+        type(splined_field_t), intent(in) :: f
+        real(dp), intent(inout) :: max_rel(3)
+        integer, intent(inout) :: n_failed
+
+        real(dp) :: x(3)
+        real(dp) :: Acov(3), hcov(3), Bmod
+        real(dp) :: dAcov(3, 3), dhcov(3, 3), dBmod(3)
+        real(dp) :: bder_spline(3), bder_fd(3)
+        integer :: k
+
+        x(1) = 0.25_dp + 0.55_dp*real(mod(13*i, 997), dp)/997.0_dp
+        x(2) = 0.1_dp + (twopi - 0.2_dp)*real(mod(29*i, 991), dp)/991.0_dp
+        x(3) = 0.1_dp + (phi_period - 0.2_dp)*real(mod(31*i, 983), dp)/983.0_dp
+
+        call f%evaluate_with_der(x, Acov, hcov, Bmod, dAcov, dhcov, dBmod)
+        bder_spline = dBmod/max(Bmod, 1.0e-30_dp)
+
+        do k = 1, 3
+            bder_fd(k) = dlogB_dx_fd5(f, x, k, phi_period)/max(Bmod, 1.0e-30_dp)
+            call update_max_and_check(k, x, bder_spline(k), bder_fd(k), max_rel, &
+                                      n_failed)
+        end do
+    end subroutine check_point
+
+
+    real(dp) function dlogB_dx_fd5(f, x, k, phi_period) result(dBdx)
+        type(splined_field_t), intent(in) :: f
+        real(dp), intent(in) :: x(3)
+        integer, intent(in) :: k
+        real(dp), intent(in) :: phi_period
+
+        real(dp) :: Bp1, Bm1, Bp2, Bm2
+        real(dp) :: step
+
+        call eval_B_only(f, x, k, +1, phi_period, Bp1)
+        call eval_B_only(f, x, k, -1, phi_period, Bm1)
+        call eval_B_only(f, x, k, +2, phi_period, Bp2)
+        call eval_B_only(f, x, k, -2, phi_period, Bm2)
+
+        if (k == 1) then
+            step = h_rho
+        else
+            step = h_ang
+        end if
+
+        dBdx = (-Bp2 + 8.0_dp*Bp1 - 8.0_dp*Bm1 + Bm2)/(12.0_dp*step)
+    end function dlogB_dx_fd5
+
+
+    subroutine eval_B_only(f, x, k, m, phi_period, Bmod)
+        type(splined_field_t), intent(in) :: f
+        real(dp), intent(in) :: x(3)
+        integer, intent(in) :: k, m
+        real(dp), intent(in) :: phi_period
+        real(dp), intent(out) :: Bmod
+
+        real(dp) :: x_shift(3)
+        real(dp) :: Acov(3), hcov(3)
+
+        x_shift = x
+        select case (k)
+        case (1)
+            x_shift(1) = x(1) + real(m, dp)*h_rho
+        case (2)
+            x_shift(2) = wrap_angle(x(2) + real(m, dp)*h_ang, twopi)
+        case (3)
+            x_shift(3) = wrap_angle(x(3) + real(m, dp)*h_ang, phi_period)
+        case default
+            error stop 'eval_B_only: invalid coordinate index'
+        end select
+
+        call f%evaluate(x_shift, Acov, hcov, Bmod)
+    end subroutine eval_B_only
+
+
+    subroutine update_max_and_check(k, x, a, b, max_rel, n_failed)
+        integer, intent(in) :: k
+        real(dp), intent(in) :: x(3), a, b
+        real(dp), intent(inout) :: max_rel(3)
+        integer, intent(inout) :: n_failed
+
+        real(dp) :: rel, denom
+
+        denom = max(abs(b), tol_abs)
+        rel = abs(a - b)/denom
+        max_rel(k) = max(max_rel(k), rel)
+
+        if (rel > tol_rel) then
+            print *, 'FAIL: bder(', k, ') at x=(rho,th,ph)=', x
+            print *, '  got=', a, ' expected=', b, ' rel=', rel, ' tol=', tol_rel
+            n_failed = n_failed + 1
+        end if
+    end subroutine update_max_and_check
+
+
+    subroutine print_summary(max_rel)
+        real(dp), intent(in) :: max_rel(3)
+
+        print *, 'Max relative errors in bder components:'
+        print '(a,3(1x,es12.4))', '  bder:', max_rel
+    end subroutine print_summary
+
+
+    pure real(dp) function wrap_angle(angle, period) result(wrapped)
+        real(dp), intent(in) :: angle, period
+
+        wrapped = modulo(angle, period)
+        if (wrapped < 0.0_dp) wrapped = wrapped + period
+    end function wrap_angle
+
+end program test_bder_from_splines


### PR DESCRIPTION
### **User description**
Implements issue #236.

- Adds `test_bder_from_splines` to validate `bder = dBmod/Bmod` from `splined_field_t%evaluate_with_der` against a 5-point FD oracle of `Bmod` from `splined_field_t%evaluate`.
- Drops any PNG requirements; test prints max relative error per component.

Evidence
- `make test TEST=test_bder_from_splines VERBOSE=1 2>&1 | tee /tmp/test_bder_from_splines.log`
  - Max relative errors observed: bder=(4.6e-10, 9.8e-09, 3.5e-08)


___

### **PR Type**
Tests


___

### **Description**
- Adds integration test validating `bder` computation from spline derivatives

- Compares spline-based `bder = dBmod/Bmod` against 5-point finite-difference oracle

- Verifies accuracy across 240 random test points in (rho, theta, phi) space

- Achieves max relative errors of ~1e-8 to 1e-10 per component


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Splined Field Derivatives"] -->|evaluate_with_der| B["Compute bder = dBmod/Bmod"]
  C["Finite Difference Oracle"] -->|5-point stencil| D["Reference bder values"]
  B -->|compare| E["Validation Test"]
  D -->|compare| E
  E -->|report max rel errors| F["Test Result"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_bder_from_splines.f90</strong><dd><code>New test for spline derivative bder validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/tests/test_bder_from_splines.f90

<ul><li>Creates new Fortran test program that validates <code>bder</code> computation from <br>spline derivatives<br> <li> Implements 5-point finite-difference oracle (<code>dlogB_dx_fd5</code>) for <br>reference <code>Bmod</code> gradients<br> <li> Generates 240 random test points across (rho, theta, phi) coordinate <br>space with pseudo-random sampling<br> <li> Compares spline-based <code>bder</code> against FD oracle with relative tolerance <br>of 5e-8 and absolute tolerance of 1e-10<br> <li> Provides detailed failure reporting and summary statistics of max <br>relative errors per component</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/245/files#diff-298871574039b1420f4630fab3211850a224cd8b29bcbf0cd55962e1586b815b">+174/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Register bder spline test in CMake</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/tests/CMakeLists.txt

<ul><li>Registers new <code>test_bder_from_splines</code> executable in CMake build system<br> <li> Links against <code>simple</code> library and depends on <code>ncsx_test_data</code> fixture<br> <li> Configures test to run in binary directory with integration test label</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/245/files#diff-d4def2b0d5e31d605182011bbbbba821f19e58be523325d4f54368225d15d8e4">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

