### PR TITLE
Update f90wrap path for libneo vmec_support decomposition

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -94,7 +94,7 @@ else()
     set(LIBNEO_SOURCE_DIR ${libneo_SOURCE_DIR})
 endif()
 
-list(APPEND FILES_TO_WRAP ${LIBNEO_SOURCE_DIR}/src/canonical_coordinates_mod.f90)
+list(APPEND FILES_TO_WRAP ${LIBNEO_SOURCE_DIR}/src/vmec_support/canonical_coordinates_mod.f90)
 
 set(EXCLUDE_BASENAMES
     # Empty


### PR DESCRIPTION
## Risk tier

- [ ] T0: docs, comments, small build metadata
- [ ] T1: pure refactor, no behavior change intended
- [ ] T2: local numerical logic
- [ ] T3: physics, output behavior, coordinate convention
- [x] T4: parallelism, GPU, dependency, CI, or security-sensitive build logic

## Correctness contract

### Intended behavior change

Update the f90wrap source path for `canonical_coordinates_mod.f90` to the decomposed libneo VMEC-support layout: `src/vmec_support/canonical_coordinates_mod.f90`.

### Behavior that must not change

SIMPLE Python wrapping should still include the same canonical-coordinate module when built against the matching decomposed libneo branch.

### Coordinate / unit conventions

Unchanged.

### Numerical invariants

Unchanged. This is a dependency-layout change only.

## Tests added

- unit: none
- integration: existing build should validate against matching libneo branch
- system: none
- golden record: unchanged

## Golden-record impact

- [x] unchanged
- [ ] changed

## Failure modes considered

- Building against old libneo fails because the moved file path does not exist.
- Building against decomposed libneo should find the new path.
- This PR should stay draft until the matching libneo branch/tag is selected in CI.

## Manual validation

Local rebase succeeded. Local build against the current local libneo checkout failed as expected for this draft because that checkout does not contain the decomposed `src/vmec_support` path.

## Verification

```text
make test-nopy TEST=test_boozer_chartmap VERBOSE=1
...
ninja: error: '/home/ert/code/libneo/src/vmec_support/canonical_coordinates_mod.f90', needed by 'python/canonical_coordinates_mod.f90.i', missing and no known rule to make it
make: *** [Makefile:71: build-deterministic] Error 1
```
