### PR TITLE
feat: use CGAL Simple_cartesian kernel for header-only builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,9 +200,24 @@ endif()
 find_or_fetch(libneo)
 
 # CGAL (optional, for STL wall intersections)
+# Uses Simple_cartesian<double> kernel - header-only, no GMP/MPFR needed
 if(SIMPLE_ENABLE_CGAL)
-    find_package(CGAL REQUIRED)
-    message(STATUS "CGAL enabled: ${CGAL_VERSION}")
+    find_package(CGAL QUIET)
+    if(CGAL_FOUND)
+        message(STATUS "CGAL enabled (system): ${CGAL_VERSION}")
+        set(CGAL_INCLUDE_DIR "")  # Use CGAL::CGAL target
+    else()
+        message(STATUS "CGAL not found on system, fetching header-only version...")
+        include(FetchContent)
+        FetchContent_Declare(
+            cgal
+            URL https://github.com/CGAL/cgal/releases/download/v5.6.2/CGAL-5.6.2-library.tar.xz
+            DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+        )
+        FetchContent_Populate(cgal)
+        set(CGAL_INCLUDE_DIR "${cgal_SOURCE_DIR}/include")
+        message(STATUS "CGAL enabled (fetched): 5.6.2 at ${CGAL_INCLUDE_DIR}")
+    endif()
     add_compile_definitions(SIMPLE_ENABLE_CGAL)
 else()
     message(STATUS "CGAL disabled (SIMPLE_ENABLE_CGAL=OFF)")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,9 +57,12 @@
 
     if(SIMPLE_ENABLE_CGAL)
         add_library(stl_wall_cgal STATIC wall/stl_wall_cgal.cpp)
-        target_link_libraries(stl_wall_cgal PUBLIC CGAL::CGAL)
-        if(TARGET CGAL::CGAL_Core)
-            target_link_libraries(stl_wall_cgal PUBLIC CGAL::CGAL_Core)
+        # Header-only usage with Simple_cartesian kernel (no GMP/MPFR needed)
+        if(TARGET CGAL::CGAL)
+            target_link_libraries(stl_wall_cgal PUBLIC CGAL::CGAL)
+        else()
+            # Fetched CGAL: just need include path (header-only)
+            target_include_directories(stl_wall_cgal PUBLIC ${CGAL_INCLUDE_DIR})
         endif()
     endif()
 

--- a/src/wall/stl_wall_cgal.cpp
+++ b/src/wall/stl_wall_cgal.cpp
@@ -14,14 +14,14 @@
 #include <CGAL/AABB_face_graph_triangle_primitive.h>
 #include <CGAL/AABB_traits.h>
 #include <CGAL/AABB_tree.h>
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Simple_cartesian.h>
 #include <CGAL/number_utils.h>
 #include <CGAL/boost/graph/IO/polygon_mesh_io.h>
 #include <CGAL/squared_distance_3.h>
 #include <CGAL/Surface_mesh.h>
 
 namespace {
-using Kernel = CGAL::Exact_predicates_inexact_constructions_kernel;
+using Kernel = CGAL::Simple_cartesian<double>;
 using Point = Kernel::Point_3;
 using Segment = Kernel::Segment_3;
 using SurfaceMesh = CGAL::Surface_mesh<Point>;


### PR DESCRIPTION
### **User description**
## Summary
- Switch from `Exact_predicates_inexact_constructions_kernel` to `Simple_cartesian<double>` for CGAL STL wall intersections
- Auto-fetch CGAL 5.6.2 via FetchContent if not found on system
- Removes GMP/MPFR dependency - CGAL is now truly header-only

## Motivation
The exact predicates kernel requires GMP and MPFR libraries which are often not available on systems without root access. For ray-mesh intersection in particle tracing, the simpler floating-point kernel works well in practice.

## Test plan
- [x] Build with `-DSIMPLE_ENABLE_CGAL=ON` succeeds
- [x] `test_stl_wall_intersection` passes


___

### **PR Type**
Enhancement


___

### **Description**
- Switch CGAL kernel from exact predicates to Simple_cartesian<double>

- Remove GMP/MPFR dependencies, making CGAL header-only

- Auto-fetch CGAL 5.6.2 via FetchContent if not found

- Simplify build configuration with fallback mechanism


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Exact_predicates_inexact_constructions_kernel<br/>+ GMP/MPFR deps"] -->|Replace| B["Simple_cartesian&lt;double&gt;<br/>Header-only"]
  C["System CGAL search"] -->|Found| D["Use system CGAL"]
  C -->|Not found| E["FetchContent CGAL 5.6.2"]
  D --> F["Build stl_wall_cgal"]
  E --> F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stl_wall_cgal.cpp</strong><dd><code>Switch to Simple_cartesian CGAL kernel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/wall/stl_wall_cgal.cpp

<ul><li>Replace CGAL kernel include from <br>Exact_predicates_inexact_constructions_kernel to Simple_cartesian<br> <li> Update kernel typedef to use Simple_cartesian<double><br> <li> Maintains same Point_3, Segment_3, and Surface_mesh types</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/315/files#diff-1c42d87b369fa8b81a1b72f0e70080d6f0b448f8ce81d40fe0b849ae73a05f3c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Add CGAL auto-fetch with fallback mechanism</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CMakeLists.txt

<ul><li>Change find_package(CGAL) from REQUIRED to QUIET for optional <br>discovery<br> <li> Add FetchContent mechanism to auto-download CGAL 5.6.2 if not found<br> <li> Implement conditional logic to use system CGAL or fetched version<br> <li> Add informative status messages for both system and fetched CGAL paths</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/315/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a">+17/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Simplify CGAL linking for header-only builds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/CMakeLists.txt

<ul><li>Replace unconditional CGAL::CGAL linking with conditional target check<br> <li> Remove CGAL::CGAL_Core dependency (not needed for Simple_cartesian)<br> <li> Add fallback to direct include directory for fetched CGAL<br> <li> Add comment clarifying header-only usage without GMP/MPFR</ul>


</details>


  </td>
  <td><a href="https://github.com/itpplasma/SIMPLE/pull/315/files#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

