### PR TITLE
Allow startmode 1 in Boozer chartmap runs

### DIFF
--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -100,11 +100,6 @@ contains
             call print_phase_time('TEST field particle sampling completed')
         else if (chartmap_mode) then
             ! Boozer chartmap: no VMEC, use Boozer magfie for field line tracing.
-            if (startmode /= 2) then
-                error stop 'Boozer chartmap requires startmode=2 '// &
-                    '(load particles from start.dat)'
-            end if
-
             call init_magfie(isw_field_type)
             call print_phase_time('Boozer magfie initialization completed')
 

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -343,6 +343,11 @@ add_test(NAME test_array_utils COMMAND test_array_utils.x)
     )
     add_custom_target(generate_test_boozer_chartmap
         DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/test_boozer_chartmap.nc)
+    add_test(NAME generate_test_boozer_chartmap_data
+        COMMAND $<TARGET_FILE:generate_test_boozer_chartmap.x> ${CMAKE_CURRENT_BINARY_DIR}/test_boozer_chartmap.nc)
+    set_tests_properties(generate_test_boozer_chartmap_data PROPERTIES
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        LABELS "unit")
     add_executable(test_boozer_chartmap.x test_boozer_chartmap.f90)
     target_link_libraries(test_boozer_chartmap.x simple)
     add_dependencies(test_boozer_chartmap.x generate_test_boozer_chartmap)
@@ -350,6 +355,15 @@ add_test(NAME test_array_utils COMMAND test_array_utils.x)
     set_tests_properties(test_boozer_chartmap PROPERTIES
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         LABELS "unit")
+    add_test(NAME test_chartmap_startmode1
+        COMMAND ${Python3_EXECUTABLE}
+            ${CMAKE_CURRENT_SOURCE_DIR}/test_chartmap_startmode1.py
+            $<TARGET_FILE:simple.x>
+            ${CMAKE_CURRENT_BINARY_DIR}/test_boozer_chartmap.nc)
+    set_tests_properties(test_chartmap_startmode1 PROPERTIES
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        LABELS "integration;python"
+        DEPENDS "generate_test_boozer_chartmap_data")
 
     # Boozer chartmap roundtrip test: requires wout.nc
     add_executable(test_boozer_chartmap_roundtrip.x test_boozer_chartmap_roundtrip.f90)

--- a/test/tests/test_chartmap_startmode1.py
+++ b/test/tests/test_chartmap_startmode1.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Regression test for chartmap runs with startmode=1."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import os
+from pathlib import Path
+
+import numpy as np
+
+
+def write_config(path: Path) -> None:
+    path.write_text(
+        """&config
+trace_time = 1d-6
+ntimstep = 4
+ntestpart = 8
+field_input = 'test_boozer_chartmap.nc'
+coord_input = 'test_boozer_chartmap.nc'
+isw_field_type = 2
+startmode = 1
+integmode = 1
+relerr = 1d-10
+deterministic = .True.
+/
+""",
+        encoding="ascii",
+    )
+
+
+def run_once(workdir: Path, simple_x: Path) -> tuple[np.ndarray, np.ndarray]:
+    for name in [
+        "start.dat",
+        "times_lost.dat",
+        "confined_fraction.dat",
+        "avg_inverse_t_lost.dat",
+        "results.nc",
+        "fort.6601",
+    ]:
+        target = workdir / name
+        if target.exists() or target.is_symlink():
+            target.unlink()
+
+    env = os.environ.copy()
+    env["OMP_NUM_THREADS"] = "1"
+    result = subprocess.run(
+        [str(simple_x)],
+        cwd=workdir,
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        raise SystemExit(f"simple.x failed with exit code {result.returncode}")
+
+    start = np.loadtxt(workdir / "start.dat")
+    confined = np.loadtxt(workdir / "confined_fraction.dat")
+    if start.ndim == 1:
+        start = start[np.newaxis, :]
+    if confined.ndim == 1:
+        confined = confined[np.newaxis, :]
+    return start, confined
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: test_chartmap_startmode1.py <simple.x> <chartmap.nc>")
+
+    simple_x = Path(sys.argv[1]).resolve()
+    chartmap = Path(sys.argv[2]).resolve()
+    base = Path.cwd() / "chartmap_startmode1_work"
+
+    if base.exists():
+        shutil.rmtree(base)
+    base.mkdir()
+    (base / "test_boozer_chartmap.nc").symlink_to(chartmap)
+    write_config(base / "simple.in")
+    np.savetxt(
+        base / "start.dat",
+        np.full((8, 5), 9.0),
+        fmt="%.16e",
+    )
+
+    start1, confined1 = run_once(base, simple_x)
+    start2, confined2 = run_once(base, simple_x)
+
+    assert start1.shape == (8, 5), start1.shape
+    assert not np.allclose(start1, 9.0), "chartmap startmode=1 reused an existing start.dat"
+    assert np.allclose(start1, start2), "deterministic chartmap starts changed between runs"
+    assert np.allclose(confined1, confined2), "deterministic chartmap outputs changed between runs"
+    assert np.isclose(confined1[0, 1] + confined1[0, 2], 1.0), confined1[0]
+    assert np.count_nonzero(np.abs(start1[:, 1] - start1[0, 1]) > 1.0e-12) > 0, (
+        "expected varied sampled poloidal angles"
+    )
+    assert np.count_nonzero(np.abs(start1[:, 2] - start1[0, 2]) > 1.0e-12) > 0, (
+        "expected varied sampled toroidal angles"
+    )
+    assert np.count_nonzero(np.abs(start1[:, 4] - start1[0, 4]) > 1.0e-12) > 0, (
+        "expected varied sampled pitches"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #339.

## Summary
- allow Boozer chartmap runs to use the normal particle sampler with `startmode = 1`
- add a generated-fixture regression that runs `simple.x` end to end in chartmap mode
- verify deterministic chartmap sampling writes fresh `start.dat` content instead of reusing a stale file

## Verification

### Test fails on main
```bash
$ cmake -S . -B build -G Ninja
$ cmake --build build -j$(nproc) --target simple.x generate_test_boozer_chartmap
$ rm -rf /tmp/chartmap-startmode1-mre
$ mkdir -p /tmp/chartmap-startmode1-mre
$ ln -s "$PWD/build/test/tests/test_boozer_chartmap.nc" /tmp/chartmap-startmode1-mre/test_boozer_chartmap.nc
$ cat > /tmp/chartmap-startmode1-mre/simple.in <<'EOCFG'
&config
trace_time = 1d-6
ntimstep = 2
ntestpart = 1
field_input = 'test_boozer_chartmap.nc'
coord_input = 'test_boozer_chartmap.nc'
isw_field_type = 2
startmode = 1
integmode = 1
relerr = 1d-10
/
EOCFG
$ (cd /tmp/chartmap-startmode1-mre && "$PWD/build/simple.x")
INFO: Boozer chartmap field loading completed
INFO: Canonical field initialization completed
ERROR STOP Boozer chartmap requires startmode=2 (load particles from start.dat)
```

### Test passes after fix
```bash
$ ctest --test-dir /tmp/simple-chartmap-startmode-one/build -R '^(generate_test_boozer_chartmap_data|test_boozer_chartmap|test_chartmap_startmode1)$' --output-on-failure
Test project /tmp/simple-chartmap-startmode-one/build
    Start 10: generate_test_boozer_chartmap_data
1/3 Test #10: generate_test_boozer_chartmap_data ...   Passed    0.13 sec
    Start 11: test_boozer_chartmap
2/3 Test #11: test_boozer_chartmap .................   Passed    0.40 sec
    Start 12: test_chartmap_startmode1
3/3 Test #12: test_chartmap_startmode1 .............   Passed   10.21 sec

100% tests passed, 0 tests failed out of 3
```

```bash
$ ctest --test-dir /tmp/simple-chartmap-startmode-one/build -R '^(test_chartmap_metadata|test_boozer_chartmap_roundtrip|test_refcoords_file_detection|test_field_equivalence_chartmap|test_chartmap_pipeline|test_chartmap_rz_consistency)$' --output-on-failure
Test project /tmp/simple-chartmap-startmode-one/build
    Start  9: test_chartmap_metadata
1/6 Test  #9: test_chartmap_metadata ............   Passed    0.15 sec
    Start 13: test_boozer_chartmap_roundtrip
2/6 Test #13: test_boozer_chartmap_roundtrip ....   Passed   12.81 sec
    Start 25: test_refcoords_file_detection
3/6 Test #25: test_refcoords_file_detection .....   Passed    0.88 sec
    Start 26: test_field_equivalence_chartmap
4/6 Test #26: test_field_equivalence_chartmap ...   Passed   94.54 sec
    Start 27: test_chartmap_pipeline
5/6 Test #27: test_chartmap_pipeline ............   Passed   24.58 sec
    Start 28: test_chartmap_rz_consistency
6/6 Test #28: test_chartmap_rz_consistency ......   Passed   20.65 sec

100% tests passed, 0 tests failed out of 6
```
