### PR TITLE
Share test assertion helpers

### DIFF
--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -327,7 +327,7 @@ add_test(NAME test_array_utils COMMAND test_array_utils.x)
     add_test(NAME test_util_simple COMMAND test_util_simple.x)
 
     add_executable(test_chartmap_metadata.x test_chartmap_metadata.f90)
-    target_link_libraries(test_chartmap_metadata.x simple)
+    target_link_libraries(test_chartmap_metadata.x simple testing_utils)
     add_test(NAME test_chartmap_metadata COMMAND test_chartmap_metadata.x)
     set_tests_properties(test_chartmap_metadata PROPERTIES LABELS "unit")
 
@@ -396,7 +396,7 @@ add_test(NAME test_array_utils COMMAND test_array_utils.x)
 
     if(SIMPLE_ENABLE_CGAL)
         add_executable(test_stl_wall_intersection.x test_stl_wall_intersection.f90)
-        target_link_libraries(test_stl_wall_intersection.x simple)
+        target_link_libraries(test_stl_wall_intersection.x simple testing_utils)
         add_test(NAME test_stl_wall_intersection COMMAND test_stl_wall_intersection.x)
         set_tests_properties(test_stl_wall_intersection PROPERTIES LABELS "unit;wall")
     endif()

--- a/test/tests/test_chartmap_metadata.f90
+++ b/test/tests/test_chartmap_metadata.f90
@@ -2,15 +2,21 @@ program test_chartmap_metadata
     use, intrinsic :: iso_fortran_env, only: dp => real64
     use netcdf
     use chartmap_metadata, only: chartmap_metadata_t, read_chartmap_metadata
+    use test_utils, only: check_close, check_string
     implicit none
 
     type(chartmap_metadata_t) :: meta
+    integer :: errors
 
+    errors = 0
     call write_min_chartmap("mini.chartmap.nc", "cm", 0.8_dp)
     call read_chartmap_metadata("mini.chartmap.nc", meta)
-    call assert_close(meta%rho_lcfs, 0.8_dp, 1.0e-15_dp, "rho_lcfs mismatch")
-    call assert_close(meta%cart_scale_to_m, 0.01_dp, 1.0e-15_dp, "scale mismatch")
-    call assert_str(meta%cart_units, "cm", "units mismatch")
+    call check_close(meta%rho_lcfs, 0.8_dp, 1.0e-15_dp, "rho_lcfs mismatch", &
+        errors)
+    call check_close(meta%cart_scale_to_m, 0.01_dp, 1.0e-15_dp, &
+        "scale mismatch", errors)
+    call check_string(meta%cart_units, "cm", "units mismatch", errors)
+    if (errors /= 0) error stop 1
 contains
 
     subroutine check_nc(status, where)
@@ -82,27 +88,4 @@ contains
         call check_nc(status, "close")
     end subroutine write_min_chartmap
 
-    subroutine assert_close(a, b, tol, msg)
-        real(dp), intent(in) :: a, b, tol
-        character(len=*), intent(in) :: msg
-
-        if (abs(a - b) > tol) then
-            print *, "ASSERTION FAILED: ", trim(msg)
-            print *, "got=", a, " expected=", b
-            error stop 1
-        end if
-    end subroutine assert_close
-
-    subroutine assert_str(a, b, msg)
-        character(len=*), intent(in) :: a, b
-        character(len=*), intent(in) :: msg
-
-        if (trim(a) /= trim(b)) then
-            print *, "ASSERTION FAILED: ", trim(msg)
-            print *, "got=", trim(a), " expected=", trim(b)
-            error stop 1
-        end if
-    end subroutine assert_str
-
 end program test_chartmap_metadata
-

--- a/test/tests/test_stl_wall_intersection.f90
+++ b/test/tests/test_stl_wall_intersection.f90
@@ -2,38 +2,42 @@ program test_stl_wall_intersection
     use, intrinsic :: iso_fortran_env, only: dp => real64
     use stl_wall_intersection, only: stl_wall_t, stl_wall_init, stl_wall_finalize, &
                                      stl_wall_first_hit_segment_with_normal
+    use test_utils, only: check, check_close, check_close_vec
     implicit none
 
     type(stl_wall_t) :: wall
+    integer :: errors
     logical :: hit
     real(dp) :: p0(3), p1(3), hit_p(3)
     real(dp) :: normal(3), dotx
 
+    errors = 0
     call write_tetra_stl_m("tetra_m.stl")
     call stl_wall_init(wall, "tetra_m.stl", 1.0_dp)
 
     p0 = [0.25_dp, 0.25_dp, 0.25_dp]
     p1 = [2.0_dp, 0.25_dp, 0.25_dp]
     call stl_wall_first_hit_segment_with_normal(wall, p0, p1, hit, hit_p, normal)
-    call assert_true(hit, "expected intersection for meters STL")
-    call assert_close_vec(hit_p, [0.5_dp, 0.25_dp, 0.25_dp], 1.0e-12_dp, &
-                          "meters STL hit point mismatch")
-    call assert_close_scalar(norm2(normal), 1.0_dp, 1.0e-12_dp, &
-                             "meters STL normal not unit length")
+    call check(hit, "expected intersection for meters STL", errors)
+    call check_close_vec(hit_p, [0.5_dp, 0.25_dp, 0.25_dp], 1.0e-12_dp, &
+        "meters STL hit point mismatch", errors)
+    call check_close(norm2(normal), 1.0_dp, 1.0e-12_dp, &
+        "meters STL normal not unit length", errors)
     dotx = abs(normal(1))
-    call assert_close_scalar(dotx, 1.0_dp/sqrt(3.0_dp), 1.0e-12_dp, &
-                             "meters STL normal mismatch")
+    call check_close(dotx, 1.0_dp/sqrt(3.0_dp), 1.0e-12_dp, &
+        "meters STL normal mismatch", errors)
     call stl_wall_finalize(wall)
 
     call write_tetra_stl_mm("tetra_mm.stl")
     call stl_wall_init(wall, "tetra_mm.stl", 1.0e-3_dp)
     call stl_wall_first_hit_segment_with_normal(wall, p0, p1, hit, hit_p, normal)
-    call assert_true(hit, "expected intersection for millimeters STL (scaled)")
-    call assert_close_vec(hit_p, [0.5_dp, 0.25_dp, 0.25_dp], 1.0e-12_dp, &
-                          "mm STL scaled hit point mismatch")
-    call assert_close_scalar(norm2(normal), 1.0_dp, 1.0e-12_dp, &
-                             "mm STL normal not unit length")
+    call check(hit, "expected intersection for millimeters STL (scaled)", errors)
+    call check_close_vec(hit_p, [0.5_dp, 0.25_dp, 0.25_dp], 1.0e-12_dp, &
+        "mm STL scaled hit point mismatch", errors)
+    call check_close(norm2(normal), 1.0_dp, 1.0e-12_dp, &
+        "mm STL normal not unit length", errors)
     call stl_wall_finalize(wall)
+    if (errors /= 0) error stop 1
 contains
 
     subroutine write_tetra_stl_m(path)
@@ -86,46 +90,10 @@ contains
         write (u, "(A)") "  endfacet"
     end subroutine write_tri
 
-    subroutine assert_true(cond, msg)
-        logical, intent(in) :: cond
-        character(len=*), intent(in) :: msg
-
-        if (.not. cond) then
-            print *, "ASSERTION FAILED: ", trim(msg)
-            error stop 1
-        end if
-    end subroutine assert_true
-
-    subroutine assert_close_vec(a, b, tol, msg)
-        real(dp), intent(in) :: a(3), b(3)
-        real(dp), intent(in) :: tol
-        character(len=*), intent(in) :: msg
-
-        if (maxval(abs(a - b)) > tol) then
-            print *, "ASSERTION FAILED: ", trim(msg)
-            print *, "got:      ", a
-            print *, "expected: ", b
-            error stop 1
-        end if
-    end subroutine assert_close_vec
-
     function norm2(v) result(n)
         real(dp), intent(in) :: v(3)
         real(dp) :: n
         n = sqrt(sum(v*v))
     end function norm2
-
-    subroutine assert_close_scalar(a, b, tol, msg)
-        real(dp), intent(in) :: a, b
-        real(dp), intent(in) :: tol
-        character(len=*), intent(in) :: msg
-
-        if (abs(a - b) > tol) then
-            print *, "ASSERTION FAILED: ", trim(msg)
-            print *, "got:      ", a
-            print *, "expected: ", b
-            error stop 1
-        end if
-    end subroutine assert_close_scalar
 
 end program test_stl_wall_intersection

--- a/test/tests/utility.f90
+++ b/test/tests/utility.f90
@@ -3,9 +3,10 @@ module test_utils
     implicit none
     save
     
-    public assert_equal
+    public assert_equal, check, check_close, check_close_vec, check_string
     interface assert_equal
-        module procedure :: assert_int, assert_flt, assert_flt_range, assert_dbl, assert_dbl_range
+        module procedure :: assert_int, assert_flt, assert_flt_range
+        module procedure :: assert_dbl, assert_dbl_range
     end interface assert_equal
 
     contains
@@ -36,4 +37,55 @@ module test_utils
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !                                       Further Templates
+subroutine check(condition, message, errors)
+    logical, intent(in) :: condition
+    character(len=*), intent(in) :: message
+    integer, intent(inout) :: errors
+
+    if (.not. condition) then
+        print *, "ERROR:", trim(message)
+        errors = errors + 1
+    end if
+end subroutine check
+
+subroutine check_close(actual, expected, tolerance, message, errors)
+    double precision, intent(in) :: actual, expected, tolerance
+    character(len=*), intent(in) :: message
+    integer, intent(inout) :: errors
+
+    if (abs(actual - expected) > tolerance) then
+        print *, "ERROR:", trim(message)
+        print *, "  actual=", actual, " expected=", expected
+        errors = errors + 1
+    end if
+end subroutine check_close
+
+subroutine check_close_vec(actual, expected, tolerance, message, errors)
+    double precision, intent(in) :: actual(:), expected(:), tolerance
+    character(len=*), intent(in) :: message
+    integer, intent(inout) :: errors
+
+    if (size(actual) /= size(expected)) then
+        print *, "ERROR:", trim(message)
+        print *, "  actual size=", size(actual), " expected size=", size(expected)
+        errors = errors + 1
+    elseif (maxval(abs(actual - expected)) > tolerance) then
+        print *, "ERROR:", trim(message)
+        print *, "  actual=", actual
+        print *, "  expected=", expected
+        errors = errors + 1
+    end if
+end subroutine check_close_vec
+
+subroutine check_string(actual, expected, message, errors)
+    character(len=*), intent(in) :: actual, expected, message
+    integer, intent(inout) :: errors
+
+    if (trim(actual) /= trim(expected)) then
+        print *, "ERROR:", trim(message)
+        print *, "  actual=", trim(actual), " expected=", trim(expected)
+        errors = errors + 1
+    end if
+end subroutine check_string
+
 end module test_utils


### PR DESCRIPTION
## Summary
- add common check helpers to test_utils
- remove duplicated local assertion helpers from chartmap metadata and STL wall tests
- link those tests to testing_utils

## Verification
- cmake --build build -j$(nproc)
- ctest --test-dir build -R 'test_chartmap_metadata|test_util_simple|test_stencil_utils|test_array_utils' --output-on-failure\n- if rg -n 'assert_true|assert_false|assert_close|assert_str|def run_case' test/tests; then exit 1; else exit 0; fi