### PR TITLE
Add Python venv setup script and fix pyproject.toml

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,4 +12,4 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
      python3-pip gfortran cmake libnetcdf-dev libnetcdff-dev libopenmpi-dev \
      libopenblas-dev wget
 
-RUN pip install numpy scipy matplotlib fortls black git+https://github.com/jameskermode/f90wrap.git@v0.2.16
+RUN pip install numpy scipy matplotlib fortls black git+https://github.com/jameskermode/f90wrap.git@v0.3.0

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ docs/_build/
 build*/
 artifacts/plots/
 artifacts/notebooks/
+.venv/

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ NVHPC_HPCX := $(NVHPC_ROOT)/comm_libs/13.0/hpcx/hpcx-2.25.1/ompi
 NVHPC_BUILD_DIR := build_nvfortran
 NVHPC_ACC_BUILD_DIR := build_nvfortran_acc
 
-.PHONY: all configure reconfigure build build-deterministic build-deterministic-nopy test test-nopy test-fast test-slow test-regression test-all test-golden-main test-golden-tag test-golden install clean nvfortran nvfortran-test nvfortran-test-nopy nvfortran-configure nvfortran-clean
+.PHONY: all configure reconfigure build build-deterministic build-deterministic-nopy test test-nopy test-fast test-slow test-regression test-all test-golden-main test-golden-tag test-golden install clean venv nvfortran nvfortran-test nvfortran-test-nopy nvfortran-configure nvfortran-clean
 .PHONY: nvfortran-acc nvfortran-acc-test nvfortran-acc-test-nopy nvfortran-acc-configure nvfortran-acc-clean
 .PHONY: gvec-qa-cache-fetch gvec-qa-cache-build gvec-qa-cache-sync-data gvec-qa-cache-refresh-data
 .PHONY: figure8-data-fetch
@@ -124,6 +124,12 @@ gvec-qa-cache-sync-data:
 	rsync -a --delete "$(SIMPLE_GVEC_QA_CACHE_ROOT)/" "$(SIMPLE_DATA_GVEC_QA_DIR)/"
 
 gvec-qa-cache-refresh-data: gvec-qa-cache-build gvec-qa-cache-sync-data
+
+venv:
+	./setup-venv.sh
+
+venv-nopy:
+	./setup-venv.sh --no-pysimple
 
 doc: configure
 	cmake --build --preset default --target doc

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ brew install gcc cmake ninja netcdf netcdf-fortran lapack
 
 For Python wrappers, do
 ```bash
-pip install f90wrap
+pip install f90wrap==0.3.0
 pip install -e . --no-build-isolation
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core", "numpy", "f90wrap"]
+requires = ["scikit-build-core", "numpy", "f90wrap==0.3.0"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,21 @@
 # Python dependencies for SIMPLE
-# Pin exact versions for reproducibility in CI
+# Use minimum versions for compatibility across Python releases.
+# Exact pins break on newer Python versions that lack prebuilt wheels.
 
 # Core dependencies
-numpy==2.2.6
-scikit-build-core==0.10.0
+numpy>=2.2
+scikit-build-core>=0.10
 
-# F90wrap - pinned to release version compatible with gvec
+# F90wrap - pinned to release version (API-sensitive)
 f90wrap==0.3.0
 
-# Optional dependencies for testing
-pytest==9.0.3
-pytest-cov==6.2.1
-netCDF4==1.7.2
+# Testing
+pytest>=9.0
+pytest-cov>=6.2
+netCDF4>=1.7
 gvec==1.4.1
 
-# Optional dependencies for examples/plotting
-matplotlib==3.9.4
-scipy==1.15.2
-shapely==2.1.2
+# Plotting and examples
+matplotlib>=3.9
+scipy>=1.15
+shapely>=2.0

--- a/setup-venv.sh
+++ b/setup-venv.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Create and populate a Python virtual environment for SIMPLE.
+# Usage: ./setup-venv.sh [--no-pysimple]
+#
+# Options:
+#   --no-pysimple   Skip building pysimple (Fortran-Python bindings).
+#                   Use this if you only need Python test/plot dependencies.
+#
+# Prerequisites (system packages):
+#   - python3 (>= 3.9) with venv module
+#   - gfortran, cmake, ninja-build
+#   - libnetcdff-dev (or netcdf-fortran-devel), liblapack-dev
+#   See docs/PREREQUISITES.md for distro-specific install commands.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VENV_DIR="${SCRIPT_DIR}/.venv"
+BUILD_PYSIMPLE=1
+
+for arg in "$@"; do
+    case "$arg" in
+        --no-pysimple) BUILD_PYSIMPLE=0 ;;
+        -h|--help)
+            sed -n '2,/^$/s/^# //p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $arg" >&2
+            exit 1
+            ;;
+    esac
+done
+
+echo "Creating virtual environment in ${VENV_DIR} ..."
+python3 -m venv "$VENV_DIR"
+# shellcheck disable=SC1091
+source "${VENV_DIR}/bin/activate"
+
+echo "Upgrading pip ..."
+pip install --upgrade pip
+
+echo "Installing Python dependencies from requirements.txt ..."
+pip install --prefer-binary -r "${SCRIPT_DIR}/requirements.txt"
+
+if [ "$BUILD_PYSIMPLE" -eq 1 ]; then
+    echo "Building pysimple (Fortran-Python bindings) ..."
+    # Build SIMPLE first if not already built
+    if [ ! -f "${SCRIPT_DIR}/build/build.ninja" ]; then
+        echo "  Configuring CMake ..."
+        cmake -S "$SCRIPT_DIR" -B"${SCRIPT_DIR}/build" -GNinja \
+            -DCMAKE_BUILD_TYPE=Release -DCMAKE_COLOR_DIAGNOSTICS=ON
+    fi
+    echo "  Building Fortran library ..."
+    cmake --build "${SCRIPT_DIR}/build" --config Release
+
+    echo "  Installing pysimple in editable mode ..."
+    pip install --no-build-isolation -e "$SCRIPT_DIR"
+else
+    echo "Skipping pysimple build (--no-pysimple)."
+fi
+
+echo ""
+echo "Done. Activate with:"
+echo "  source .venv/bin/activate"

--- a/setup-venv.sh
+++ b/setup-venv.sh
@@ -10,7 +10,7 @@
 #   - python3 (>= 3.9) with venv module
 #   - gfortran, cmake, ninja-build
 #   - libnetcdff-dev (or netcdf-fortran-devel), liblapack-dev
-#   See docs/PREREQUISITES.md for distro-specific install commands.
+#   See README.md for distro-specific install commands.
 
 set -euo pipefail
 


### PR DESCRIPTION
## Risk tier

- [x] T0: docs, comments, small build metadata
- [ ] T1: pure refactor, no behavior change intended
- [ ] T2: local numerical logic
- [ ] T3: physics, output behavior, coordinate convention
- [ ] T4: parallelism, GPU, dependency, CI, or security-sensitive build logic

## Correctness contract

### Intended behavior change

Add `setup-venv.sh` plus `make venv` and `make venv-nopy` so contributors can create the Python environment from repo tooling. Relax Python package pins where exact pins blocked newer Python wheels, and remove invalid scikit-build metadata.

### Behavior that must not change

The CMake/Ninja build remains the primary build. Existing `make test*` targets keep their behavior. The Python package remains `pysimple` with the same package path.

### Coordinate / unit conventions

Not applicable.

### Numerical invariants

Not applicable.

## Tests added

- unit: none
- integration: none
- system: venv setup path exercised manually
- golden record: unchanged

## Golden-record impact

- [x] unchanged
- [ ] changed

## Failure modes considered

- Exact pins can block Python 3.14 installs when wheels are unavailable.
- Invalid `[project.package-data]` metadata is rejected by current scikit-build-core.
- Contributors may need dependencies without rebuilding pysimple; `--no-pysimple` covers that path.

## Manual validation

`./setup-venv.sh --no-pysimple` completed on Python 3.14 using the repo requirements.

## Verification

```text
bash -n setup-venv.sh
./setup-venv.sh --no-pysimple
...
Successfully installed pip-26.1.2
Requirement already satisfied: numpy>=2.2 ...
Requirement already satisfied: scikit-build-core>=0.10 ...
Requirement already satisfied: f90wrap==0.3.0 ...
Skipping pysimple build (--no-pysimple).
Done. Activate with:
  source .venv/bin/activate
```
