### PR TITLE
Polish examples and README quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ brew install gcc cmake ninja netcdf netcdf-fortran lapack
 
 For Python wrappers, do
 ```bash
-pip install f90wrap==0.2.16
+pip install f90wrap
 pip install -e . --no-build-isolation
 ```
 
@@ -160,10 +160,12 @@ fields residing in main memory. The main executable is `simple.x`.
 * `simple.in`
 * a VMEC NetCDF equlibrium (wout.nc) file with name specified in `simple.in`
 
-An example input file with explanation of each parameter can be found in `examples/simple.in`. An example `wout.nc` can be obtained by
+A minimal quickstart input is `examples/simple.in`. The full parameter reference with comments is `examples/simple_full.in`. An example `wout.nc` can be obtained by
 ```bash
 wget https://github.com/hiddenSymmetries/simsopt/raw/master/tests/test_files/wout_LandremanPaul2021_QA_reactorScale_lowres_reference.nc -O wout.nc
 ```
+
+For a self-contained demo that downloads test data, runs SIMPLE, and prints the confined fraction, use `examples/run_example.sh`.
 
 In addition `start.dat` is either an input for given (`startmode>=2`) or an output (`startmode` 0 or 1) for randomly generated initial conditions.
 Diagnostics for slow convergence of Newton iterations are written in `fort.6601`.
@@ -187,10 +189,7 @@ The sum of 2. and 3. yields the overall confined fraction at each time.
    Whenever trap_par < contr_pp, particle is not traced and counted as confined.
 
 ### Comparing Commits ("Golden Record")
-To execute test_against_legacy_behaviour.py, execute `get_test_data.sh`, run SIMPLE and create the following symlinks in the `tests` directory after running SIMPLE in the `test_data` directory:
-* ../../../test_data/wout.nc --> wout.nc
-*  ../../../../examples/simple_full.in --> simple.in
-*  ../../../../build/start.dat start.dat
+To compare output between commits, use the golden record test suite in `test/golden_record/`. Run `test/golden_record/golden_record.sh [ref_version]` to build a reference version and compare its output against the current build.
 
 ## References
 When using this code for scientific publications, please cite the according references:

--- a/examples/run_example.sh
+++ b/examples/run_example.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Run a quick SIMPLE example: download test data, trace orbits, print result.
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+SIMPLE_X="${1:-$REPO_ROOT/build/simple.x}"
+WOUT_URL="https://github.com/hiddenSymmetries/simsopt/raw/master/tests/test_files/wout_LandremanPaul2021_QA_reactorScale_lowres_reference.nc"
+
+if [ ! -x "$SIMPLE_X" ]; then
+    echo "Executable not found: $SIMPLE_X"
+    echo "Build first with 'make' from the repository root, or pass the path as argument."
+    exit 1
+fi
+
+RUN_DIR="/tmp/simple_example"
+mkdir -p "$RUN_DIR"
+cp "$SCRIPT_DIR/simple.in" "$RUN_DIR/"
+
+if [ ! -f "$RUN_DIR/wout.nc" ]; then
+    echo "Downloading test VMEC file..."
+    wget -q "$WOUT_URL" -O "$RUN_DIR/wout.nc"
+fi
+
+echo "Running SIMPLE in $RUN_DIR ..."
+(cd "$RUN_DIR" && "$SIMPLE_X")
+
+echo -e "\nConfined fraction over time:"
+column -t "$RUN_DIR/confined_fraction.dat"


### PR DESCRIPTION
## Summary
- Add `examples/run_example.sh` as a self-contained demo script (downloads test data, runs SIMPLE, prints confined fraction)
- Fix stale f90wrap version pin in README (was 0.2.16, now unpinned)
- Clarify that `simple.in` is the quickstart and `simple_full.in` the full parameter reference
- Replace stale "Comparing Commits" section with reference to `test/golden_record/golden_record.sh`

## Test plan
- [x] `make CONFIG=Fast` builds successfully
- [x] `examples/run_example.sh` downloads data and runs SIMPLE, producing `confined_fraction.dat`
- [x] No existing tests affected (documentation/example changes only)