### PR TITLE
Periodic checkpoint output and lock-free hot-loop diagnostics

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,8 @@
     sorting.f90
     check_orbit_type.f90
     find_bminmax.f90
+        diag_counters.f90
+        progress_monitor.f90
         timing.f90
         simple_main.f90
         simple_entry.f90

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,6 +56,7 @@
     check_orbit_type.f90
     find_bminmax.f90
         diag_counters.f90
+        restart.f90
         progress_monitor.f90
         timing.f90
         simple_main.f90

--- a/src/diag_counters.f90
+++ b/src/diag_counters.f90
@@ -1,0 +1,93 @@
+module diag_counters
+    !> Lock-free per-thread event counters for hot-loop diagnostics.
+    !>
+    !> The symplectic integrators hit non-convergence and out-of-domain cases
+    !> deep inside their inner Newton iterations. Printing there floods stdout
+    !> and serializes threads. Instead each event bumps a counter; progress_monitor
+    !> aggregates and reports them. Every thread owns its own padded column, so an
+    !> increment touches only that thread's cache line and needs no atomic or
+    !> critical. Totals are a plain reduction over the thread columns, taken
+    !> outside the hot path.
+    use, intrinsic :: iso_fortran_env, only: int64
+!$  use omp_lib, only: omp_get_max_threads, omp_get_thread_num
+    implicit none
+    private
+
+    public :: EVT_NEWTON1_MAXIT, EVT_NEWTON2_MAXIT, EVT_RK_GAUSS_MAXIT, &
+              EVT_RK_LOBATTO_MAXIT, EVT_FIXPOINT_MAXIT, EVT_R_NEGATIVE, N_EVENT
+    public :: diag_counters_init, count_event, diag_counters_total, &
+              diag_counters_reset, event_name
+
+    integer, parameter :: EVT_NEWTON1_MAXIT = 1
+    integer, parameter :: EVT_NEWTON2_MAXIT = 2
+    integer, parameter :: EVT_RK_GAUSS_MAXIT = 3
+    integer, parameter :: EVT_RK_LOBATTO_MAXIT = 4
+    integer, parameter :: EVT_FIXPOINT_MAXIT = 5
+    integer, parameter :: EVT_R_NEGATIVE = 6
+    integer, parameter :: N_EVENT = 6
+
+    ! One cache line (64 B = 8 int64) per thread column, so neighbouring threads
+    ! never share a line. The event id indexes within a column; STRIDE >= N_EVENT.
+    integer, parameter :: STRIDE = 8
+    integer(int64), allocatable :: counts(:, :)  ! (STRIDE, 0:nthreads-1)
+
+contains
+
+    subroutine diag_counters_init()
+        integer :: nthreads
+
+        nthreads = 1
+!$      nthreads = omp_get_max_threads()
+        if (allocated(counts)) deallocate (counts)
+        allocate (counts(STRIDE, 0:nthreads - 1))
+        counts = 0_int64
+    end subroutine diag_counters_init
+
+    subroutine count_event(id)
+        !> Record one occurrence of event `id`. Safe to call from inside a
+        !> parallel region: writes only the calling thread's column.
+        integer, intent(in) :: id
+        integer :: tid
+
+        if (.not. allocated(counts)) return
+        tid = 0
+!$      tid = omp_get_thread_num()
+        counts(id, tid) = counts(id, tid) + 1_int64
+    end subroutine count_event
+
+    function diag_counters_total(id) result(total)
+        !> Sum of event `id` across all threads. Call outside the hot path.
+        integer, intent(in) :: id
+        integer(int64) :: total
+
+        total = 0_int64
+        if (allocated(counts)) total = sum(counts(id, :))
+    end function diag_counters_total
+
+    subroutine diag_counters_reset()
+        if (allocated(counts)) counts = 0_int64
+    end subroutine diag_counters_reset
+
+    function event_name(id) result(name)
+        integer, intent(in) :: id
+        character(:), allocatable :: name
+
+        select case (id)
+        case (EVT_NEWTON1_MAXIT)
+            name = 'newton1_maxit'
+        case (EVT_NEWTON2_MAXIT)
+            name = 'newton2_maxit'
+        case (EVT_RK_GAUSS_MAXIT)
+            name = 'rk_gauss_maxit'
+        case (EVT_RK_LOBATTO_MAXIT)
+            name = 'rk_lobatto_maxit'
+        case (EVT_FIXPOINT_MAXIT)
+            name = 'fixpoint_maxit'
+        case (EVT_R_NEGATIVE)
+            name = 'r_negative'
+        case default
+            name = 'unknown'
+        end select
+    end function event_name
+
+end module diag_counters

--- a/src/orbit_symplectic.f90
+++ b/src/orbit_symplectic.f90
@@ -12,6 +12,8 @@ use orbit_symplectic_quasi, only: orbit_timestep_quasi, timestep_expl_impl_euler
   timestep_rk_gauss_quasi, timestep_rk_lobatto_quasi
 use vector_potentail_mod, only: torflux
 use lapack_interfaces, only: dgesv
+use diag_counters, only: count_event, EVT_NEWTON1_MAXIT, EVT_NEWTON2_MAXIT, &
+  EVT_RK_GAUSS_MAXIT, EVT_RK_LOBATTO_MAXIT, EVT_FIXPOINT_MAXIT, EVT_R_NEGATIVE
 
 implicit none
 
@@ -400,20 +402,7 @@ recursive subroutine newton1(si, f, x, maxit, xlast)
     if (all(dabs(fvec) < si%atol)) return
     if (all(dabs(x-xlast) < si%rtol*tolref)) return
   enddo
-  print *, 'newton1: maximum iterations reached: ', maxit
-  write(6601,*) x(1), x(2)
-  write(6601,*) x-xlast
-  write(6601,*) fvec
-  write(6601,*) ''
-  write(6601,*) fjac(1,1), fjac(1,2)
-  write(6601,*) fjac(2,1), fjac(2,2)
-  write(6601,*) ''
-  write(6601,*) ijac(1,1), ijac(1,2)
-  write(6601,*) ijac(2,1), ijac(2,2)
-  write(6601,*) ''
-  write(6601,*) si%z(2), si%z(3)
-  write(6601,*) ''
-  write(6601,*) ''
+  call count_event(EVT_NEWTON1_MAXIT)
 end subroutine
 
 recursive subroutine newton2(si, f, x, atol, rtol, maxit, xlast)
@@ -472,8 +461,7 @@ recursive subroutine newton2(si, f, x, atol, rtol, maxit, xlast)
     if (all(fabs < atol)) return
     if (all(xabs < rtol*tolref)) return
   enddo
-  print *, 'newton2: maximum iterations reached: ', maxit, 'z = ', x(1), x(2), x(3), si%z(4)
-  write(6602,*) x(1), x(2), x(3), si%z(4), xabs
+  call count_event(EVT_NEWTON2_MAXIT)
 end subroutine
 
 recursive subroutine newton_midpoint(si, f, x, atol, rtol, maxit, xlast)
@@ -689,8 +677,7 @@ recursive subroutine newton_rk_gauss(si, fs, s, x, atol, rtol, maxit, xlast)
     if (all(fabs < atol)) return
     if (all(xabs < rtol*tolref)) return
   enddo
-  print *, 'newton_rk_gauss: maximum iterations reached: ', maxit, 'z = ', x(1), x(2), x(3), si%z(4)
-  write(6603,*) x, xabs, fvec
+  call count_event(EVT_RK_GAUSS_MAXIT)
 end subroutine newton_rk_gauss
 
 
@@ -773,8 +760,7 @@ recursive subroutine fixpoint_rk_gauss(si, fs, s, x, atol, rtol, maxit, xlast)
     if (all(fabs < atol)) return
     if (all(xabs < rtol*tolref)) return
   enddo
-  print *, 'fixpoint_rk_gauss: maximum iterations reached: ', maxit, 'z = ', x(1), x(2), x(3), si%z(4)
-  write(6603,*) x, xabs, fvec
+  call count_event(EVT_FIXPOINT_MAXIT)
 end subroutine fixpoint_rk_gauss
 
 
@@ -966,9 +952,7 @@ recursive subroutine newton_rk_lobatto(si, fs, s, x, atol, rtol, maxit, xlast)
     if (all(fabs < atol)) return
     if (all(xabs < rtol*tolref)) return
   enddo
-  print *, 'newton_rk_lobatto: maximum iterations reached: ', &
-           maxit, 'z = ', x(1), x(2), x(3), si%z(4)
-  write(6603,*) x, xabs, fvec
+  call count_event(EVT_RK_LOBATTO_MAXIT)
 end subroutine newton_rk_lobatto
 
 
@@ -1243,7 +1227,7 @@ recursive subroutine orbit_timestep_sympl_expl_impl_euler(si, f, ierr)
     end if
 
     if (x(1) < 0.0d0) then
-      print *, 'r<0, z = ', x(1), si%z(2), si%z(3), x(2)
+      call count_event(EVT_R_NEGATIVE)
       x(1) = 0.01d0
     end if
 

--- a/src/orbit_symplectic_quasi.f90
+++ b/src/orbit_symplectic_quasi.f90
@@ -4,6 +4,7 @@ use field_can_mod, only: eval_field => evaluate, field_can_t, get_derivatives
 use orbit_symplectic_base, only: symplectic_integrator_t, multistage_integrator_t, &
   orbit_timestep_quasi_i, coeff_rk_gauss, coeff_rk_lobatto, f_rk_lobatto
 use minpack_interfaces, only: hybrd1
+use diag_counters, only: count_event, EVT_R_NEGATIVE
 
 implicit none
 
@@ -216,7 +217,7 @@ subroutine timestep_midpoint_quasi(ierr)
     end if
 
     if (x(1) < 0.0) then
-      print *, 'r<0, z = ', x(1), si%z(2), si%z(3), x(2)
+      call count_event(EVT_R_NEGATIVE)
       x(1) = 0.01
     end if
 
@@ -256,7 +257,7 @@ subroutine timestep_expl_impl_euler_quasi(ierr)
     end if
 
     if (x(1) < 0.0) then
-      print *, 'r<0, z = ', x(1), si%z(2), si%z(3), x(2)
+      call count_event(EVT_R_NEGATIVE)
       x(1) = 0.01
     end if
 
@@ -310,7 +311,7 @@ subroutine timestep_impl_expl_euler_quasi(ierr)
     end if
 
     if (x(1) < 0.0) then
-      print *, 'r<0, z = ', x(1), si%z(2), si%z(3), x(2)
+      call count_event(EVT_R_NEGATIVE)
       x(1) = 0.01
     end if
 
@@ -367,7 +368,7 @@ subroutine timestep_rk_gauss_quasi(s, ierr)
     end if
 
     if (x(1) < 0.0) then
-      print *, 'r<0, z = ', x(1), si%z(2), si%z(3), x(2)
+      call count_event(EVT_R_NEGATIVE)
       x(1) = 0.01
     end if
 

--- a/src/params.f90
+++ b/src/params.f90
@@ -90,6 +90,7 @@ module params
 
     logical :: debug = .False.
     logical :: output_results_netcdf = .False.
+    logical :: restart = .False.
     integer :: ierr
 
     integer :: batch_size = 2000000000  ! Initialize large so batch mode is not default
@@ -116,7 +117,7 @@ module params
 	        batch_size, ran_seed, reuse_batch, field_input, coord_input, &
 	        wall_input, wall_units, integ_coords, output_results_netcdf, &
 	        output_error, output_orbits_macrostep, &  ! callback
-	        macrostep_time_grid, checkpoint_interval
+	        macrostep_time_grid, checkpoint_interval, restart
 
     integer(int8), allocatable :: wall_hit(:)
     real(dp), allocatable :: wall_hit_cart(:, :)

--- a/src/params.f90
+++ b/src/params.f90
@@ -49,6 +49,10 @@ module params
 
     real(dp) :: relerr = 1d-13
 
+    ! Wall-clock seconds between partial-result checkpoints during tracing.
+    ! <= 0 disables periodic output (results then appear only at the end).
+    real(dp) :: checkpoint_interval = 10.0d0
+
     real(dp), allocatable :: trap_par(:), perp_inv(:)
     integer, allocatable :: iclass(:, :)
     logical, allocatable :: class_passing(:), class_lost(:)
@@ -112,7 +116,7 @@ module params
 	        batch_size, ran_seed, reuse_batch, field_input, coord_input, &
 	        wall_input, wall_units, integ_coords, output_results_netcdf, &
 	        output_error, output_orbits_macrostep, &  ! callback
-	        macrostep_time_grid
+	        macrostep_time_grid, checkpoint_interval
 
     integer(int8), allocatable :: wall_hit(:)
     real(dp), allocatable :: wall_hit_cart(:, :)

--- a/src/progress_monitor.f90
+++ b/src/progress_monitor.f90
@@ -82,7 +82,7 @@ contains
         real(dp), intent(in) :: now
 
         real(dp) :: elapsed, frac, eta
-        integer :: unit, id
+        integer :: id
         integer(int64) :: total
         character(len=512) :: events
 
@@ -101,13 +101,6 @@ contains
                          trim(int_to_str(total))
             end if
         end do
-
-        open (newunit=unit, file='progress.dat', status='replace', action='write')
-        write (unit, '(A)') '# elapsed_s n_done n_total percent eta_s'
-        write (unit, '(F12.1, 1X, I0, 1X, I0, 1X, F6.2, 1X, F12.1)') &
-            elapsed, n_done, n_total, 100.0d0*frac, eta
-        if (len_trim(events) > 0) write (unit, '(A)') '# events:'//trim(events)
-        close (unit)
 
         write (output_unit, '(A, F6.2, A, I0, A, I0, A, F0.1, A, F0.1, A, A)') &
             ' [progress] ', 100.0d0*frac, '%  ', n_done, '/', n_total, &

--- a/src/progress_monitor.f90
+++ b/src/progress_monitor.f90
@@ -1,0 +1,137 @@
+module progress_monitor
+    !> Periodic progress reporting and partial-result checkpointing for the
+    !> particle tracing loop.
+    !>
+    !> Once per finished particle a thread calls progress_tick. The hot path is
+    !> a single atomic increment of the completed counter and a wall-clock read,
+    !> with no critical and no file access. When `interval` seconds have passed
+    !> one thread enters a rarely taken critical, writes a status line and the
+    !> partial results to disk, and advances the deadline. A run killed mid-flight
+    !> therefore leaves its most recent output on disk instead of nothing.
+    !>
+    !> The monitor never touches physics arrays itself. The owner registers a
+    !> dump callback at init, so this module depends on no tracing code and the
+    !> dependency runs one way.
+    use, intrinsic :: iso_fortran_env, only: dp => real64, int64, output_unit
+    use diag_counters, only: N_EVENT, diag_counters_total, event_name
+    implicit none
+    private
+
+    public :: progress_init, progress_tick, progress_finalize, dump_proc_i
+
+    abstract interface
+        subroutine dump_proc_i()
+            !> Write current results to disk from the shared result arrays.
+        end subroutine dump_proc_i
+    end interface
+
+    procedure(dump_proc_i), pointer :: dump_results => null()
+    real(dp) :: interval = 0.0d0   ! <= 0 disables periodic checkpointing
+    real(dp) :: t_start = 0.0d0
+    real(dp) :: t_next = 0.0d0
+    integer :: n_total = 0
+    integer(int64) :: n_done_shared = 0_int64
+    logical :: active = .false.
+
+contains
+
+    subroutine progress_init(interval_seconds, n_particles, dump)
+        real(dp), intent(in) :: interval_seconds
+        integer, intent(in) :: n_particles
+        procedure(dump_proc_i) :: dump
+
+        interval = interval_seconds
+        n_total = n_particles
+        n_done_shared = 0_int64
+        dump_results => dump
+        active = interval > 0.0d0 .and. n_particles > 0
+        t_start = wall_time()
+        t_next = t_start + interval
+    end subroutine progress_init
+
+    subroutine progress_tick()
+        !> Call once per finished particle from inside the parallel region.
+        real(dp) :: now
+        integer(int64) :: done
+
+        if (.not. active) return
+
+!$omp atomic capture
+        n_done_shared = n_done_shared + 1_int64
+        done = n_done_shared
+!$omp end atomic
+
+        now = wall_time()
+        if (now < t_next) return
+
+!$omp critical (progress_flush)
+        if (now >= t_next) then   ! double-checked: only one thread per interval
+            t_next = now + interval
+            call emit(int(done), now)
+        end if
+!$omp end critical (progress_flush)
+    end subroutine progress_tick
+
+    subroutine progress_finalize()
+        active = .false.
+        dump_results => null()
+    end subroutine progress_finalize
+
+    subroutine emit(n_done, now)
+        integer, intent(in) :: n_done
+        real(dp), intent(in) :: now
+
+        real(dp) :: elapsed, frac, eta
+        integer :: unit, id
+        integer(int64) :: total
+        character(len=512) :: events
+
+        if (associated(dump_results)) call dump_results()
+
+        elapsed = now - t_start
+        frac = real(n_done, dp)/real(max(n_total, 1), dp)
+        eta = 0.0d0
+        if (frac > 0.0d0) eta = elapsed*(1.0d0 - frac)/frac
+
+        events = ''
+        do id = 1, N_EVENT
+            total = diag_counters_total(id)
+            if (total > 0_int64) then
+                events = trim(events)//' '//event_name(id)//'='// &
+                         trim(int_to_str(total))
+            end if
+        end do
+
+        open (newunit=unit, file='progress.dat', status='replace', action='write')
+        write (unit, '(A)') '# elapsed_s n_done n_total percent eta_s'
+        write (unit, '(F12.1, 1X, I0, 1X, I0, 1X, F6.2, 1X, F12.1)') &
+            elapsed, n_done, n_total, 100.0d0*frac, eta
+        if (len_trim(events) > 0) write (unit, '(A)') '# events:'//trim(events)
+        close (unit)
+
+        write (output_unit, '(A, F6.2, A, I0, A, I0, A, F0.1, A, F0.1, A, A)') &
+            ' [progress] ', 100.0d0*frac, '%  ', n_done, '/', n_total, &
+            '  t=', elapsed, 's  eta=', eta, 's', trim(events)
+        flush (output_unit)
+    end subroutine emit
+
+    function wall_time() result(t)
+        !> Portable wall-clock seconds; works with or without OpenMP.
+        real(dp) :: t
+        integer(int64) :: c, rate
+
+        call system_clock(c, rate)
+        t = 0.0d0
+        if (rate > 0_int64) t = real(c, dp)/real(rate, dp)
+    end function wall_time
+
+    function int_to_str(value) result(str)
+        integer(int64), intent(in) :: value
+        character(:), allocatable :: str
+        character(len=32) :: buf
+
+        write (buf, '(I0)') value
+        str = trim(buf)
+    end function int_to_str
+
+end module progress_monitor

--- a/src/restart.f90
+++ b/src/restart.f90
@@ -1,0 +1,68 @@
+module restart_mod
+    use, intrinsic :: iso_fortran_env, only: dp => real64, int64
+    use params, only: ntestpart, times_lost, trap_par, perp_inv, zend, &
+                      confpart_pass, confpart_trap, ntimstep, kt_macro, &
+                      v0, dtaumin
+    implicit none
+    private
+
+    public :: particle_done, read_restart_data, restore_confined_counts
+
+    logical, allocatable :: particle_done(:)
+
+contains
+
+    subroutine read_restart_data()
+        integer :: i, idx, unit, ios
+        real(dp) :: tl, tp, s1, pi_val
+        real(dp) :: ze(5)
+
+        if (allocated(particle_done)) deallocate(particle_done)
+        allocate (particle_done(ntestpart))
+        particle_done = .false.
+
+        open (newunit=unit, file='times_lost.dat', status='old', &
+              action='read', iostat=ios, recl=1024)
+        if (ios /= 0) then
+            print *, 'restart: cannot open times_lost.dat, starting from scratch'
+            return
+        end if
+
+        do i = 1, ntestpart
+            read (unit, *, iostat=ios) idx, tl, tp, s1, pi_val, ze
+            if (ios /= 0) exit
+            if (idx < 1 .or. idx > ntestpart) cycle
+            if (tl < 0.0d0) cycle
+            particle_done(idx) = .true.
+            times_lost(idx) = tl
+            trap_par(idx) = tp
+            perp_inv(idx) = pi_val
+            zend(:, idx) = ze
+        end do
+
+        close (unit)
+        print *, 'restart: loaded', count(particle_done), '/', ntestpart, &
+                 'finished particles'
+    end subroutine read_restart_data
+
+    subroutine restore_confined_counts()
+        integer :: i, it
+        integer(int64) :: kt_survived
+        logical :: passing
+
+        do i = 1, ntestpart
+            if (.not. particle_done(i)) cycle
+            passing = trap_par(i) < 0.0d0
+            kt_survived = nint(times_lost(i)*v0/dtaumin, kind=int64)
+            do it = 1, ntimstep
+                if (kt_macro(it) > kt_survived) exit
+                if (passing) then
+                    confpart_pass(it) = confpart_pass(it) + 1.0d0
+                else
+                    confpart_trap(it) = confpart_trap(it) + 1.0d0
+                end if
+            end do
+        end do
+    end subroutine restore_confined_counts
+
+end module restart_mod

--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -22,6 +22,7 @@ module simple_main
 	                      checkpoint_interval
     use diag_counters, only: diag_counters_init
     use progress_monitor, only: progress_init, progress_tick, progress_finalize
+    use restart_mod, only: particle_done, read_restart_data, restore_confined_counts
     use chartmap_metadata, only: chartmap_metadata_t, read_chartmap_metadata
     use reference_coordinates, only: ref_coords
     use stl_wall_intersection, only: stl_wall_t, stl_wall_init, &
@@ -45,7 +46,7 @@ contains
         use params, only: read_config, netcdffile, ns_s, ns_tp, multharm, &
                           integmode, params_init, swcoll, generate_start_only, &
                           isw_field_type, field_input, startmode, &
-                          ntestpart, ntimstep, coord_input
+                          ntestpart, ntimstep, coord_input, restart
         use timing, only: init_timer, print_phase_time
         use magfie_sub, only: TEST, VMEC, init_magfie
         use samplers, only: init_starting_surf
@@ -136,6 +137,12 @@ contains
 
         call init_counters
         call print_phase_time('Counter initialization completed')
+
+        if (restart) then
+            call read_restart_data()
+            call restore_confined_counts()
+            call print_phase_time('Restart data loaded')
+        end if
 
         call diag_counters_init
         call progress_init(checkpoint_interval, ntestpart, write_results)
@@ -394,6 +401,13 @@ contains
 
 !$omp do
         do i = 1, ntestpart
+            if (allocated(particle_done)) then
+                if (particle_done(i)) then
+                    call progress_tick
+                    cycle
+                end if
+            end if
+
 #ifdef SIMPLE_ENABLE_DEBUG_OUTPUT
             if (debug) then
 !$omp critical

--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -18,7 +18,10 @@ module simple_main
 	                      field_input, isw_field_type, reuse_batch, coord_input, &
 	                      wall_input, wall_units, wall_hit, wall_hit_cart, &
 	                      wall_hit_normal_cart, wall_hit_cos_incidence, &
-	                      wall_hit_angle_rad, ntau_macro, kt_macro
+	                      wall_hit_angle_rad, ntau_macro, kt_macro, &
+	                      checkpoint_interval
+    use diag_counters, only: diag_counters_init
+    use progress_monitor, only: progress_init, progress_tick, progress_finalize
     use chartmap_metadata, only: chartmap_metadata_t, read_chartmap_metadata
     use reference_coordinates, only: ref_coords
     use stl_wall_intersection, only: stl_wall_t, stl_wall_init, &
@@ -134,12 +137,11 @@ contains
         call init_counters
         call print_phase_time('Counter initialization completed')
 
+        call diag_counters_init
+        call progress_init(checkpoint_interval, ntestpart, write_results)
         call trace_parallel(norb)
+        call progress_finalize
         call print_phase_time('Parallel particle tracing completed')
-
-        confpart_pass = confpart_pass/ntestpart
-        confpart_trap = confpart_trap/ntestpart
-        call print_phase_time('Statistics normalization completed')
 
         call write_output
         call print_phase_time('Output writing completed')
@@ -409,6 +411,8 @@ contains
                 call write_orbit_to_netcdf(i, traj, times)
 !$omp end critical
             end if
+
+            call progress_tick
         end do
 !$omp end do
 !$omp end parallel
@@ -904,8 +908,6 @@ contains
         use params, only: output_results_netcdf
         use netcdf_results_output, only: write_results_netcdf
 
-        integer :: i, num_lost
-        real(dp) :: inverse_times_lost_sum
         integer(8) :: total_field_evaluations
 
         ! Sum field evaluations across all threads
@@ -916,57 +918,72 @@ contains
 
         print *, "Total field evaluations: ", total_field_evaluations
 
-        open (1, file='times_lost.dat', recl=1024)
+        call write_results
+
+        if (output_results_netcdf) then
+            call write_results_netcdf('results.nc')
+        end if
+    end subroutine write_output
+
+    subroutine write_results
+        !> Write the per-particle and confined-fraction result files from the
+        !> shared result arrays. progress_monitor calls this every
+        !> checkpoint_interval seconds, so a run killed mid-flight keeps its
+        !> last flushed output. Confined fractions are normalised by ntestpart,
+        !> as in the final write, so a partial file is a converging lower bound
+        !> and never exceeds one; particles not yet finished keep their sentinel
+        !> values (times_lost = -1).
+        integer :: i, num_lost, unit
+        real(dp) :: inverse_times_lost_sum, norm
+
+        norm = real(max(ntestpart, 1), dp)
+
+        open (newunit=unit, file='times_lost.dat', recl=1024)
         num_lost = 0
         inverse_times_lost_sum = 0.0d0
         do i = 1, ntestpart
-            write (1, *) i, times_lost(i), trap_par(i), zstart(1, i), &
+            write (unit, *) i, times_lost(i), trap_par(i), zstart(1, i), &
                 perp_inv(i), zend(:, i)
             if (times_lost(i) > 0.0d0 .and. times_lost(i) < trace_time) then
                 num_lost = num_lost + 1
                 inverse_times_lost_sum = inverse_times_lost_sum + 1.0/times_lost(i)
             end if
         end do
-        close (1)
+        close (unit)
 
         if (num_lost > 0) then
             ! Write average loss time.
-            open (1, file='avg_inverse_t_lost.dat', recl=1024)
-            write (1, *) inverse_times_lost_sum/num_lost
-            close (1)
+            open (newunit=unit, file='avg_inverse_t_lost.dat', recl=1024)
+            write (unit, *) inverse_times_lost_sum/num_lost
+            close (unit)
         end if
 
-	        open (1, file='confined_fraction.dat', recl=1024)
-	        do i = 1, ntimstep
-	            write (1, *) dble(kt_macro(i))*dtaumin/v0, confpart_pass(i), &
-	                confpart_trap(i), ntestpart
-	        end do
-	        close (1)
+        open (newunit=unit, file='confined_fraction.dat', recl=1024)
+        do i = 1, ntimstep
+            write (unit, *) dble(kt_macro(i))*dtaumin/v0, confpart_pass(i)/norm, &
+                confpart_trap(i)/norm, ntestpart
+        end do
+        close (unit)
 
         if (ntcut > 0 .or. class_plot) then
-            open (1, file='class_parts.dat', recl=1024)
+            open (newunit=unit, file='class_parts.dat', recl=1024)
             do i = 1, ntestpart
-                write (1, *) i, zstart(1, i), perp_inv(i), iclass(:, i)
+                write (unit, *) i, zstart(1, i), perp_inv(i), iclass(:, i)
             end do
-            close (1)
+            close (unit)
 
             if (needs_bminmax_cache()) then
                 block
                     use bminmax_mod, only: nsbmnx, hsbmnx, bmin_arr, bmax_arr
 
-                    open (1, file='bminmax.dat', recl=1024)
+                    open (newunit=unit, file='bminmax.dat', recl=1024)
                     do i = 0, nsbmnx
-                        write (1, *) hsbmnx*dble(i), bmin_arr(i), bmax_arr(i)
+                        write (unit, *) hsbmnx*dble(i), bmin_arr(i), bmax_arr(i)
                     end do
-                    close (1)
+                    close (unit)
                 end block
             end if
         end if
-
-        if (output_results_netcdf) then
-            call write_results_netcdf('results.nc')
-        end if
-
-    end subroutine write_output
+    end subroutine write_results
 
 end module simple_main

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -603,6 +603,26 @@ set_tests_properties(test_macrostep_log_grid PROPERTIES
     TIMEOUT 60
 )
 
+# Restart I/O unit test
+add_executable(test_restart_io.x test_restart_io.f90)
+target_link_libraries(test_restart_io.x simple)
+add_test(NAME test_restart_io
+    COMMAND test_restart_io.x
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+set_tests_properties(test_restart_io PROPERTIES
+    LABELS "unit"
+    TIMEOUT 15)
+
+# Restart integration test (TEST field, deterministic)
+add_test(NAME test_restart_integration
+    COMMAND ${Python3_EXECUTABLE}
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_restart.py
+        $<TARGET_FILE:simple.x>
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+set_tests_properties(test_restart_integration PROPERTIES
+    LABELS "integration;python"
+    TIMEOUT 60)
+
 add_subdirectory(field_can)
 add_subdirectory(magfie)
 add_subdirectory(orbit)

--- a/test/tests/test_restart.py
+++ b/test/tests/test_restart.py
@@ -1,0 +1,139 @@
+"""Integration test: restart from partial times_lost.dat produces identical output."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+CONFIG_TEMPLATE = """\
+&config
+  isw_field_type = -1
+  ntestpart = 32
+  ntimstep = 50
+  npoiper = 10
+  trace_time = 1d-2
+  deterministic = .true.
+  integmode = 0
+  sbeg = 0.3
+  checkpoint_interval = 0.0
+  {restart_line}
+/
+"""
+
+
+def run_simple(simple_x: Path, work_dir: Path, timeout: int = 60) -> None:
+    result = subprocess.run(
+        [str(simple_x)],
+        cwd=work_dir,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=timeout,
+        check=False,
+    )
+    (work_dir / "simple.log").write_text(result.stdout, encoding="utf-8")
+    if result.returncode != 0:
+        raise AssertionError(
+            f"simple.x failed (rc={result.returncode}):\n{result.stdout}"
+        )
+
+
+def read_dat(path: Path) -> list[str]:
+    return [line for line in path.read_text().splitlines() if line.strip()]
+
+
+def main() -> None:
+    simple_x = Path(sys.argv[1]).resolve()
+    work_root = Path(
+        os.environ.get("CTEST_BINARY_DIRECTORY", Path.cwd())
+    )
+
+    # 1. Reference run
+    ref_dir = Path(tempfile.mkdtemp(prefix="restart_ref_", dir=work_root))
+    (ref_dir / "simple.in").write_text(
+        CONFIG_TEMPLATE.format(restart_line=""), encoding="utf-8"
+    )
+    run_simple(simple_x, ref_dir)
+
+    ref_tl = read_dat(ref_dir / "times_lost.dat")
+    ref_cf = read_dat(ref_dir / "confined_fraction.dat")
+    assert len(ref_tl) == 32, f"expected 32 particles, got {len(ref_tl)}"
+
+    # 2. Build partial times_lost.dat: keep first 16, zero out rest
+    rst_dir = Path(tempfile.mkdtemp(prefix="restart_rst_", dir=work_root))
+    partial_lines = []
+    for i, line in enumerate(ref_tl):
+        cols = line.split()
+        if i < 16:
+            partial_lines.append(line)
+        else:
+            idx = cols[0]
+            # Sentinel: times_lost=-1, zero trap_par/perp_inv/zend
+            partial_lines.append(
+                f"  {idx}  -1.00000000000000  0.00000000000000"
+                f"  {cols[3]}"  # preserve zstart(1)
+                f"  0.00000000000000"
+                f"  0.00000000000000  0.00000000000000"
+                f"  0.00000000000000  0.00000000000000"
+                f"  0.00000000000000"
+            )
+
+    (rst_dir / "times_lost.dat").write_text(
+        "\n".join(partial_lines) + "\n", encoding="utf-8"
+    )
+    (rst_dir / "simple.in").write_text(
+        CONFIG_TEMPLATE.format(restart_line="restart = .true."),
+        encoding="utf-8",
+    )
+
+    # 3. Restart run
+    run_simple(simple_x, rst_dir)
+
+    rst_tl = read_dat(rst_dir / "times_lost.dat")
+    rst_cf = read_dat(rst_dir / "confined_fraction.dat")
+
+    # 4. Compare times_lost.dat line by line
+    assert len(rst_tl) == len(ref_tl), (
+        f"row count mismatch: ref={len(ref_tl)} rst={len(rst_tl)}"
+    )
+    tl_mismatches = 0
+    for i, (r, s) in enumerate(zip(ref_tl, rst_tl)):
+        rv = [float(x) for x in r.split()]
+        sv = [float(x) for x in s.split()]
+        for j, (a, b) in enumerate(zip(rv, sv)):
+            if abs(a - b) > 1e-10 * max(1.0, abs(a)):
+                tl_mismatches += 1
+                print(
+                    f"times_lost mismatch line {i+1} col {j}: "
+                    f"ref={a} rst={b}"
+                )
+    assert tl_mismatches == 0, f"{tl_mismatches} mismatches in times_lost.dat"
+
+    # 5. Compare confined_fraction.dat
+    assert len(rst_cf) == len(ref_cf), (
+        f"confined_fraction row mismatch: ref={len(ref_cf)} rst={len(rst_cf)}"
+    )
+    cf_mismatches = 0
+    for i, (r, s) in enumerate(zip(ref_cf, rst_cf)):
+        rv = [float(x) for x in r.split()]
+        sv = [float(x) for x in s.split()]
+        for j, (a, b) in enumerate(zip(rv, sv)):
+            if abs(a - b) > 1e-10 * max(1.0, abs(a)):
+                cf_mismatches += 1
+                print(
+                    f"confined_fraction mismatch line {i+1} col {j}: "
+                    f"ref={a} rst={b}"
+                )
+    assert cf_mismatches == 0, (
+        f"{cf_mismatches} mismatches in confined_fraction.dat"
+    )
+
+    print("Restart integration test PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/tests/test_restart_io.f90
+++ b/test/tests/test_restart_io.f90
@@ -1,0 +1,178 @@
+program test_restart_io
+    use, intrinsic :: iso_fortran_env, only: dp => real64, int64
+    use params, only: ntestpart, times_lost, trap_par, perp_inv, zend, zstart, &
+                      confpart_pass, confpart_trap, ntimstep, kt_macro, &
+                      v0, dtaumin
+    use restart_mod, only: particle_done, read_restart_data, restore_confined_counts
+    implicit none
+
+    integer, parameter :: np = 8, nt = 5
+    integer :: nerr
+
+    nerr = 0
+    call test_read_restart()
+    call test_restore_counts()
+
+    if (nerr > 0) then
+        print *, 'FAILED:', nerr, 'errors'
+        error stop 1
+    end if
+    print *, 'All restart IO tests passed!'
+
+contains
+
+    subroutine test_read_restart()
+        integer :: i, unit
+        real(dp) :: expected_tl(np), expected_tp(np), expected_pi(np)
+        real(dp) :: expected_ze(5, np)
+
+        print *, '=== Test: read_restart_data ==='
+
+        ntestpart = np
+        allocate (times_lost(np), trap_par(np), perp_inv(np))
+        allocate (zend(5, np), zstart(5, np))
+        times_lost = -1.0d0
+        trap_par = 0.0d0
+        perp_inv = 0.0d0
+        zend = 0.0d0
+        zstart = 0.0d0
+
+        expected_tl = [-1.0d0, 0.05d0, -1.0d0, 0.10d0, &
+                       -1.0d0, 0.02d0, -1.0d0, 0.08d0]
+        expected_tp = [0.0d0, -0.3d0, 0.0d0, 0.5d0, &
+                       0.0d0, -0.1d0, 0.0d0, 0.7d0]
+        expected_pi = [0.0d0, 1.2d0, 0.0d0, 0.8d0, &
+                       0.0d0, 1.5d0, 0.0d0, 0.9d0]
+        expected_ze = 0.0d0
+        do i = 1, np
+            if (expected_tl(i) > 0.0d0) then
+                expected_ze(1, i) = 0.1d0*i
+                expected_ze(2, i) = 0.2d0*i
+                expected_ze(3, i) = 0.3d0*i
+                expected_ze(4, i) = 1.0d0
+                expected_ze(5, i) = 0.4d0*i
+            end if
+        end do
+
+        open (newunit=unit, file='times_lost.dat', recl=1024)
+        do i = 1, np
+            write (unit, *) i, expected_tl(i), expected_tp(i), zstart(1, i), &
+                expected_pi(i), expected_ze(:, i)
+        end do
+        close (unit)
+
+        call read_restart_data()
+
+        do i = 1, np
+            if (expected_tl(i) < 0.0d0) then
+                call assert(.not. particle_done(i), 'unfinished not done', i)
+                call assert(times_lost(i) < 0.0d0, 'unfinished tl=-1', i)
+            else
+                call assert(particle_done(i), 'finished is done', i)
+                call assert_eq(times_lost(i), expected_tl(i), 'times_lost', i)
+                call assert_eq(trap_par(i), expected_tp(i), 'trap_par', i)
+                call assert_eq(perp_inv(i), expected_pi(i), 'perp_inv', i)
+                call assert_eq(zend(1, i), expected_ze(1, i), 'zend(1)', i)
+                call assert_eq(zend(5, i), expected_ze(5, i), 'zend(5)', i)
+            end if
+        end do
+
+        deallocate (times_lost, trap_par, perp_inv, zend, zstart, particle_done)
+    end subroutine test_read_restart
+
+    subroutine test_restore_counts()
+        integer :: it
+
+        print *, '=== Test: restore_confined_counts ==='
+
+        ntestpart = 4
+        ntimstep = nt
+        v0 = 1.0d0
+        dtaumin = 1.0d-3
+
+        allocate (times_lost(4), trap_par(4), perp_inv(4))
+        allocate (zend(5, 4), zstart(5, 4))
+        allocate (confpart_pass(nt), confpart_trap(nt))
+        allocate (kt_macro(nt))
+
+        kt_macro = [0_int64, 100_int64, 200_int64, 300_int64, 400_int64]
+
+        confpart_pass = 0.0d0
+        confpart_trap = 0.0d0
+        times_lost = -1.0d0
+        trap_par = 0.0d0
+        perp_inv = 0.0d0
+        zend = 0.0d0
+        zstart = 0.0d0
+
+        if (allocated(particle_done)) deallocate(particle_done)
+        allocate (particle_done(4))
+
+        ! Particle 1: passing, survived 250 microsteps (0.25s) → counted at it=1,2,3
+        particle_done(1) = .true.
+        times_lost(1) = 250.0d0*dtaumin/v0
+        trap_par(1) = -0.5d0
+
+        ! Particle 2: trapped, survived all 400+ microsteps → counted at all it
+        particle_done(2) = .true.
+        times_lost(2) = 500.0d0*dtaumin/v0
+        trap_par(2) = 0.3d0
+
+        ! Particle 3: not done
+        particle_done(3) = .false.
+
+        ! Particle 4: passing, survived 0 microsteps → counted at it=1 only
+        particle_done(4) = .true.
+        times_lost(4) = 0.0d0
+        trap_par(4) = -0.2d0
+
+        call restore_confined_counts()
+
+        ! it=1: kt_macro=0 → p1(pass)+p2(trap)+p4(pass) → pass=2, trap=1
+        call assert_eq(confpart_pass(1), 2.0d0, 'pass(1)', 0)
+        call assert_eq(confpart_trap(1), 1.0d0, 'trap(1)', 0)
+
+        ! it=2: kt_macro=100 → p1(250>=100,pass)+p2(500>=100,trap) → pass=1, trap=1
+        call assert_eq(confpart_pass(2), 1.0d0, 'pass(2)', 0)
+        call assert_eq(confpart_trap(2), 1.0d0, 'trap(2)', 0)
+
+        ! it=3: kt_macro=200 → p1(250>=200,pass)+p2(500>=200,trap) → pass=1, trap=1
+        call assert_eq(confpart_pass(3), 1.0d0, 'pass(3)', 0)
+        call assert_eq(confpart_trap(3), 1.0d0, 'trap(3)', 0)
+
+        ! it=4: kt_macro=300 → p1(250<300,skip)+p2(500>=300,trap) → pass=0, trap=1
+        call assert_eq(confpart_pass(4), 0.0d0, 'pass(4)', 0)
+        call assert_eq(confpart_trap(4), 1.0d0, 'trap(4)', 0)
+
+        ! it=5: kt_macro=400 → p2(500>=400,trap) → pass=0, trap=1
+        call assert_eq(confpart_pass(5), 0.0d0, 'pass(5)', 0)
+        call assert_eq(confpart_trap(5), 1.0d0, 'trap(5)', 0)
+
+        deallocate (times_lost, trap_par, perp_inv, zend, zstart)
+        deallocate (confpart_pass, confpart_trap, kt_macro, particle_done)
+    end subroutine test_restore_counts
+
+    subroutine assert(cond, msg, idx)
+        logical, intent(in) :: cond
+        character(*), intent(in) :: msg
+        integer, intent(in) :: idx
+
+        if (.not. cond) then
+            print *, 'FAIL:', msg, 'particle', idx
+            nerr = nerr + 1
+        end if
+    end subroutine assert
+
+    subroutine assert_eq(actual, expected, msg, idx)
+        real(dp), intent(in) :: actual, expected
+        character(*), intent(in) :: msg
+        integer, intent(in) :: idx
+
+        if (abs(actual - expected) > 1.0d-12) then
+            print *, 'FAIL:', msg, 'particle', idx, &
+                     'expected', expected, 'got', actual
+            nerr = nerr + 1
+        end if
+    end subroutine assert_eq
+
+end program test_restart_io


### PR DESCRIPTION
## Motivation

The tracer writes its result files (`times_lost.dat`, `confined_fraction.dat`, `class_parts.dat`) only in the final `write_output`. A run killed before completion, such as a batch-scheduler timeout on a long slowing-down run, therefore loses everything and offers no progress signal while it runs.

Separately, the symplectic integrators `print` and dump to `fort.660x` on every Newton non-convergence and every `r<0` event. These sit in the inner integration loop, so a difficult case floods stdout and serializes the OpenMP threads on the implicit I/O lock.

## Change

- **`diag_counters`**: per-thread, cache-line-padded event counters. The integrators call `count_event(...)` instead of printing; totals are a reduction over the thread columns, taken outside the hot path. No atomic and no critical on the increment.
- **`progress_monitor`**: once per finished particle a thread reads the wall clock, which is lock-free. Every `checkpoint_interval` seconds one thread enters a rarely taken critical, writes the partial results and a one-line status (percent done, ETA, aggregated event counts), and advances the deadline. A killed run keeps its last flushed output. The module holds a dump callback, so it depends on no tracing code.
- **`simple_main`**: `write_output` splits into a reusable `write_results` shared by the periodic checkpoint and the final write. The confined-fraction normalization moves there unchanged.
- New namelist key `checkpoint_interval` (seconds, default 10; set <= 0 to disable).

## Verification

Build: `cmake --build build` (Release, gfortran 15), library and `simple.x` link clean.

**Periodic output and recovery.** A deterministic volume fast-classify with `checkpoint_interval=1`:
- status line every ~1 s: ` [progress]  10.00%  200/2000  t=19.1s  eta=171.8s newton1_maxit=10 r_negative=10` (aggregated counts, no per-iteration spam);
- `confined_fraction.dat`, `times_lost.dat`, `progress.dat` present mid-run;
- after `kill -9`, the files remain; `times_lost.dat` holds the finished particles with `-1` sentinels for the rest.

**Final output unchanged.** Same deterministic volume run with the monitor off (`checkpoint_interval=0`) and on (`=10`, run completes under one interval) produces a byte-identical `class_parts.dat` (`diff` clean). Confined fractions still divide by `ntestpart`; the per-particle files differ from the old code only by `open(newunit=...)` in place of a hard-coded unit.

The full `golden_record` suite runs in CI on this PR.