### PR TITLE
Fix full-suite test registration and spline oracle

### DIFF
--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -388,7 +388,7 @@ add_test(NAME test_array_utils COMMAND test_array_utils.x)
 
     # E2E test: VMEC-Boozer vs chartmap confined fractions
     add_test(NAME test_e2e_boozer_chartmap
-        COMMAND ${Python_EXECUTABLE}
+        COMMAND ${Python3_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/test_e2e_boozer_chartmap.py)
     set_tests_properties(test_e2e_boozer_chartmap PROPERTIES
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/test/tests/test_bder_from_splines.f90
+++ b/test/tests/test_bder_from_splines.f90
@@ -23,7 +23,7 @@ program test_bder_from_splines
     real(dp), parameter :: tol_rel = 5.0e-8_dp
     real(dp), parameter :: tol_abs = 1.0e-10_dp
     real(dp), parameter :: h_rho = 1.0e-4_dp
-    real(dp), parameter :: h_ang = 1.0e-5_dp
+    real(dp), parameter :: h_ang = 3.0e-5_dp
 
     real(dp) :: max_rel(3)
     integer :: i


### PR DESCRIPTION
## Summary
- run the Boozer chartmap e2e test through the configured Python3 interpreter
- increase only the angular finite-difference step in test_bder_from_splines; the relative tolerance remains 5e-8

## Why the bder change is an oracle fix, not a tolerance relaxation
The failing comparison is analytic spline derivative from evaluate_with_der versus a 5-point finite-difference derivative of evaluate on the same spline. After #341 reduced this test spline grid from 62x63x64 to 32x33x32, the old angular FD step h=1e-5 became too small for the coarser quintic spline oracle. The failure was one theta component at rel=8.067e-8 against tol=5e-8.

Local isolation on the same code/libneo:
- dense old grid 62x63x64 with h_ang=1e-5: passed, max rel bder=(4.6135e-10, 9.7805e-09, 3.4699e-08)
- reduced grid 32x33x32 with h_ang=1e-5: failed, max rel bder=(5.6559e-10, 8.0671e-08, 2.6457e-08)
- reduced grid 32x33x32 with h_ang=2e-5: passed, max rel bder=(5.6559e-10, 2.5096e-08, 5.4406e-09)
- reduced grid 32x33x32 with h_ang=3e-5: passed, max rel bder=(5.6559e-10, 4.7798e-09, 1.9796e-08)

The test accuracy gate is unchanged: tol_rel remains 5e-8. The changed step is still tiny compared to the reduced angular grid spacing, so it does not hide interval-scale spline errors.

## Verification
- cmake --build build -j$(nproc)
- ctest --test-dir build -R 'test_e2e_boozer_chartmap|test_bder_from_splines' --output-on-failure\n- temporary FD-step isolation runs listed above\n- full stack later: ctest --test-dir build --output-on-failure (65/65 passed, 680.50 s)