### PR TITLE
docs: add module docstrings and cleanup field_can modules

### DIFF
--- a/src/field/field_can_albert.f90
+++ b/src/field/field_can_albert.f90
@@ -1,4 +1,24 @@
 module field_can_albert
+    !> Albert canonical coordinates extending Meiss coordinates.
+    !>
+    !> This module builds on field_can_meiss to provide Albert-type canonical
+    !> coordinates (psi, theta_c, phi_c) where psi is proportional to the
+    !> poloidal magnetic flux A_theta, giving the simple form A = (0, psi, Aphi).
+    !>
+    !> The Albert coordinates differ from Meiss in the radial coordinate:
+    !>   - Meiss: r = sqrt(s), fixed radial coordinate
+    !>   - Albert: psi ~ A_theta, flux-based radial coordinate
+    !>
+    !> The transformation is built by:
+    !>   1. Computing Meiss coordinates via field_can_meiss
+    !>   2. Regridding onto a uniform psi grid via psi_transform
+    !>
+    !> Key subroutines:
+    !>   - get_albert_coordinates: Build full transformation (calls Meiss first)
+    !>   - evaluate_albert: Fast splined field evaluation in Albert coords
+    !>   - integ_to_ref_albert: Convert integrator coords to reference (s,th,ph)
+    !>
+    !> The Albert form simplifies the symplectic integrator since dA_theta/dr = 0.
 
 use, intrinsic :: iso_fortran_env, only: dp => real64
 use interpolate, only: &
@@ -30,7 +50,7 @@ type(BatchSplineData3D) :: spl_r_batch
 ! Batch spline for optimized field evaluation (4 components: Aphi, hth, hph, Bmod)
 type(BatchSplineData3D) :: spl_albert_batch
 
-real(8) :: Ath_norm
+real(dp) :: Ath_norm
 
 contains
 


### PR DESCRIPTION
### **User description**
## Summary

Cleanup and streamline the field/coordinate API following the completion of epic #242 (magfie_refcoords) and #254 (coordinate scaling decoupling).

## Changes

- Add comprehensive module-level documentation to `field_can_meiss.f90` explaining:
  - Meiss canonical coordinate conventions (r, theta_c, phi_c)
  - How different field sources are handled (vmec_field_t vs splined_field_t)
  - The coordinate_scaling abstraction for s <-> r transforms
  - Key subroutines and their purposes

- Add module docstring to `field_can_albert.f90` explaining:
  - Relationship to Meiss coordinates
  - psi-based radial coordinate (proportional to A_theta)
  - Key subroutines

- Cleanup:
  - Remove stale TODO comments
  - Fix `real(8)` -> `real(dp)` for consistency

## Review Summary

After reviewing the codebase for issue #258:
- No dead code found in coordinate transform paths
- No consolidation opportunities between Meiss/Albert modules (patterns serve different purposes)
- Public API surface is appropriate for test coverage needs
- Architecture is clean after the refcoords epic

## Test Plan

- [x] All 42 tests pass locally

Closes #258


___

### **PR Type**
Documentation


___

### **Description**
- Add comprehensive module docstrings to field_can_meiss.f90

- Add module docstring to field_can_albert.f90

- Remove stale TODO comments from coordinate modules

- Fix real(8) to real(dp) for consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["field_can_meiss<br/>Add docstring"] --> B["Meiss coordinates<br/>documentation"]
  C["field_can_albert<br/>Add docstring"] --> D["Albert coordinates<br/>documentation"]
  E["Remove TODOs<br/>Fix real8 to dp"] --> F["Code cleanup<br/>consistency"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>field_can_meiss.f90</strong><dd><code>Add Meiss coordinates module documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/field/field_can_meiss.f90

<ul><li>Add comprehensive 30-line module docstring explaining Meiss canonical <br>coordinates<br> <li> Document coordinate conventions (r, theta_c, phi_c) and field source <br>handling<br> <li> Explain coordinate_scaling abstraction for s <-> r transforms<br> <li> Remove stale TODO comment from ah_cov_on_slice subroutine<br> <li> Remove TODO comment from xmin initialization</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/259/files#diff-b5ad912c397088efc3a437be5e2a1fb56feb9e7b375db5e7e2e016800a9d399b">+30/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>field_can_albert.f90</strong><dd><code>Add Albert coordinates module documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/field/field_can_albert.f90

<ul><li>Add 20-line module docstring explaining Albert canonical coordinates<br> <li> Document relationship to Meiss coordinates and psi-based radial <br>coordinate<br> <li> Describe transformation pipeline and key subroutines<br> <li> Fix real(8) to real(dp) for Ath_norm variable consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/259/files#diff-9ffe59ff4a655be27ee823942ebe63429c6aa4f618429e78801fe138c32bc74e">+21/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

