### PR TITLE
Add explicit initial alpha energy config

### DIFF
--- a/DOC/config.md
+++ b/DOC/config.md
@@ -1,3 +1,8 @@
+* `alpha_energy_ev` sets the initial test-particle energy directly in eV when
+  positive. The default `-1d0` leaves the legacy `3.5d6/facE_al` scaling in
+  effect. `facE_al` must remain positive because it is still the fallback
+  energy scale.
+
 * For symplectic Euler, `npoiper2=256` should be set in particular if all orbits
   (including strongly passing) are traced. This is especially the case when they can collide into this region if `sw_coll=.True.`. If one sets a limit via
   e.g. `contr_pp=-1d0` to trace only mildly passing orbits, or even switch

--- a/examples/orbit_output_test/simple.in
+++ b/examples/orbit_output_test/simple.in
@@ -11,6 +11,7 @@ phibeg = 0.d0
 thetabeg = 0.d0
 contr_pp = -1.0d0
 facE_al = 1.0
+alpha_energy_ev = -1.0d0
 npoiper2 = 128
 n_e = 2
 n_d = 4

--- a/examples/simple_full.in
+++ b/examples/simple_full.in
@@ -15,6 +15,7 @@ phibeg = 0.d0            ! starting phi for field line
 thetabeg = 0.d0          ! starting theta for field line
 contr_pp = -1.0d0        ! control of passing particle fraction
 facE_al = 1.0            ! test particle energy reduction factor
+alpha_energy_ev = -1.0d0 ! explicit initial energy in eV; positive value overrides facE_al
 npoiper2 = 128	         ! points per period for integrator step
 n_e = 2                  ! test particle charge number (the same as Z)
 n_d = 4                  ! test particle mass number (the same as A)

--- a/simple.in
+++ b/simple.in
@@ -15,6 +15,7 @@ phibeg = 0.d0            ! starting phi for field line
 thetabeg = 0.d0          ! starting theta for field line
 contr_pp = -1.0d0        ! control of passing particle fraction
 facE_al = 1.0            ! test particle energy reduction factor
+alpha_energy_ev = -1.0d0 ! explicit initial energy in eV; positive value overrides facE_al
 npoiper2 = 128	         ! points per period for integrator step
 n_e = 2                  ! test particle charge number (the same as Z)
 n_d = 4                  ! test particle mass number (the same as A)

--- a/src/netcdf_results_output.f90
+++ b/src/netcdf_results_output.f90
@@ -42,7 +42,8 @@ contains
 
         use params, only: ntestpart, trace_time, zstart, zend, times_lost, &
                           trap_par, perp_inv, iclass, class_lost, &
-                          facE_al, v0, integmode, relerr, npoiper, npoiper2, &
+                          facE_al, alpha_energy_ev, particle_energy_ev, v0, &
+                          integmode, relerr, npoiper, npoiper2, &
                           ntimstep, startmode, num_surf, sbeg, &
                           isw_field_type, swcoll, deterministic, ran_seed, &
                           netcdffile, field_input, coord_input, &
@@ -268,6 +269,12 @@ contains
         call check_nc(status, 'put_att trace_time')
         status = nf90_put_att(ncid, nf90_global, 'facE_al', facE_al)
         call check_nc(status, 'put_att facE_al')
+        status = nf90_put_att(ncid, nf90_global, 'alpha_energy_ev', &
+                              alpha_energy_ev)
+        call check_nc(status, 'put_att alpha_energy_ev')
+        status = nf90_put_att(ncid, nf90_global, 'particle_energy_ev', &
+                              particle_energy_ev)
+        call check_nc(status, 'put_att particle_energy_ev')
         status = nf90_put_att(ncid, nf90_global, 'v0', v0)
         call check_nc(status, 'put_att v0')
         status = nf90_put_att(ncid, nf90_global, 'integmode', integmode)

--- a/src/params.f90
+++ b/src/params.f90
@@ -78,7 +78,8 @@ module params
 
     ! Further configuration parameters
     integer          :: notrace_passing = 0
-    real(dp) :: facE_al = 1d0, trace_time = 1d-1
+    real(dp) :: facE_al = 1d0, alpha_energy_ev = -1d0, &
+                particle_energy_ev = 3.5d6, trace_time = 1d-1
     integer :: ntimstep = 10000, npoiper = 100, npoiper2 = 256, n_e = 2
     real(dp) :: n_d = 4
 
@@ -102,9 +103,9 @@ module params
 
 	    namelist /config/ notrace_passing, nper, npoiper, ntimstep, ntestpart, &
 	        trace_time, num_surf, sbeg, phibeg, thetabeg, contr_pp, &
-	        facE_al, npoiper2, n_e, n_d, netcdffile, ns_s, ns_tp, multharm, &
-	        isw_field_type, generate_start_only, startmode, grid_density, &
-	        special_ants_file, integmode, relerr, tcut, nturns, debug, &
+	        facE_al, alpha_energy_ev, npoiper2, n_e, n_d, netcdffile, ns_s, &
+	        ns_tp, multharm, isw_field_type, generate_start_only, startmode, &
+	        grid_density, special_ants_file, integmode, relerr, tcut, nturns, debug, &
 	        class_plot, cut_in_per, fast_class, vmec_B_scale, &
 	        vmec_RZ_scale, swcoll, deterministic, old_axis_healing, &
 	        old_axis_healing_boundary, am1, am2, Z1, Z2, &
@@ -131,6 +132,8 @@ contains
 
         call apply_config_aliases
 
+        call validate_energy_config
+
         call reset_seed_if_deterministic
 
         if (swcoll .and. (tcut > 0.0d0 .or. class_plot .or. fast_class)) then
@@ -143,7 +146,6 @@ contains
     end subroutine read_config
 
 	    subroutine params_init
-	        real(dp) :: E_alpha
 	        integer :: L1i
 	        real(dp) :: weight_sum, cumul_weight, w
 	        integer :: i, nintv
@@ -167,9 +169,9 @@ contains
 	            dtaumin = dtau/ntau
 	            fper = 2d0*pi       ! Full torus
 	        else
-            E_alpha = 3.5d6/facE_al
+            particle_energy_ev = effective_alpha_energy_ev()
             ! set alpha energy, velocity, and Larmor radius
-            v0 = sqrt(2.d0*E_alpha*ev/(n_d*p_mass))
+            v0 = sqrt(2.d0*particle_energy_ev*ev/(n_d*p_mass))
             rlarm = v0*n_d*p_mass*c/(n_e*e_charge)
             ro0 = rlarm
             ! Neglect relativistic effects by large inverse relativistic temperature
@@ -248,6 +250,26 @@ contains
         call init_batch
         call reallocate_arrays
 	    end subroutine params_init
+
+    function effective_alpha_energy_ev() result(energy_ev)
+        real(dp) :: energy_ev
+
+        if (alpha_energy_ev > 0d0) then
+            energy_ev = alpha_energy_ev
+        else
+            energy_ev = 3.5d6/facE_al
+        end if
+    end function effective_alpha_energy_ev
+
+    subroutine validate_energy_config
+        if (facE_al <= 0d0) then
+            error stop 'facE_al must be positive'
+        end if
+
+        if (abs(alpha_energy_ev) <= tiny(alpha_energy_ev)) then
+            error stop 'alpha_energy_ev must be positive when set'
+        end if
+    end subroutine validate_energy_config
 
 	    pure function to_lower(s) result(out)
 	        character(*), intent(in) :: s

--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -462,13 +462,14 @@ contains
 
     subroutine init_collisions
         use params, only: am1, am2, Z1, Z2, densi1, densi2, tempi1, tempi2, tempe, &
-                          facE_al, dchichi, slowrate, dchichi_norm, slowrate_norm, v0
+                          dchichi, slowrate, dchichi_norm, slowrate_norm, &
+                          particle_energy_ev, v0
 
         real(dp) :: v0_coll
 
         call loacol_alpha(am1, am2, Z1, Z2, densi1, densi2, tempi1, tempi2, tempe, &
-                          3.5d6/facE_al, v0_coll, dchichi, slowrate, dchichi_norm, &
-                          slowrate_norm)
+                          particle_energy_ev, v0_coll, dchichi, slowrate, &
+                          dchichi_norm, slowrate_norm)
 
         if (abs(v0_coll - v0) > 1d-6) then
             error stop 'simple_main.init_collisions: v0_coll != v0'

--- a/test/golden_record/albert_coils/simple.in
+++ b/test/golden_record/albert_coils/simple.in
@@ -9,4 +9,5 @@ isw_field_type = 4       ! Albert coordinates
 deterministic = .True.
 field_input = 'coils.simple'
 facE_al = 100.0d0        ! Energy scale factor (E_alpha / facE_al)
+alpha_energy_ev = -1.0d0 ! Explicit initial energy in eV; positive value overrides facE_al
 /

--- a/test/golden_record/boozer_ncsx/simple.in
+++ b/test/golden_record/boozer_ncsx/simple.in
@@ -8,4 +8,5 @@ netcdffile = 'wout.nc'
 isw_field_type = 2       ! Boozer coordinates
 deterministic = .True.
 facE_al = 100.0d0        ! Energy scale factor (E_alpha / facE_al)
+alpha_energy_ev = -1.0d0 ! Explicit initial energy in eV; positive value overrides facE_al
 /

--- a/test/golden_record/meiss_coils/simple.in
+++ b/test/golden_record/meiss_coils/simple.in
@@ -9,4 +9,5 @@ isw_field_type = 3       ! Meiss coordinates
 deterministic = .True.
 field_input = 'coils.simple'
 facE_al = 100.0d0        ! Energy scale factor (E_alpha / facE_al)
+alpha_energy_ev = -1.0d0 ! Explicit initial energy in eV; positive value overrides facE_al
 /

--- a/test/test_data/simple.multiple_fieldline.in
+++ b/test/test_data/simple.multiple_fieldline.in
@@ -15,6 +15,7 @@ thetabeg = 0.d0          ! starting theta for field line
 loopskip = 0             ! loops to skip for random number shift
 contr_pp = -1.0d0        ! control of passing particle fraction
 facE_al = 1.0            ! test particle energy reduction factor
+alpha_energy_ev = -1.0d0 ! explicit initial energy in eV; positive value overrides facE_al
 npoiper2 = 128	         ! points per period for integrator step
 n_e = 2                  ! test particle charge number (the same as Z)
 n_d = 4                  ! test particle mass number (the same as A)

--- a/test/test_data/simple.single_fieldline.in
+++ b/test/test_data/simple.single_fieldline.in
@@ -15,6 +15,7 @@ thetabeg = 0.d0          ! starting theta for field line
 loopskip = 0             ! loops to skip for random number shift
 contr_pp = -1.0d0        ! control of passing particle fraction
 facE_al = 1.0            ! test particle energy reduction factor
+alpha_energy_ev = -1.0d0 ! explicit initial energy in eV; positive value overrides facE_al
 npoiper2 = 128	         ! points per period for integrator step
 n_e = 2                  ! test particle charge number (the same as Z)
 n_d = 4                  ! test particle mass number (the same as A)

--- a/test/test_data/simple.volume.in
+++ b/test/test_data/simple.volume.in
@@ -15,6 +15,7 @@ thetabeg = 0.d0          ! starting theta for field line
 loopskip = 0             ! loops to skip for random number shift
 contr_pp = -1.0d0        ! control of passing particle fraction
 facE_al = 1.0            ! test particle energy reduction factor
+alpha_energy_ev = -1.0d0 ! explicit initial energy in eV; positive value overrides facE_al
 npoiper2 = 128	         ! points per period for integrator step
 n_e = 2                  ! test particle charge number (the same as Z)
 n_d = 4                  ! test particle mass number (the same as A)

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -358,6 +358,11 @@ add_test(NAME test_array_utils COMMAND test_array_utils.x)
     target_link_libraries(test_util_simple.x simple)
     add_test(NAME test_util_simple COMMAND test_util_simple.x)
 
+    add_executable(test_params_energy_config.x test_params_energy_config.f90)
+    target_link_libraries(test_params_energy_config.x simple)
+    add_test(NAME test_params_energy_config COMMAND test_params_energy_config.x)
+    set_tests_properties(test_params_energy_config PROPERTIES LABELS "unit")
+
     add_executable(test_chartmap_metadata.x test_chartmap_metadata.f90)
     target_link_libraries(test_chartmap_metadata.x simple testing_utils)
     add_test(NAME test_chartmap_metadata COMMAND test_chartmap_metadata.x)

--- a/test/tests/test_params_energy_config.f90
+++ b/test/tests/test_params_energy_config.f90
@@ -1,0 +1,81 @@
+program test_params_energy_config
+    use params, only: alpha_energy_ev, effective_alpha_energy_ev, facE_al, &
+                      read_config
+    implicit none
+
+    integer, parameter :: dp = kind(1.0d0)
+    integer :: errors
+
+    errors = 0
+
+    call test_explicit_energy(errors)
+    call test_scaled_energy(errors)
+
+    if (errors /= 0) then
+        print *, "ERROR:", errors, "params energy config test(s) failed"
+        stop 1
+    end if
+
+    print *, "All params energy config tests passed!"
+
+contains
+
+    subroutine test_explicit_energy(errors)
+        integer, intent(inout) :: errors
+        character(len=256) :: path
+
+        path = "test_alpha_energy_explicit.in"
+        call reset_energy_defaults
+        call write_config(path, 10.0d0, 1.25d6)
+        call read_config(path)
+
+        call expect_close("facE_al explicit case", facE_al, 10.0d0, errors)
+        call expect_close("alpha_energy_ev", alpha_energy_ev, 1.25d6, errors)
+        call expect_close("explicit effective energy", effective_alpha_energy_ev(), &
+                          1.25d6, errors)
+    end subroutine test_explicit_energy
+
+    subroutine test_scaled_energy(errors)
+        integer, intent(inout) :: errors
+        character(len=256) :: path
+
+        path = "test_alpha_energy_scaled.in"
+        call reset_energy_defaults
+        call write_config(path, 100.0d0, -1.0d0)
+        call read_config(path)
+
+        call expect_close("facE_al scaled case", facE_al, 100.0d0, errors)
+        call expect_close("unset alpha_energy_ev", alpha_energy_ev, -1.0d0, errors)
+        call expect_close("scaled effective energy", effective_alpha_energy_ev(), &
+                          3.5d4, errors)
+    end subroutine test_scaled_energy
+
+    subroutine write_config(path, fac, energy)
+        character(len=*), intent(in) :: path
+        real(dp), intent(in) :: fac, energy
+        integer :: unit
+
+        open (newunit=unit, file=path, status="replace", action="write")
+        write (unit, '(a)') "&config"
+        write (unit, '(a, es24.16)') "facE_al = ", fac
+        write (unit, '(a, es24.16)') "alpha_energy_ev = ", energy
+        write (unit, '(a)') "/"
+        close (unit)
+    end subroutine write_config
+
+    subroutine reset_energy_defaults
+        facE_al = 1d0
+        alpha_energy_ev = -1d0
+    end subroutine reset_energy_defaults
+
+    subroutine expect_close(label, got, expected, errors)
+        character(len=*), intent(in) :: label
+        real(dp), intent(in) :: got, expected
+        integer, intent(inout) :: errors
+
+        if (abs(got - expected) > 1d-12*max(1d0, abs(expected))) then
+            print *, "ERROR:", trim(label), "got", got, "expected", expected
+            errors = errors + 1
+        end if
+    end subroutine expect_close
+end program test_params_energy_config


### PR DESCRIPTION
## Summary
- add `alpha_energy_ev` as an optional direct initial-energy input in eV
- keep `facE_al` as the legacy fallback energy scale
- record both requested and effective energy in NetCDF output
- add a unit test for explicit and scaled energy config paths

Fixes #7

## Verification

### Test fails on main

Not run: this branch adds the new `test_params_energy_config` test for the new config key.

### Test passes after fix

```text
$ make test TEST=test_params_energy_config
Test project /home/ert/code/SIMPLE/build/test
    Start 9: test_params_energy_config
1/1 Test #9: test_params_energy_config ........   Passed    0.05 sec

100% tests passed, 0 tests failed out of 1
```