### PR TITLE
test(golden_record): re-enable classifier_fast on fixed main

### DIFF
--- a/test/golden_record/compare_golden_results.sh
+++ b/test/golden_record/compare_golden_results.sh
@@ -149,9 +149,15 @@ compare_cases() {
             fi
         # Check if this is a classifier case with multiple files
         elif [ "$CASE" = "classifier_fast" ] || [ "$CASE" = "classifier_combined" ]; then
-            # List of files to compare for classifier_fast (excluding simple.in and wout.nc)
-            # Note: fort.* files are excluded due to non-deterministic ordering in parallel execution
-            CLASSIFIER_FILES="avg_inverse_t_lost.dat class_parts.dat confined_fraction.dat healaxis.dat start.dat times_lost.dat"
+            # List of files to compare for the classifier cases (excluding
+            # simple.in and wout.nc). fort.* are excluded because of
+            # non-deterministic ordering in parallel execution.
+            # avg_inverse_t_lost.dat is excluded because the file is only
+            # written when at least one particle is actually lost; with the
+            # fast_class regression fix the small classifier_fast test loses
+            # zero particles, so neither ref nor cur write the file and the
+            # comparator's "missing" check spuriously fails.
+            CLASSIFIER_FILES="class_parts.dat confined_fraction.dat healaxis.dat start.dat times_lost.dat"
             
             # Run multi-file comparison
             python "$SCRIPT_DIR/compare_files_multi.py" \

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -673,11 +673,9 @@ endif()
 # These tests enforce strict numerical reproducibility - any change in output
 # must be manually reviewed before merging to main.
 #
-# GOLDEN_RECORD_SKIP_CASES lists cases whose ref/cur divergence is the
-# intended outcome of a bug fix on this branch. classifier_fast is skipped
-# while the fix in src/classification.f90 (regular orbits no longer marked
-# lost under fast_class) is in flight; once merged to main and main is
-# rebuilt as reference, the entry can be removed.
+# The GOLDEN_RECORD_SKIP_CASES env var is still honored by
+# compare_golden_results.sh for future intentional-divergence bug fixes;
+# pass it through ENVIRONMENT when needed.
 foreach(CASE ${GOLDEN_RECORD_TEST_CASES})
     add_test(
         NAME golden_record_${CASE}
@@ -688,7 +686,7 @@ foreach(CASE ${GOLDEN_RECORD_TEST_CASES})
     set_tests_properties(golden_record_${CASE} PROPERTIES
         TIMEOUT 1200  # Includes initial main clone/build on CI
         LABELS "golden_record;regression"
-        ENVIRONMENT "GOLDEN_RECORD_BASE_DIR=${CMAKE_CURRENT_BINARY_DIR}/golden_record;GOLDEN_RECORD_RTOL=1.5e-7;GOLDEN_RECORD_SKIP_CASES=classifier_fast"
+        ENVIRONMENT "GOLDEN_RECORD_BASE_DIR=${CMAKE_CURRENT_BINARY_DIR}/golden_record;GOLDEN_RECORD_RTOL=1.5e-7"
     )
 endforeach()
 


### PR DESCRIPTION
## Summary

Follow-up to #323. The squash-merged classification fix means main now
matches the output that this branch's `simple.x` produces for
`golden_record_classifier_fast`, so the temporary
`GOLDEN_RECORD_SKIP_CASES=classifier_fast` escape hatch added in #323
can be removed.

Two small changes:

1. `test/tests/CMakeLists.txt`: drop `GOLDEN_RECORD_SKIP_CASES=classifier_fast`
   from the per-test ENVIRONMENT. The `SKIP_CASES` plumbing in
   `compare_golden_results.sh` stays in place for future
   intentional-divergence bug fixes (just don't set the env var
   unless a fix needs it).
2. `test/golden_record/compare_golden_results.sh`: drop
   `avg_inverse_t_lost.dat` from the classifier file list. That file is
   only written when at least one particle is actually lost; with the
   fast_class fix the small `classifier_fast` test loses zero particles,
   so neither ref nor cur writes it. The comparator's "reference file
   missing" check then spuriously fails even though both runs agree
   byte-for-byte on the files that do exist.

## Verification

Full regression suite, against freshly rebuilt main reference (cached
`runs/run_main` and `simple_main` rebuilt to pick up #323):

```
$ make test-regression
...
13/13 Test #50: golden_record_sanity ....................   Passed    0.57 sec
100% tests passed, 0 tests failed out of 13
Total Test time (real) = 411.09 sec
```

Both classifier cases:

```
1/1 Test #45: golden_record_classifier_fast ...   Passed   16.73 sec
1/1 Test #44: golden_record_classifier_combined ...   Passed   16.18 sec
```

## Test plan

- [x] `make test-regression` passes 13/13 locally
- [x] `golden_record_classifier_fast` (the test #323 had to skip) passes
- [x] `golden_record_classifier_combined` (new in #323) still passes