### PR TITLE
feat: extract coordinate scaling abstraction from Meiss/Albert

### DIFF
--- a/test/tests/field_can/CMakeLists.txt
+++ b/test/tests/field_can/CMakeLists.txt
@@ -31,3 +31,13 @@ set_tests_properties(test_coord_transform_roundtrip PROPERTIES
 
 add_executable(test_albert_transform_diagnostic.x test_albert_transform_diagnostic.f90)
 target_link_libraries(test_albert_transform_diagnostic.x simple)
+
+add_executable(test_scaling_abstraction.x test_scaling_abstraction.f90)
+target_link_libraries(test_scaling_abstraction.x simple)
+
+add_test(NAME test_scaling_abstraction
+    COMMAND $<TARGET_FILE:test_scaling_abstraction.x>
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..)
+set_tests_properties(test_scaling_abstraction PROPERTIES
+    LABELS "integration;slow"
+    TIMEOUT 300)

--- a/test/tests/field_can/test_scaling_abstraction.f90
+++ b/test/tests/field_can/test_scaling_abstraction.f90
@@ -1,0 +1,144 @@
+program test_scaling_abstraction
+    !> Test that Meiss and Albert coordinates work with different scaling options.
+    !>
+    !> Verifies:
+    !>   1. Default (sqrt_s_scaling_t) works as before
+    !>   2. identity_scaling_t works when reference coords already use r (not s)
+    !>   3. Transform roundtrips are correct for both scalings
+
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+
+    use coordinate_scaling, only: sqrt_s_scaling_t, identity_scaling_t
+    use field_can_meiss, only: init_meiss, get_meiss_coordinates, cleanup_meiss, &
+        integ_to_ref_meiss, ref_to_integ_meiss, twopi
+    use simple, only: init_vmec
+    use field, only: vmec_field_t
+
+    implicit none
+
+    integer :: n_failed
+    real(dp) :: fper
+    class(vmec_field_t), allocatable :: magfie
+
+    n_failed = 0
+
+    print *, 'Initializing VMEC...'
+    call init_vmec('wout.nc', 5, 5, 5, fper)
+
+    magfie = vmec_field_t()
+
+    print *, ''
+    print *, '=== Testing default sqrt_s_scaling_t ==='
+    call test_sqrt_s_scaling(n_failed)
+
+    print *, ''
+    print *, '=== Testing identity_scaling_t ==='
+    call test_identity_scaling(n_failed)
+
+    print *, ''
+    if (n_failed == 0) then
+        print *, 'PASSED: All scaling abstraction tests passed'
+    else
+        print *, 'FAILED:', n_failed, 'test(s) failed'
+        error stop 'Scaling abstraction tests failed'
+    end if
+
+contains
+
+    subroutine test_sqrt_s_scaling(n_failed)
+        !> Test default sqrt_s_scaling_t produces r = sqrt(s).
+        integer, intent(inout) :: n_failed
+        real(dp), parameter :: TOL = 1d-10
+        type(sqrt_s_scaling_t) :: scaling
+        real(dp) :: x_ref(3), x_integ(3), x_ref_back(3)
+        real(dp) :: err(3), max_err
+
+        print *, 'Initializing Meiss with sqrt_s_scaling_t...'
+        call init_meiss(magfie, 32, 32, 32, 0.01d0, 0.99d0, 0.0d0, twopi, scaling)
+        call get_meiss_coordinates()
+
+        ! Test point: s=0.25 should give r=0.5
+        x_ref = [0.25d0, 1.0d0, 0.5d0]
+        call ref_to_integ_meiss(x_ref, x_integ)
+
+        if (abs(x_integ(1) - 0.5d0) > TOL) then
+            print *, '  FAILED: s=0.25 should give r=0.5'
+            print *, '    Expected r = 0.5'
+            print *, '    Got r =', x_integ(1)
+            n_failed = n_failed + 1
+        else
+            print *, '  PASSED: s=0.25 -> r=0.5 conversion correct'
+        end if
+
+        ! Test roundtrip
+        call integ_to_ref_meiss(x_integ, x_ref_back)
+        err(1) = abs(x_ref(1) - x_ref_back(1))
+        err(2) = abs(mod(x_ref(2) - x_ref_back(2) + twopi, twopi))
+        if (err(2) > twopi/2) err(2) = twopi - err(2)
+        err(3) = abs(mod(x_ref(3) - x_ref_back(3) + twopi, twopi))
+        if (err(3) > twopi/2) err(3) = twopi - err(3)
+        max_err = maxval(err)
+
+        if (max_err > TOL) then
+            print *, '  FAILED: roundtrip error too large'
+            print *, '    x_ref      =', x_ref
+            print *, '    x_ref_back =', x_ref_back
+            print *, '    error      =', err
+            n_failed = n_failed + 1
+        else
+            print *, '  PASSED: roundtrip with sqrt_s_scaling (max_err =', max_err, ')'
+        end if
+
+        call cleanup_meiss()
+    end subroutine test_sqrt_s_scaling
+
+
+    subroutine test_identity_scaling(n_failed)
+        !> Test identity_scaling_t produces r = s (no scaling).
+        !> This would be used when reference coordinates already use rho_tor.
+        integer, intent(inout) :: n_failed
+        real(dp), parameter :: TOL = 1d-10
+        type(identity_scaling_t) :: scaling
+        real(dp) :: x_ref(3), x_integ(3), x_ref_back(3)
+        real(dp) :: err(3), max_err
+
+        print *, 'Initializing Meiss with identity_scaling_t...'
+        call init_meiss(magfie, 32, 32, 32, 0.01d0, 0.99d0, 0.0d0, twopi, scaling)
+        call get_meiss_coordinates()
+
+        ! Test point: s=0.25 should give r=0.25 (no scaling)
+        x_ref = [0.25d0, 1.0d0, 0.5d0]
+        call ref_to_integ_meiss(x_ref, x_integ)
+
+        if (abs(x_integ(1) - 0.25d0) > TOL) then
+            print *, '  FAILED: s=0.25 should give r=0.25 (identity)'
+            print *, '    Expected r = 0.25'
+            print *, '    Got r =', x_integ(1)
+            n_failed = n_failed + 1
+        else
+            print *, '  PASSED: s=0.25 -> r=0.25 identity conversion correct'
+        end if
+
+        ! Test roundtrip
+        call integ_to_ref_meiss(x_integ, x_ref_back)
+        err(1) = abs(x_ref(1) - x_ref_back(1))
+        err(2) = abs(mod(x_ref(2) - x_ref_back(2) + twopi, twopi))
+        if (err(2) > twopi/2) err(2) = twopi - err(2)
+        err(3) = abs(mod(x_ref(3) - x_ref_back(3) + twopi, twopi))
+        if (err(3) > twopi/2) err(3) = twopi - err(3)
+        max_err = maxval(err)
+
+        if (max_err > TOL) then
+            print *, '  FAILED: roundtrip error too large'
+            print *, '    x_ref      =', x_ref
+            print *, '    x_ref_back =', x_ref_back
+            print *, '    error      =', err
+            n_failed = n_failed + 1
+        else
+            print *, '  PASSED: roundtrip with identity_scaling (max_err =', max_err, ')'
+        end if
+
+        call cleanup_meiss()
+    end subroutine test_identity_scaling
+
+end program test_scaling_abstraction


### PR DESCRIPTION
### **User description**
## Summary

Closes #252

Extract coordinate scaling abstraction from Meiss/Albert canonical coordinate modules, enabling them to work with different reference coordinate conventions.

### Changes

- Add `coord_scaling` module-level variable to `field_can_meiss`
- Add optional `scaling` parameter to `init_meiss` (defaults to `sqrt_s_scaling_t`)
- Replace hardcoded `xinteg(1)**2` / `sqrt(xref(1))` with `coord_scaling%inverse()` / `coord_scaling%transform()`
- Clean up `coord_scaling` in `cleanup_meiss`
- Add `test_scaling_abstraction.f90` verifying both `sqrt_s_scaling_t` and `identity_scaling_t`

### Benefits

This decoupling enables Meiss/Albert to work with:
- Reference coordinates using normalized flux s (default behavior via `sqrt_s_scaling_t`)
- Reference coordinates using rho_tor = sqrt(s) (via `identity_scaling_t`)
- Any future custom scaling via user-defined `coordinate_scaling_t` subtypes

### Test Plan

- [x] New `test_scaling_abstraction` passes for both sqrt_s and identity scalings
- [x] Existing `test_coord_transform_roundtrip` passes
- [x] All unit and integration tests pass
- [x] Golden record tests show only machine-precision differences (1e-11 to 1e-16)


___

### **PR Type**
Enhancement


___

### **Description**
- Extract coordinate scaling abstraction from Meiss/Albert modules

- Add optional `scaling` parameter to `init_meiss` with default `sqrt_s_scaling_t`

- Replace hardcoded coordinate transforms with polymorphic `coord_scaling` methods

- Add comprehensive test suite for both sqrt_s and identity scaling behaviors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["init_meiss with optional scaling param"] --> B["allocate coord_scaling"]
  B --> C["sqrt_s_scaling_t or identity_scaling_t"]
  D["ref_to_integ_meiss"] --> E["coord_scaling%transform"]
  F["integ_to_ref_meiss"] --> G["coord_scaling%inverse"]
  E --> H["Flexible s to r conversion"]
  G --> H
  I["cleanup_meiss"] --> J["deallocate coord_scaling"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>field_can_meiss.f90</strong><dd><code>Implement polymorphic coordinate scaling abstraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/field/field_can_meiss.f90

<ul><li>Add <code>coordinate_scaling_t</code> import and module-level <code>coord_scaling</code> <br>allocatable variable<br> <li> Add optional <code>scaling</code> parameter to <code>init_meiss</code> subroutine with default <br><code>sqrt_s_scaling_t</code> allocation<br> <li> Replace hardcoded <code>xinteg(1)**2</code> with <code>coord_scaling%inverse()</code> call in <br><code>integ_to_ref_meiss</code><br> <li> Replace hardcoded <code>sqrt(xref(1))</code> with <code>coord_scaling%transform()</code> call in <br><code>ref_to_integ_meiss</code><br> <li> Add <code>coord_scaling</code> deallocation in <code>cleanup_meiss</code> subroutine</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/256/files#diff-b5ad912c397088efc3a437be5e2a1fb56feb9e7b375db5e7e2e016800a9d399b">+18/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_scaling_abstraction.f90</strong><dd><code>Add comprehensive scaling abstraction test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/tests/field_can/test_scaling_abstraction.f90

<ul><li>Create new test program verifying coordinate scaling abstraction with <br>two scaling types<br> <li> Implement <code>test_sqrt_s_scaling</code> subroutine testing default behavior (r = <br>sqrt(s))<br> <li> Implement <code>test_identity_scaling</code> subroutine testing identity behavior <br>(r = s)<br> <li> Test coordinate transform roundtrips and conversion accuracy for both <br>scaling modes<br> <li> Include tolerance checks and detailed error reporting for failed <br>assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/256/files#diff-5f48bfdca7c5bd135bf9d72c4f06f0f7bcb9afb948373dbb933f404b4575b2ed">+144/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Register scaling abstraction test in build system</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/tests/field_can/CMakeLists.txt

<ul><li>Add new executable target <code>test_scaling_abstraction.x</code> linking against <br><code>simple</code> library<br> <li> Register test with CMake including integration and slow test labels<br> <li> Set 300-second timeout for test execution</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/256/files#diff-f5c0e9e854f49ee97de69fb8758bc92a5474f2470df879598ae6008296cdaae1">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

