### PR TITLE
Apply VMEC scaling to chartmap inputs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@
         coordinates/array_utils.f90
         coordinates/reference_coordinates.f90
         coordinates/coordinate_scaling.f90
+        coordinates/scaled_chartmap_coordinates.f90
     coordinates/cartesian_coordinates.f90
     field/field_base.f90
     field/field_coils.f90

--- a/src/coordinates/reference_coordinates.f90
+++ b/src/coordinates/reference_coordinates.f90
@@ -4,6 +4,8 @@ module reference_coordinates
     use libneo_coordinates, only: coordinate_system_t, make_vmec_coordinate_system, &
         make_chartmap_coordinate_system, detect_refcoords_file_type, &
         refcoords_file_chartmap, refcoords_file_vmec_wout, refcoords_file_unknown
+    use new_vmec_stuff_mod, only: vmec_RZ_scale
+    use scaled_chartmap_coordinates, only: wrap_scaled_chartmap_coordinate_system
 
     implicit none
 
@@ -36,6 +38,7 @@ contains
         select case (file_type)
         case (refcoords_file_chartmap)
             call make_chartmap_coordinate_system(ref_coords, coord_input)
+            call wrap_scaled_chartmap_coordinate_system(ref_coords, vmec_RZ_scale)
         case (refcoords_file_vmec_wout)
             call make_vmec_coordinate_system(ref_coords)
         case (refcoords_file_unknown)

--- a/src/coordinates/scaled_chartmap_coordinates.f90
+++ b/src/coordinates/scaled_chartmap_coordinates.f90
@@ -1,0 +1,119 @@
+module scaled_chartmap_coordinates
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use libneo_coordinates, only: coordinate_system_t, chartmap_coordinate_system_t
+
+    implicit none
+
+    private
+    public :: scaled_chartmap_coordinate_system_t
+    public :: wrap_scaled_chartmap_coordinate_system
+
+    type, extends(chartmap_coordinate_system_t) :: scaled_chartmap_coordinate_system_t
+        real(dp) :: cart_scale = 1.0_dp
+    contains
+        procedure :: evaluate_cart => scaled_chartmap_evaluate_cart
+        procedure :: evaluate_cyl => scaled_chartmap_evaluate_cyl
+        procedure :: covariant_basis => scaled_chartmap_covariant_basis
+        procedure :: metric_tensor => scaled_chartmap_metric_tensor
+        procedure :: from_cyl => scaled_chartmap_from_cyl
+        procedure :: from_cart => scaled_chartmap_from_cart
+    end type scaled_chartmap_coordinate_system_t
+
+contains
+
+    subroutine wrap_scaled_chartmap_coordinate_system(coords, cart_scale)
+        class(coordinate_system_t), allocatable, intent(inout) :: coords
+        real(dp), intent(in) :: cart_scale
+
+        class(coordinate_system_t), allocatable :: wrapped
+
+        if (abs(cart_scale - 1.0_dp) <= epsilon(1.0_dp)) return
+        if (cart_scale <= 0.0_dp) error stop "chartmap cart_scale must be positive"
+
+        select type (base => coords)
+        type is (scaled_chartmap_coordinate_system_t)
+            base%cart_scale = base%cart_scale*cart_scale
+        type is (chartmap_coordinate_system_t)
+            allocate (scaled_chartmap_coordinate_system_t :: wrapped)
+            select type (scaled => wrapped)
+            type is (scaled_chartmap_coordinate_system_t)
+                scaled%chartmap_coordinate_system_t = base
+                scaled%cart_scale = cart_scale
+            class default
+                error stop "wrap_scaled_chartmap_coordinate_system: allocation failed"
+            end select
+            call move_alloc(wrapped, coords)
+        class default
+            error stop "wrap_scaled_chartmap_coordinate_system: expected chartmap coords"
+        end select
+    end subroutine wrap_scaled_chartmap_coordinate_system
+
+    subroutine scaled_chartmap_evaluate_cart(self, u, x)
+        class(scaled_chartmap_coordinate_system_t), intent(in) :: self
+        real(dp), intent(in) :: u(3)
+        real(dp), intent(out) :: x(3)
+
+        call self%chartmap_coordinate_system_t%evaluate_cart(u, x)
+        x = self%cart_scale*x
+    end subroutine scaled_chartmap_evaluate_cart
+
+    subroutine scaled_chartmap_evaluate_cyl(self, u, x)
+        class(scaled_chartmap_coordinate_system_t), intent(in) :: self
+        real(dp), intent(in) :: u(3)
+        real(dp), intent(out) :: x(3)
+
+        call self%chartmap_coordinate_system_t%evaluate_cyl(u, x)
+        x(1) = self%cart_scale*x(1)
+        x(3) = self%cart_scale*x(3)
+    end subroutine scaled_chartmap_evaluate_cyl
+
+    subroutine scaled_chartmap_covariant_basis(self, u, e_cov)
+        class(scaled_chartmap_coordinate_system_t), intent(in) :: self
+        real(dp), intent(in) :: u(3)
+        real(dp), intent(out) :: e_cov(3, 3)
+
+        call self%chartmap_coordinate_system_t%covariant_basis(u, e_cov)
+        e_cov = self%cart_scale*e_cov
+    end subroutine scaled_chartmap_covariant_basis
+
+    subroutine scaled_chartmap_metric_tensor(self, u, g, ginv, sqrtg)
+        class(scaled_chartmap_coordinate_system_t), intent(in) :: self
+        real(dp), intent(in) :: u(3)
+        real(dp), intent(out) :: g(3, 3), ginv(3, 3), sqrtg
+
+        real(dp) :: scale2
+
+        call self%chartmap_coordinate_system_t%metric_tensor(u, g, ginv, sqrtg)
+        scale2 = self%cart_scale*self%cart_scale
+        g = scale2*g
+        ginv = ginv/scale2
+        sqrtg = self%cart_scale*scale2*sqrtg
+    end subroutine scaled_chartmap_metric_tensor
+
+    subroutine scaled_chartmap_from_cyl(self, xcyl, u, ierr)
+        class(scaled_chartmap_coordinate_system_t), intent(in) :: self
+        real(dp), intent(in) :: xcyl(3)
+        real(dp), intent(out) :: u(3)
+        integer, intent(out) :: ierr
+
+        real(dp) :: xcyl_base(3)
+
+        xcyl_base = xcyl
+        xcyl_base(1) = xcyl_base(1)/self%cart_scale
+        xcyl_base(3) = xcyl_base(3)/self%cart_scale
+        call self%chartmap_coordinate_system_t%from_cyl(xcyl_base, u, ierr)
+    end subroutine scaled_chartmap_from_cyl
+
+    subroutine scaled_chartmap_from_cart(self, x, u, ierr)
+        class(scaled_chartmap_coordinate_system_t), intent(in) :: self
+        real(dp), intent(in) :: x(3)
+        real(dp), intent(out) :: u(3)
+        integer, intent(out) :: ierr
+
+        real(dp) :: x_base(3)
+
+        x_base = x/self%cart_scale
+        call self%chartmap_coordinate_system_t%from_cart(x_base, u, ierr)
+    end subroutine scaled_chartmap_from_cart
+
+end module scaled_chartmap_coordinates

--- a/src/field/field_boozer_chartmap.f90
+++ b/src/field/field_boozer_chartmap.f90
@@ -19,7 +19,9 @@ module field_boozer_chartmap
                            evaluate_batch_splines_1d_der2, &
                            evaluate_batch_splines_3d, &
                            destroy_batch_splines_1d, destroy_batch_splines_3d
+    use new_vmec_stuff_mod, only: vmec_B_scale, vmec_RZ_scale
     use netcdf
+    use scaled_chartmap_coordinates, only: wrap_scaled_chartmap_coordinate_system
 
     implicit none
 
@@ -80,6 +82,7 @@ contains
         real(dp), allocatable :: y_aphi(:, :), y_bcovar(:, :), y_bmod(:, :, :, :)
         real(dp) :: s_min, s_max, rho_min, rho_max
         real(dp) :: h_s, h_theta_val, h_phi_val
+        real(dp) :: b_scale, rz_scale, covar_scale, flux_scale
         integer :: i
         integer, parameter :: spline_order_1d = 5
         integer, parameter :: spline_order_3d(3) = [5, 5, 5]
@@ -137,6 +140,17 @@ contains
 
         call check_nc(nf90_close(ncid), "close")
 
+        b_scale = vmec_B_scale
+        rz_scale = vmec_RZ_scale
+        covar_scale = b_scale*rz_scale
+        flux_scale = covar_scale*rz_scale
+
+        A_phi_arr = flux_scale*A_phi_arr
+        B_theta_arr = covar_scale*B_theta_arr
+        B_phi_arr = covar_scale*B_phi_arr
+        Bmod_arr = b_scale*Bmod_arr
+        torflux_val = flux_scale*torflux_val
+
         ! Grid parameters
         rho_min = rho(1)
         rho_max = rho(n_rho)
@@ -187,6 +201,7 @@ contains
 
         ! Set up coordinate system from the same chartmap file
         call make_chartmap_coordinate_system(cs, filename)
+        call wrap_scaled_chartmap_coordinate_system(cs, rz_scale)
         allocate (field%coords, source=cs)
 
         field%initialized = .true.

--- a/src/field/field_can_meiss.f90
+++ b/src/field/field_can_meiss.f90
@@ -153,7 +153,7 @@ subroutine choose_default_scaling(field, scaling)
     select type (fld => field)
     type is (splined_field_t)
         select type (cs => fld%coords)
-        type is (chartmap_coordinate_system_t)
+        class is (chartmap_coordinate_system_t)
             ! RHO_TOR/RHO_POL: rho = sqrt(s), already in Meiss integrator coords
             ! UNKNOWN: geometric rho, no flux meaning, use directly
             ! PSI_TOR_NORM/PSI_POL_NORM: rho = s, needs sqrt transform

--- a/src/field/field_splined.f90
+++ b/src/field/field_splined.f90
@@ -214,7 +214,7 @@ contains
         if (present(n_phi_in)) n_phi = n_phi_in
 
         select type (cs => ref_coords)
-        type is (chartmap_coordinate_system_t)
+        class is (chartmap_coordinate_system_t)
             if (.not. present(n_r_in)) n_r = cs%nrho
             if (.not. present(n_th_in)) n_th = cs%ntheta
             if (.not. present(n_phi_in)) n_phi = cs%nzeta
@@ -228,7 +228,7 @@ contains
         if (present(xmax_in)) xmax = xmax_in
 
         select type (cs => ref_coords)
-        type is (chartmap_coordinate_system_t)
+        class is (chartmap_coordinate_system_t)
             block
                 real(dp) :: rho_min, rho_max, rho_max_safe, h_rho
 
@@ -548,7 +548,7 @@ contains
         class(coordinate_scaling_t), pointer :: scaling_ptr
 
         select type (cs => ref_coords)
-        type is (chartmap_coordinate_system_t)
+        class is (chartmap_coordinate_system_t)
             if (cs%rho_convention == PSI_TOR_NORM .or. &
                 cs%rho_convention == PSI_POL_NORM) then
                 scaling_ptr => sqrt_s_scaling

--- a/src/magfie.f90
+++ b/src/magfie.f90
@@ -181,7 +181,7 @@ subroutine scaled_to_ref_coords(coords, x_scaled, u_ref, J)
   real(dp), intent(out) :: J
 
   select type (coords)
-  type is (chartmap_coordinate_system_t)
+  class is (chartmap_coordinate_system_t)
     ! Chartmap methods (metric_tensor, covariant_basis) expect native rho coords,
     ! not s = rho^2. The chartmap splines are stored on a rho grid.
     u_ref = x_scaled

--- a/src/netcdf_results_output.f90
+++ b/src/netcdf_results_output.f90
@@ -99,7 +99,7 @@ contains
         coord_type = 'vmec'
         cart_units = 'cm'
         select type (ref_coords)
-        type is (chartmap_coordinate_system_t)
+        class is (chartmap_coordinate_system_t)
             coord_type = 'chartmap'
             call read_chartmap_metadata(coord_input, meta)
             cart_units = meta%cart_units

--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -181,7 +181,7 @@ contains
             block
                 use libneo_coordinates, only: chartmap_coordinate_system_t
                 select type (cs => ref_coords)
-                type is (chartmap_coordinate_system_t)
+                class is (chartmap_coordinate_system_t)
                     self%fper = twopi / real(cs%num_field_periods, dp)
                 class default
                     self%fper = twopi
@@ -290,7 +290,7 @@ contains
         end if
 
         select type (ref_coords)
-        type is (chartmap_coordinate_system_t)
+        class is (chartmap_coordinate_system_t)
             continue
         class default
             error stop "wall_input requires chartmap reference coordinates"
@@ -763,7 +763,7 @@ contains
 
                         ierr_from_cart = 0
                         select type (ccs => ref_coords)
-                        type is (chartmap_coordinate_system_t)
+                        class is (chartmap_coordinate_system_t)
                             call ccs%from_cart(x_hit, u_ref_hit, ierr_from_cart)
                         class default
                             ierr_from_cart = 1

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -365,6 +365,14 @@ add_test(NAME test_array_utils COMMAND test_array_utils.x)
         LABELS "integration;python"
         DEPENDS "generate_test_boozer_chartmap_data")
 
+    add_executable(test_chartmap_scaling.x test_chartmap_scaling.f90)
+    target_link_libraries(test_chartmap_scaling.x simple)
+    add_dependencies(test_chartmap_scaling.x generate_test_boozer_chartmap)
+    add_test(NAME test_chartmap_scaling COMMAND test_chartmap_scaling.x)
+    set_tests_properties(test_chartmap_scaling PROPERTIES
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        LABELS "unit")
+
     # Boozer chartmap roundtrip test: requires wout.nc
     add_executable(test_boozer_chartmap_roundtrip.x test_boozer_chartmap_roundtrip.f90)
     target_link_libraries(test_boozer_chartmap_roundtrip.x simple)

--- a/test/tests/test_chartmap_scaling.f90
+++ b/test/tests/test_chartmap_scaling.f90
@@ -1,0 +1,98 @@
+program test_chartmap_scaling
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use field_boozer_chartmap, only: boozer_chartmap_field_t, create_boozer_chartmap_field
+    use new_vmec_stuff_mod, only: vmec_B_scale, vmec_RZ_scale
+    use reference_coordinates, only: init_reference_coordinates, ref_coords
+    use scaled_chartmap_coordinates, only: scaled_chartmap_coordinate_system_t
+
+    implicit none
+
+    type(boozer_chartmap_field_t), allocatable :: base_field, scaled_field
+    real(dp), parameter :: rz_scale = 3.0_dp
+    real(dp), parameter :: b_scale = 5.0_dp
+    real(dp), parameter :: tol = 1.0e-10_dp
+    real(dp) :: u(3), x_cart_base(3), x_cart_scaled(3)
+    real(dp) :: ref_cart_base(3), ref_cart_scaled(3)
+    real(dp) :: Acov_base(3), hcov_base(3), Bmod_base
+    real(dp) :: Acov_scaled(3), hcov_scaled(3), Bmod_scaled
+    real(dp) :: u_back(3), x_scaled_input(3)
+    real(dp) :: flux_scale
+    character(len=*), parameter :: filename = 'test_boozer_chartmap.nc'
+    integer :: ierr, nfail
+
+    nfail = 0
+    flux_scale = b_scale*rz_scale*rz_scale
+    u = [0.5_dp, 0.7_dp, 0.3_dp]
+
+    vmec_B_scale = 1.0_dp
+    vmec_RZ_scale = 1.0_dp
+    call create_boozer_chartmap_field(filename, base_field)
+    call base_field%coords%evaluate_cart(u, x_cart_base)
+    call base_field%evaluate(u, Acov_base, hcov_base, Bmod_base)
+    call init_reference_coordinates(filename)
+    call ref_coords%evaluate_cart(u, ref_cart_base)
+
+    vmec_B_scale = b_scale
+    vmec_RZ_scale = rz_scale
+    call create_boozer_chartmap_field(filename, scaled_field)
+    call scaled_field%coords%evaluate_cart(u, x_cart_scaled)
+    call scaled_field%evaluate(u, Acov_scaled, hcov_scaled, Bmod_scaled)
+    call init_reference_coordinates(filename)
+    call ref_coords%evaluate_cart(u, ref_cart_scaled)
+
+    if (maxval(abs(x_cart_scaled - rz_scale*x_cart_base)) > tol*max(1.0_dp, maxval(abs(x_cart_scaled)))) then
+        print *, 'FAIL: field coords cart scaling mismatch'
+        nfail = nfail + 1
+    end if
+
+    if (maxval(abs(ref_cart_scaled - rz_scale*ref_cart_base)) > tol*max(1.0_dp, maxval(abs(ref_cart_scaled)))) then
+        print *, 'FAIL: reference coords cart scaling mismatch'
+        nfail = nfail + 1
+    end if
+
+    if (abs(Bmod_scaled - b_scale*Bmod_base) > tol*max(1.0_dp, abs(Bmod_scaled))) then
+        print *, 'FAIL: Bmod scaling mismatch'
+        nfail = nfail + 1
+    end if
+
+    if (abs(scaled_field%torflux - flux_scale*base_field%torflux) > tol*max(1.0_dp, abs(scaled_field%torflux))) then
+        print *, 'FAIL: torflux scaling mismatch'
+        nfail = nfail + 1
+    end if
+
+    if (maxval(abs(Acov_scaled(2:3) - flux_scale*Acov_base(2:3))) > tol*max(1.0_dp, maxval(abs(Acov_scaled(2:3))))) then
+        print *, 'FAIL: Acov angular scaling mismatch'
+        nfail = nfail + 1
+    end if
+
+    if (maxval(abs(hcov_scaled(2:3) - rz_scale*hcov_base(2:3))) > tol*max(1.0_dp, maxval(abs(hcov_scaled(2:3))))) then
+        print *, 'FAIL: hcov scaling mismatch'
+        nfail = nfail + 1
+    end if
+
+    select type (cs => ref_coords)
+    type is (scaled_chartmap_coordinate_system_t)
+        x_scaled_input = ref_cart_scaled
+        call cs%from_cart(x_scaled_input, u_back, ierr)
+        if (ierr /= 0) then
+            print *, 'FAIL: scaled chartmap from_cart ierr=', ierr
+            nfail = nfail + 1
+        else if (maxval(abs(u_back - u)) > 1.0e-8_dp) then
+            print *, 'FAIL: scaled chartmap from_cart roundtrip mismatch'
+            nfail = nfail + 1
+        end if
+    class default
+        print *, 'FAIL: reference coordinates were not wrapped in scaled chartmap type'
+        nfail = nfail + 1
+    end select
+
+    vmec_B_scale = 1.0_dp
+    vmec_RZ_scale = 1.0_dp
+
+    if (nfail /= 0) then
+        print *, nfail, 'chartmap scaling tests failed'
+        error stop
+    end if
+
+    print *, 'PASS: chartmap scaling applies to field and coordinates'
+end program test_chartmap_scaling


### PR DESCRIPTION
## Summary
- apply `vmec_RZ_scale` to chartmap-backed reference coordinates by wrapping chartmap coordinate systems
- apply `vmec_B_scale` and `vmec_RZ_scale` to Boozer chartmap field data so chartmap runs follow the same scaling knobs as VMEC-backed runs
- add a regression test that checks geometry, field magnitudes, flux scaling, and chartmap `from_cart` roundtrips under scaling

## Verification
```bash
cmake -S . -B build -G Ninja
cmake --build build --target test_boozer_chartmap.x test_chartmap_scaling.x test_boozer_chartmap_roundtrip.x -j$(nproc)
ctest --test-dir build -R 'test_boozer_chartmap|test_chartmap_scaling' --output-on-failure

cmake --build build --target test_chartmap_metadata.x test_refcoords_file_detection.x test_chartmap_pipeline.x test_chartmap_rz_consistency.x test_field_equivalence_chartmap.x -j$(nproc)
ctest --test-dir build -R 'test_chartmap_metadata|test_refcoords_file_detection|test_chartmap_pipeline|test_chartmap_rz_consistency|test_field_equivalence_chartmap' --output-on-failure
```
