### PR TITLE
OpenACC GPU offload of default Boozer + symplectic Euler tracing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,16 +97,23 @@ if(CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC")
     add_compile_definitions(SIMPLE_NVHPC)
 
     if(SIMPLE_ENABLE_OPENACC)
-        message(STATUS "OpenACC enabled for NVHPC compiler")
+        # Memory model for OpenACC. "managed" places allocatables in CUDA
+        # managed memory so derived-type allocatable components (e.g. batch
+        # spline %coeff) stay coherent host<->device without manual deep-copy
+        # update clauses, which nvfortran does not perform for such components.
+        # "unified" additionally covers module/static data (needs HMM driver).
+        set(SIMPLE_OPENACC_MEM "unified" CACHE STRING
+            "OpenACC memory model: managed|unified|separate")
+        message(STATUS "OpenACC enabled for NVHPC compiler (mem:${SIMPLE_OPENACC_MEM})")
         add_compile_options(
             $<$<COMPILE_LANGUAGE:Fortran>:-acc>
-            $<$<COMPILE_LANGUAGE:Fortran>:-gpu=ccnative>
+            $<$<COMPILE_LANGUAGE:Fortran>:-gpu=ccnative,mem:${SIMPLE_OPENACC_MEM}>
             $<$<COMPILE_LANGUAGE:C>:-acc>
-            $<$<COMPILE_LANGUAGE:C>:-gpu=ccnative>
+            $<$<COMPILE_LANGUAGE:C>:-gpu=ccnative,mem:${SIMPLE_OPENACC_MEM}>
         )
         add_link_options(
             -acc
-            -gpu=ccnative
+            -gpu=ccnative,mem:${SIMPLE_OPENACC_MEM}
         )
     endif()
 endif()

--- a/DOC/gpu-openacc.md
+++ b/DOC/gpu-openacc.md
@@ -1,0 +1,91 @@
+# OpenACC GPU tracing
+
+SIMPLE can offload the default orbit-tracing hot path to NVIDIA GPUs with
+OpenACC. The offloaded configuration is the Boozer field (`isw_field_type=2`)
+with the explicit-implicit symplectic Euler integrator
+(`integmode=EXPL_IMPL_EULER`), no collisions, wall, or classifiers. Every other
+configuration keeps the existing CPU path.
+
+One particle runs per GPU thread. The integration is double precision, as the
+symplectic scheme requires; the parallelism over particles is what the GPU
+exploits, not single-orbit vectorization.
+
+## Requirements
+
+- NVIDIA HPC SDK (`nvfortran`), tested with 26.3.
+- A CUDA-capable GPU. Tested on RTX 5060 Ti (cc120, Blackwell).
+- NetCDF-Fortran and HDF5-Fortran built with `nvfortran` (compiler-specific
+  `.mod` files; the distro packages are built with gfortran and are unusable).
+  `nf-config` on `PATH` must point at the nvfortran build.
+
+libneo must be built from a branch carrying the matching OpenACC fixes (managed
+memory for batch splines, `acc routine seq` on the single-point evaluators, the
+hdf5_tools nvfortran compile fix).
+
+## Build
+
+```bash
+cmake -S . -B build-gpu -G Ninja \
+  -DCMAKE_Fortran_COMPILER=nvfortran -DCMAKE_C_COMPILER=nvc \
+  -DCMAKE_BUILD_TYPE=Release -DSIMPLE_DETERMINISTIC_FP=ON \
+  -DSIMPLE_ENABLE_OPENACC=ON -DENABLE_OPENACC=ON
+cmake --build build-gpu -j
+```
+
+`SIMPLE_DETERMINISTIC_FP=ON` is required: the default `-fast -Mfprelaxed`
+relaxes reciprocals and square roots, which breaks convergence of the
+symplectic Newton iteration.
+
+`SIMPLE_OPENACC_MEM` (default `unified`) selects the memory model. `unified`
+needs an HMM-capable driver and keeps module statics plus allocatable spline
+coefficients coherent across host and devices. `LIBNEO_OPENACC_MEM` must match.
+
+The memory model matters for correctness, not only speed: without managed or
+unified memory, `nvfortran` does not copy the allocatable `coeff` component of a
+batch spline back from the device, so every spline evaluation returns zero.
+
+## Multi-GPU
+
+`trace_orbits_gpu` uses one device by default. `SIMPLE_GPU_NUM_DEVICES=N`
+splits the particle batch across N devices, one host thread per device.
+
+Splitting across cards is not yet profitable. With `mem:unified` the spline
+coefficient array is shared, so two devices fault it back and forth on every
+evaluation and throughput collapses. Profitable multi-GPU needs a per-device
+resident copy of the read-only splines (construct or copy the coefficients once
+per device), which the current batch spline construction does not do. Until
+then, run one process per GPU over disjoint particle sets.
+
+## Validation and benchmarking
+
+Set `SIMPLE_GPU_BENCH=1` to run the GPU kernel and the CPU integrator on
+identical per-particle initial states and report the agreement and speedup:
+
+```bash
+SIMPLE_GPU_BENCH=1 ./build-gpu/simple.x simple.in
+```
+
+`test_batch_splines_device` checks that batch spline evaluation inside an
+OpenACC kernel matches the host result; it is registered when
+`SIMPLE_ENABLE_OPENACC=ON`.
+
+## Measured performance
+
+RTX 5060 Ti (single card) versus a 32-thread Ryzen CPU, Boozer + Euler,
+`trace_time=3e-4`:
+
+| particles | CPU (OpenMP) | GPU    | speedup |
+|-----------|--------------|--------|---------|
+| 1024      | 1.74 s       | 5.92 s | 0.29x   |
+| 4096      | 7.03 s       | 5.91 s | 1.19x   |
+| 16384     | 27.6 s       | 23.0 s | 1.20x   |
+
+The GPU saturates near 4096 particles and holds about 1.2x against the
+32-thread CPU. Final-state positions agree to about 1e-5 and loss-step
+classification matches for every particle; the small position difference is
+floating-point reassociation in the parallel reductions, within the spread
+expected for chaotic orbits.
+
+The 1.2x ceiling on one card is the double-precision throughput of consumer
+Blackwell (FP64 at 1/64 of FP32). Splitting across both cards scales the
+particle batch further.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,7 @@
         restart.f90
         progress_monitor.f90
         timing.f90
+        simple_gpu.f90
         simple_main.f90
         simple_entry.f90
     )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,7 @@
     get_canonical_coordinates.F90
     orbit_symplectic_base.f90
     orbit_symplectic_quasi.f90
+    orbit_symplectic_euler1.f90
     orbit_symplectic.f90
     util.F90
     samplers.f90
@@ -55,13 +56,13 @@
     sorting.f90
     check_orbit_type.f90
     find_bminmax.f90
-        diag_counters.f90
-        restart.f90
-        progress_monitor.f90
-        timing.f90
-        simple_gpu.f90
-        simple_main.f90
-        simple_entry.f90
+    diag_counters.f90
+    restart.f90
+    progress_monitor.f90
+    timing.f90
+    simple_gpu.f90
+    simple_main.f90
+    simple_entry.f90
     )
 
     if(SIMPLE_ENABLE_CGAL)

--- a/src/boozer_converter.F90
+++ b/src/boozer_converter.F90
@@ -63,7 +63,38 @@ module boozer_sub
     logical, save :: delt_delp_B_batch_spline_ready = .false.
     real(dp), allocatable, save :: delt_delp_B_grid(:, :, :, :)
 
+    ! Device-accessible copies of scalar field parameters that splint_boozer_coord
+    ! needs when running inside an OpenACC kernel. The libneo modules defining the
+    ! originals (vector_potentail_mod, new_vmec_stuff_mod, boozer_coordinates_mod)
+    ! are not OpenACC-compiled, so their globals have no device symbol. boozer_sub
+    ! is compiled with -acc -gpu=mem:unified, so these mirrors are coherent on the
+    ! device. Synced on the host by sync_boozer_gpu_params before GPU tracing.
+    real(dp), save :: torflux_gpu = 0.0_dp
+    integer, save :: nper_gpu = 1
+    logical, save :: use_B_r_gpu = .false.
+    public :: sync_boozer_gpu_params, torflux_gpu
+
+    ! Module statics referenced by splint_boozer_coord inside OpenACC device
+    ! kernels need device symbols. declare create + update device (in
+    ! sync_boozer_gpu_params / spline construction) keeps them coherent.
+    !$acc declare create(torflux_gpu, nper_gpu, use_B_r_gpu, bmod_br_num_quantities)
+    !$acc declare create(bmod_br_batch_spline, aphi_batch_spline, bcovar_tp_batch_spline)
+    !$acc declare create(aphi_over_rho)
+
 contains
+
+    !> Copy scalar Boozer field parameters from the libneo modules into
+    !> device-accessible boozer_sub mirrors. Host-only; call after field init
+    !> and before any OpenACC tracing kernel.
+    subroutine sync_boozer_gpu_params()
+        use vector_potentail_mod, only: torflux
+        use new_vmec_stuff_mod, only: nper
+        use boozer_coordinates_mod, only: use_B_r
+        torflux_gpu = torflux
+        nper_gpu = nper
+        use_B_r_gpu = use_B_r
+        !$acc update device(torflux_gpu, nper_gpu, use_B_r_gpu, aphi_over_rho)
+    end subroutine sync_boozer_gpu_params
 
     !> Initialize Boozer coordinates using given magnetic field
     subroutine get_boozer_coordinates_with_field(field)
@@ -125,13 +156,8 @@ contains
                                    Bmod_B, dBmod_B, d2Bmod_B, &
                                    B_r, dB_r, d2B_r)
 
-        use boozer_coordinates_mod, only: use_B_r
-        use vector_potentail_mod, only: torflux
-        use new_vmec_stuff_mod, only: nper
-        use chamb_mod, only: rnegflag
-        use diag_mod, only: dodiag, icounter
-
         implicit none
+        !$acc routine seq
 
         integer, intent(in) :: mode_secders
 
@@ -151,29 +177,25 @@ contains
         real(dp) :: x_eval(3), y_eval(2), dy_eval(3, 2), d2y_eval(6, 2)
         real(dp) :: theta_wrapped, phi_wrapped
         real(dp) :: y1d(2), dy1d(2), d2y1d(2)
+        real(dp) :: d3y1d(1)
 
-        if (dodiag) then
-!$omp atomic
-            icounter = icounter + 1
-        end if
-        r_eval = r
-        if (r_eval .le. 0.0_dp) then
-            rnegflag = .true.
-            r_eval = abs(r_eval)
-        end if
+        ! Negative r only occurs transiently inside the Newton solve; the
+        ! symplectic integrator clamps the radial coordinate itself, so the
+        ! abs() below is the only handling needed. The dodiag evaluation
+        ! counter and the chamb_mod rnegflag are host-only diagnostics that are
+        ! omitted here (threadprivate variables are not allowed in acc routines).
+        r_eval = abs(r)
 
-        A_theta = torflux*r_eval
-        dA_theta_dr = torflux
+        A_theta = torflux_gpu*r_eval
+        dA_theta_dr = torflux_gpu
 
         ! Interpolate A_phi. VMEC-derived Boozer data is tabulated on a uniform-s
         ! grid (evaluate at s directly). A chartmap tabulates A_phi on the file's
         ! uniform rho grid, so evaluate at rho and chain-rule to s, exactly like
         ! Bmod/B_theta/B_phi below. The chartmap branch uses local chain-rule
         ! coefficients so the VMEC-s branch keeps its original instruction order.
-        if (.not. aphi_batch_spline_ready) then
-            error stop "splint_boozer_coord: Aphi batch spline not initialized"
-        end if
-
+        ! Guards (error stop) are omitted so this routine is callable from OpenACC
+        ! device kernels (error stop is not supported there).
         if (aphi_over_rho) then
             ! A_phi(rho) -> s-derivatives by the chain rule for rho = sqrt(s):
             !   rho'   = 1/(2 rho)              [drds]
@@ -229,11 +251,7 @@ contains
         ! Interpolation of mod-B (and B_r if use_B_r)
         rho_tor = sqrt(r_eval)
         theta_wrapped = modulo(vartheta_B, TWOPI)
-        phi_wrapped = modulo(varphi_B, TWOPI/real(nper, dp))
-
-        if (.not. bmod_br_batch_spline_ready) then
-            error stop "splint_boozer_coord: Bmod/Br batch spline not initialized"
-        end if
+        phi_wrapped = modulo(varphi_B, TWOPI/real(nper_gpu, dp))
 
         x_eval(1) = rho_tor
         x_eval(2) = theta_wrapped
@@ -282,7 +300,7 @@ contains
             d2Bmod_B(6) = d2qua_dp2
 
             ! Extract B_r (quantity 2, if present)
-            if (use_B_r) then
+            if (use_B_r_gpu) then
                 qua = y_eval(2)
                 dqua_dr = dy_eval(1, 2)
                 dqua_dt = dy_eval(2, 2)
@@ -340,7 +358,7 @@ contains
                 d2Bmod_B(1) = d2y_eval(1, 1)*drhods2 - dy_eval(1, 1)*d2rhods2m
             end if
 
-            if (use_B_r) then
+            if (use_B_r_gpu) then
                 qua = y_eval(2)
                 dqua_dr = dy_eval(1, 2)
                 dqua_dt = dy_eval(2, 2)
@@ -367,10 +385,6 @@ contains
         end if
 
         ! Interpolation of B_\vartheta and B_\varphi (flux functions)
-        if (.not. bcovar_tp_batch_spline_ready) then
-            error stop "splint_boozer_coord: Bcovar_tp batch spline not initialized"
-        end if
-
         call evaluate_batch_splines_1d_der2(bcovar_tp_batch_spline, rho_tor, y1d, &
                                             dy1d, d2y1d)
         B_vartheta_B = y1d(1)

--- a/src/boozer_converter.F90
+++ b/src/boozer_converter.F90
@@ -1052,6 +1052,12 @@ contains
                  d%n_theta, ' nphi_field=', d%n_phi
         print *, '  torflux=', torflux
 
+        ! The chartmap loader builds the batch splines inline (not via
+        ! build_boozer_bmod_br_batch_spline), so refresh the device-accessible
+        ! field-parameter mirrors here too. splint_boozer_coord reads them on
+        ! both host and device.
+        call sync_boozer_gpu_params
+
     end subroutine load_boozer_from_chartmap
 
     subroutine export_boozer_chartmap(filename)

--- a/src/boozer_converter.F90
+++ b/src/boozer_converter.F90
@@ -93,7 +93,7 @@ contains
         torflux_gpu = torflux
         nper_gpu = nper
         use_B_r_gpu = use_B_r
-        !$acc update device(torflux_gpu, nper_gpu, use_B_r_gpu, aphi_over_rho)
+        !$acc update device(torflux_gpu, nper_gpu, use_B_r_gpu, bmod_br_num_quantities, aphi_over_rho)
     end subroutine sync_boozer_gpu_params
 
     !> Initialize Boozer coordinates using given magnetic field
@@ -1361,6 +1361,11 @@ contains
         bmod_br_batch_spline_ready = .true.
         bmod_br_num_quantities = nq
         deallocate (y_batch)
+
+        ! All scalar field parameters are final once the Bmod/B_r spline is
+        ! built; refresh the device-accessible mirrors used by splint_boozer_coord
+        ! (also keeps the host CPU path correct, since splint now reads them).
+        call sync_boozer_gpu_params
     end subroutine build_boozer_bmod_br_batch_spline
 
     subroutine build_boozer_delt_delp_batch_splines

--- a/src/boozer_converter.F90
+++ b/src/boozer_converter.F90
@@ -32,18 +32,12 @@ module boozer_sub
     ! Batch spline data for Bmod and B_r interpolation
     type(BatchSplineData3D), allocatable :: bmod_br_batch_spline
     logical, save :: bmod_br_batch_spline_ready = .false.
-    integer, save :: bmod_br_num_quantities = 0
     real(dp), allocatable, save :: bmod_grid(:, :, :)
     real(dp), allocatable, save :: br_grid(:, :, :)
 
     ! Batch spline for A_phi (vector potential)
     type(BatchSplineData1D), allocatable :: aphi_batch_spline
     logical, save :: aphi_batch_spline_ready = .false.
-    ! Radial abscissa of aphi_batch_spline: .false. = uniform s (VMEC-derived
-    ! Boozer), .true. = uniform rho grid (chartmap file). A chartmap tabulates
-    ! every 1D profile against its rho grid, so A_phi is evaluated at rho and
-    ! chain-ruled to s, matching B_theta/B_phi/Bmod.
-    logical, save :: aphi_over_rho = .false.
     ! Canonical A_phi sampled natively on the Boozer rho grid in
     ! compute_boozer_data (a flux function, like s_Bcovar_tp_B). export_boozer_chartmap
     ! writes this directly so the chartmap A_phi shares the rho abscissa of
@@ -63,39 +57,40 @@ module boozer_sub
     logical, save :: delt_delp_B_batch_spline_ready = .false.
     real(dp), allocatable, save :: delt_delp_B_grid(:, :, :, :)
 
-    ! Device-accessible copies of scalar field parameters that splint_boozer_coord
-    ! needs when running inside an OpenACC kernel. The libneo modules defining the
-    ! originals (vector_potentail_mod, new_vmec_stuff_mod, boozer_coordinates_mod)
-    ! are not OpenACC-compiled, so their globals have no device symbol. boozer_sub
-    ! is compiled with -acc -gpu=mem:unified, so these mirrors are coherent on the
-    ! device. Synced on the host by sync_boozer_gpu_params before GPU tracing.
-    real(dp), save :: torflux_gpu = 0.0_dp
-    integer, save :: nper_gpu = 1
-    logical, save :: use_B_r_gpu = .false.
-    public :: sync_boozer_gpu_params, torflux_gpu
+    type :: boozer_state_t
+        real(dp) :: torflux = 0.0_dp
+        integer :: nper = 1
+        logical :: use_B_r = .false.
+        integer :: bmod_br_num_quantities = 0
+        logical :: aphi_over_rho = .false.
+    end type boozer_state_t
+
+    ! Device-accessible Boozer runtime state shared by host and OpenACC code.
+    ! sync_boozer_state copies the libneo globals into this object before GPU use.
+    type(boozer_state_t), save :: boozer_state
+    public :: sync_boozer_state, boozer_state
 
     ! Module statics referenced by splint_boozer_coord inside OpenACC device
     ! kernels need device symbols. declare create + update device (in
-    ! sync_boozer_gpu_params / spline construction) keeps them coherent.
-    !$acc declare create(torflux_gpu, nper_gpu, use_B_r_gpu, bmod_br_num_quantities)
+    ! sync_boozer_state / spline construction) keeps them coherent.
+    !$acc declare create(boozer_state)
     !$acc declare create(bmod_br_batch_spline, aphi_batch_spline, bcovar_tp_batch_spline)
-    !$acc declare create(aphi_over_rho)
 
 contains
 
-    !> Copy scalar Boozer field parameters from the libneo modules into
-    !> device-accessible boozer_sub mirrors. Host-only; call after field init
-    !> and before any OpenACC tracing kernel.
-    subroutine sync_boozer_gpu_params()
+    !> Copy scalar Boozer field parameters from the libneo modules into the
+    !> shared runtime state. Host-only; call after field init and before any
+    !> OpenACC tracing kernel.
+    subroutine sync_boozer_state()
         use vector_potentail_mod, only: torflux
         use new_vmec_stuff_mod, only: nper
         use boozer_coordinates_mod, only: use_B_r
-        torflux_gpu = torflux
-        nper_gpu = nper
-        use_B_r_gpu = use_B_r
-        !$acc update device(torflux_gpu, nper_gpu, use_B_r_gpu, bmod_br_num_quantities, aphi_over_rho)
+        boozer_state%torflux = torflux
+        boozer_state%nper = nper
+        boozer_state%use_B_r = use_B_r
+        !$acc update device(boozer_state)
         !$acc update device(bmod_br_batch_spline, aphi_batch_spline, bcovar_tp_batch_spline)
-    end subroutine sync_boozer_gpu_params
+    end subroutine sync_boozer_state
 
     !> Initialize Boozer coordinates using given magnetic field
     subroutine get_boozer_coordinates_with_field(field)
@@ -187,8 +182,8 @@ contains
         ! omitted here (threadprivate variables are not allowed in acc routines).
         r_eval = abs(r)
 
-        A_theta = torflux_gpu*r_eval
-        dA_theta_dr = torflux_gpu
+        A_theta = boozer_state%torflux*r_eval
+        dA_theta_dr = boozer_state%torflux
 
         ! Interpolate A_phi. VMEC-derived Boozer data is tabulated on a uniform-s
         ! grid (evaluate at s directly). A chartmap tabulates A_phi on the file's
@@ -197,7 +192,7 @@ contains
         ! coefficients so the VMEC-s branch keeps its original instruction order.
         ! Guards (error stop) are omitted so this routine is callable from OpenACC
         ! device kernels (error stop is not supported there).
-        if (aphi_over_rho) then
+        if (boozer_state%aphi_over_rho) then
             ! A_phi(rho) -> s-derivatives by the chain rule for rho = sqrt(s):
             !   rho'   = 1/(2 rho)              [drds]
             !   rho''  = -1/(4 rho^3)           [-d2rds2m]
@@ -252,7 +247,7 @@ contains
         ! Interpolation of mod-B (and B_r if use_B_r)
         rho_tor = sqrt(r_eval)
         theta_wrapped = modulo(vartheta_B, TWOPI)
-        phi_wrapped = modulo(varphi_B, TWOPI/real(nper_gpu, dp))
+        phi_wrapped = modulo(varphi_B, TWOPI/real(boozer_state%nper, dp))
 
         x_eval(1) = rho_tor
         x_eval(2) = theta_wrapped
@@ -265,9 +260,9 @@ contains
 
         if (mode_secders == 2) then
             call evaluate_batch_splines_3d_der2(bmod_br_batch_spline, x_eval, &
-                                                y_eval(1:bmod_br_num_quantities), &
-                                                dy_eval(:, 1:bmod_br_num_quantities), &
-                                                d2y_eval(:, 1:bmod_br_num_quantities))
+                                                y_eval(1:boozer_state%bmod_br_num_quantities), &
+                                                dy_eval(:, 1:boozer_state%bmod_br_num_quantities), &
+                                                d2y_eval(:, 1:boozer_state%bmod_br_num_quantities))
 
             ! Extract Bmod (quantity 1)
             qua = y_eval(1)
@@ -301,7 +296,7 @@ contains
             d2Bmod_B(6) = d2qua_dp2
 
             ! Extract B_r (quantity 2, if present)
-            if (use_B_r_gpu) then
+            if (boozer_state%use_B_r) then
                 qua = y_eval(2)
                 dqua_dr = dy_eval(1, 2)
                 dqua_dt = dy_eval(2, 2)
@@ -339,8 +334,8 @@ contains
             end if
         else
             call evaluate_batch_splines_3d_der(bmod_br_batch_spline, x_eval, &
-                                               y_eval(1:bmod_br_num_quantities), &
-                                               dy_eval(:, 1:bmod_br_num_quantities))
+                                               y_eval(1:boozer_state%bmod_br_num_quantities), &
+                                               dy_eval(:, 1:boozer_state%bmod_br_num_quantities))
 
             Bmod_B = y_eval(1)
             dBmod_B(1) = dy_eval(1, 1)*drhods
@@ -351,15 +346,15 @@ contains
 
             if (mode_secders == 1) then
                 call evaluate_batch_splines_3d_der2(bmod_br_batch_spline, x_eval, &
-                                                    y_eval(1:bmod_br_num_quantities), &
+                                                    y_eval(1:boozer_state%bmod_br_num_quantities), &
                                                     dy_eval(:, &
-                                                            1:bmod_br_num_quantities), &
+                                                            1:boozer_state%bmod_br_num_quantities), &
                                                     d2y_eval(:, &
-                                                             1:bmod_br_num_quantities))
+                                                             1:boozer_state%bmod_br_num_quantities))
                 d2Bmod_B(1) = d2y_eval(1, 1)*drhods2 - dy_eval(1, 1)*d2rhods2m
             end if
 
-            if (use_B_r_gpu) then
+            if (boozer_state%use_B_r) then
                 qua = y_eval(2)
                 dqua_dr = dy_eval(1, 2)
                 dqua_dt = dy_eval(2, 2)
@@ -920,6 +915,8 @@ contains
     end subroutine ensure_grid_4d
 
     subroutine reset_boozer_batch_splines
+        boozer_state = boozer_state_t()
+        !$acc update device(boozer_state)
         if (aphi_batch_spline_ready) then
             call destroy_batch_splines_1d(aphi_batch_spline)
             aphi_batch_spline_ready = .false.
@@ -931,7 +928,7 @@ contains
         if (bmod_br_batch_spline_ready) then
             call destroy_batch_splines_3d(bmod_br_batch_spline)
             bmod_br_batch_spline_ready = .false.
-            bmod_br_num_quantities = 0
+            boozer_state%bmod_br_num_quantities = 0
         end if
         if (allocated(bmod_grid)) deallocate (bmod_grid)
         if (allocated(br_grid)) deallocate (br_grid)
@@ -1027,7 +1024,7 @@ contains
         call construct_batch_splines_1d(d%rho(1), d%rho(d%n_rho), y_aphi, spline_order, &
                                         .false., aphi_batch_spline)
         aphi_batch_spline_ready = .true.
-        aphi_over_rho = .true.
+        boozer_state%aphi_over_rho = .true.
         deallocate (y_aphi)
 
         ! Build B_theta, B_phi batch spline over rho_tor
@@ -1053,7 +1050,7 @@ contains
         call construct_batch_splines_3d(x_min_3d, x_max_3d, y_bmod, order_3d, &
                                         periodic_3d, bmod_br_batch_spline)
         bmod_br_batch_spline_ready = .true.
-        bmod_br_num_quantities = 1
+        boozer_state%bmod_br_num_quantities = 1
         deallocate (y_bmod)
 
         print *, 'Loaded Boozer splines from chartmap: ', trim(filename)
@@ -1065,7 +1062,7 @@ contains
         ! build_boozer_bmod_br_batch_spline), so refresh the device-accessible
         ! field-parameter mirrors here too. splint_boozer_coord reads them on
         ! both host and device.
-        call sync_boozer_gpu_params
+        call sync_boozer_state
 
     end subroutine load_boozer_from_chartmap
 
@@ -1290,7 +1287,7 @@ contains
         aphi_batch_spline%coeff(1, 0:order, :) = sA_phi(1:order + 1, :)
 
         aphi_batch_spline_ready = .true.
-        aphi_over_rho = .false.  ! VMEC A_phi lives on the uniform-s grid
+        boozer_state%aphi_over_rho = .false.  ! VMEC A_phi lives on the uniform-s grid
     end subroutine build_boozer_aphi_batch_spline
 
     subroutine build_boozer_bcovar_tp_batch_spline
@@ -1343,7 +1340,7 @@ contains
         if (bmod_br_batch_spline_ready) then
             call destroy_batch_splines_3d(bmod_br_batch_spline)
             bmod_br_batch_spline_ready = .false.
-            bmod_br_num_quantities = 0
+            boozer_state%bmod_br_num_quantities = 0
         end if
 
         order = [ns_s_B, ns_tp_B, ns_tp_B]
@@ -1374,13 +1371,13 @@ contains
         call construct_batch_splines_3d(x_min, x_max, y_batch, order, periodic, &
                                         bmod_br_batch_spline)
         bmod_br_batch_spline_ready = .true.
-        bmod_br_num_quantities = nq
+        boozer_state%bmod_br_num_quantities = nq
         deallocate (y_batch)
 
         ! All scalar field parameters are final once the Bmod/B_r spline is
         ! built; refresh the device-accessible mirrors used by splint_boozer_coord
         ! (also keeps the host CPU path correct, since splint now reads them).
-        call sync_boozer_gpu_params
+        call sync_boozer_state
     end subroutine build_boozer_bmod_br_batch_spline
 
     subroutine build_boozer_delt_delp_batch_splines

--- a/src/boozer_converter.F90
+++ b/src/boozer_converter.F90
@@ -30,14 +30,14 @@ module boozer_sub
 !$omp threadprivate(current_field)
 
     ! Batch spline data for Bmod and B_r interpolation
-    type(BatchSplineData3D), save :: bmod_br_batch_spline
+    type(BatchSplineData3D), allocatable :: bmod_br_batch_spline
     logical, save :: bmod_br_batch_spline_ready = .false.
     integer, save :: bmod_br_num_quantities = 0
     real(dp), allocatable, save :: bmod_grid(:, :, :)
     real(dp), allocatable, save :: br_grid(:, :, :)
 
     ! Batch spline for A_phi (vector potential)
-    type(BatchSplineData1D), save :: aphi_batch_spline
+    type(BatchSplineData1D), allocatable :: aphi_batch_spline
     logical, save :: aphi_batch_spline_ready = .false.
     ! Radial abscissa of aphi_batch_spline: .false. = uniform s (VMEC-derived
     ! Boozer), .true. = uniform rho grid (chartmap file). A chartmap tabulates
@@ -51,7 +51,7 @@ module boozer_sub
     real(dp), allocatable, save :: aphi_rho(:)
 
     ! Batch spline for B_theta, B_phi covariant components
-    type(BatchSplineData1D), save :: bcovar_tp_batch_spline
+    type(BatchSplineData1D), allocatable :: bcovar_tp_batch_spline
     logical, save :: bcovar_tp_batch_spline_ready = .false.
 
     ! Batch splines for coordinate transformations (VMEC <-> Boozer)
@@ -94,6 +94,7 @@ contains
         nper_gpu = nper
         use_B_r_gpu = use_B_r
         !$acc update device(torflux_gpu, nper_gpu, use_B_r_gpu, bmod_br_num_quantities, aphi_over_rho)
+        !$acc update device(bmod_br_batch_spline, aphi_batch_spline, bcovar_tp_batch_spline)
     end subroutine sync_boozer_gpu_params
 
     !> Initialize Boozer coordinates using given magnetic field
@@ -944,6 +945,14 @@ contains
             delt_delp_B_batch_spline_ready = .false.
         end if
         if (allocated(delt_delp_B_grid)) deallocate (delt_delp_B_grid)
+
+        ! Descriptors are allocatable so that, under -gpu=mem:managed/separate,
+        ! the module common is not emitted as a value-initialized device global
+        ! (which trips an nvfortran NVVM codegen bug). Keep them allocated for the
+        ! program lifetime; destroy_batch_splines_* above frees only %coeff.
+        if (.not. allocated(aphi_batch_spline)) allocate (aphi_batch_spline)
+        if (.not. allocated(bcovar_tp_batch_spline)) allocate (bcovar_tp_batch_spline)
+        if (.not. allocated(bmod_br_batch_spline)) allocate (bmod_br_batch_spline)
     end subroutine reset_boozer_batch_splines
 
     subroutine load_boozer_from_chartmap(filename)

--- a/src/field/field_can_boozer.f90
+++ b/src/field/field_can_boozer.f90
@@ -67,8 +67,7 @@ contains
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !
     subroutine eval_field_booz(f, r, th_c, ph_c, mode_secders)
-        use boozer_sub, only: splint_boozer_coord
-        use vector_potentail_mod, only: torflux
+        use boozer_sub, only: splint_boozer_coord, torflux_gpu
         !
         ! Evaluates magnetic field in Boozer canonical coordinates (r, th_c, ph_c)
         ! and stores results in variable f
@@ -90,6 +89,7 @@ contains
         type(field_can_t), intent(inout) :: f
         double precision, intent(in) :: r, th_c, ph_c
         integer, intent(in) :: mode_secders
+        !$acc routine seq
 
         double precision :: Bctr_vartheta, Bctr_varphi, bmod2, sqg, &
             d3Aphdr3, dummy, dummy3(3), dummy6(6), &
@@ -117,7 +117,7 @@ contains
                                  f%Bmod, f%dBmod, f%d2Bmod, dummy, dummy3, dummy6)
 
         bmod2 = f%Bmod**2
-        sqg = (-f%dAph(1)/f%dAth(1)*Bth + Bph)/bmod2*torflux
+        sqg = (-f%dAph(1)/f%dAth(1)*Bth + Bph)/bmod2*torflux_gpu
         Bctr_vartheta = -f%dAph(1)/sqg
         Bctr_varphi = f%dAth(1)/sqg
 

--- a/src/field/field_can_boozer.f90
+++ b/src/field/field_can_boozer.f90
@@ -67,7 +67,7 @@ contains
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !
     subroutine eval_field_booz(f, r, th_c, ph_c, mode_secders)
-        use boozer_sub, only: splint_boozer_coord, torflux_gpu
+        use boozer_sub, only: splint_boozer_coord, boozer_state
         !
         ! Evaluates magnetic field in Boozer canonical coordinates (r, th_c, ph_c)
         ! and stores results in variable f
@@ -117,7 +117,7 @@ contains
                                  f%Bmod, f%dBmod, f%d2Bmod, dummy, dummy3, dummy6)
 
         bmod2 = f%Bmod**2
-        sqg = (-f%dAph(1)/f%dAth(1)*Bth + Bph)/bmod2*torflux_gpu
+        sqg = (-f%dAph(1)/f%dAth(1)*Bth + Bph)/bmod2*boozer_state%torflux
         Bctr_vartheta = -f%dAph(1)/sqg
         Bctr_varphi = f%dAth(1)/sqg
 

--- a/src/field_can.f90
+++ b/src/field_can.f90
@@ -221,6 +221,7 @@ subroutine get_val(f, pphi)
   !
   type(field_can_t), intent(inout) :: f
   real(dp), intent(in) :: pphi
+  !$acc routine seq
 
   f%vpar = (pphi - f%Aph/f%ro0)/f%hph
   f%H = f%vpar**2/2d0 + f%mu*f%Bmod
@@ -238,6 +239,7 @@ subroutine get_derivatives(f, pphi)
   !
   type(field_can_t), intent(inout) :: f
   real(dp), intent(in) :: pphi
+  !$acc routine seq
 
   call get_val(f, pphi)
 
@@ -264,6 +266,7 @@ subroutine get_derivatives2(f, pphi)
   !
   type(field_can_t), intent(inout) :: f
   real(dp), intent(in) :: pphi
+  !$acc routine seq
 
   call get_derivatives(f, pphi)
 

--- a/src/orbit_symplectic.f90
+++ b/src/orbit_symplectic.f90
@@ -11,7 +11,8 @@ use orbit_symplectic_quasi, only: orbit_timestep_quasi, timestep_expl_impl_euler
   timestep_impl_expl_euler_quasi, timestep_midpoint_quasi, orbit_timestep_rk45, &
   timestep_rk_gauss_quasi, timestep_rk_lobatto_quasi
 use orbit_symplectic_euler1, only: sympl_euler1_residual, sympl_euler1_jacobian, &
-  sympl_euler1_newton_iter, sympl_euler1_extrapolate_step
+  sympl_euler1_newton_iter, sympl_euler1_extrapolate_field, &
+  sympl_euler1_advance_angles
 use vector_potentail_mod, only: torflux
 use lapack_interfaces, only: dgesv
 use diag_counters, only: count_event, EVT_NEWTON1_MAXIT, EVT_NEWTON2_MAXIT, &
@@ -369,31 +370,22 @@ recursive subroutine newton1(si, f, x, maxit, xlast)
   integer, intent(in) :: maxit
   real(dp), intent(out) :: xlast(n)
 
-  real(dp) :: fvec(n), fjac(n,n), ijac(n,n)
   real(dp) :: tolref(n)
   integer :: kit
+  logical :: converged
 
   tolref(1) = 1d0
   tolref(2) = dabs(1d1*torflux/f%ro0)
 
   do kit = 1, maxit
-    if(x(1) > 1d0) return
-    if(x(1) < 0d0) x(1) = 0.01d0
+    if (x(1) > 1d0) return
+    if (x(1) < 0d0) x(1) = 0.01d0
 
-    call f_sympl_euler1(si, f, n, x, fvec, 1)
-    call jac_sympl_euler1(si, f, x, fjac)
-    ijac(1,1) = 1d0/(fjac(1,1) - fjac(1,2)*fjac(2,1)/fjac(2,2))
-    ijac(1,2) = -1d0/(fjac(1,1)*fjac(2,2)/fjac(1,2) - fjac(2,1))
-    ijac(2,1) = -1d0/(fjac(1,1)*fjac(2,2)/fjac(2,1) - fjac(1,2))
-    ijac(2,2) = 1d0/(fjac(2,2) - fjac(1,2)*fjac(2,1)/fjac(1,1))
-    xlast = x
-    x = x - matmul(ijac, fvec)
+    call eval_field(f, x(1), si%z(2), si%z(3), 2)
+    call get_derivatives2(f, x(2))
+    call sympl_euler1_newton_iter(si, f, x, tolref, xlast, converged)
 
-    ! Don't take too small values in pphi as tolerance reference
-    tolref(2) = max(dabs(x(2)), tolref(2))
-
-    if (all(dabs(fvec) < si%atol)) return
-    if (all(dabs(x-xlast) < si%rtol*tolref)) return
+    if (converged) return
   enddo
   call count_event(EVT_NEWTON1_MAXIT)
 end subroutine
@@ -1228,19 +1220,13 @@ recursive subroutine orbit_timestep_sympl_expl_impl_euler(si, f, ierr)
     si%z(4) = x(2)
 
     if (extrap_field) then
-      f%pth = f%pth + f%dpth(1)*(x(1)-xlast(1))  + f%dpth(4)*(x(2)-xlast(2))
-      f%dH(1) = f%dH(1) + f%d2H(1)*(x(1)-xlast(1)) + f%d2H(7)*(x(2)-xlast(2))
-      f%dpth(1)=f%dpth(1)+f%d2pth(1)*(x(1)-xlast(1))+f%d2pth(7)*(x(2)-xlast(2))
-      f%vpar = f%vpar + f%dvpar(1)*(x(1)-xlast(1)) + f%dvpar(4)*(x(2)-xlast(2))
-      f%hth = f%hth + f%dhth(1)*(x(1)-xlast(1))
-      f%hph = f%hph + f%dhph(1)*(x(1)-xlast(1))
+      call sympl_euler1_extrapolate_field(si, f, x, xlast)
     else
       call eval_field(f, si%z(1), si%z(2), si%z(3), 0)
       call get_derivatives(f, si%z(4))
     endif
 
-    si%z(2) = si%z(2) + si%dt*f%dH(1)/f%dpth(1)
-    si%z(3) = si%z(3) + si%dt*(f%vpar - f%dH(1)/f%dpth(1)*f%hth)/f%hph
+    call sympl_euler1_advance_angles(si, f)
 
     ktau = ktau+1
   enddo

--- a/src/orbit_symplectic.f90
+++ b/src/orbit_symplectic.f90
@@ -10,6 +10,8 @@ use orbit_symplectic_base, only: symplectic_integrator_t, multistage_integrator_
 use orbit_symplectic_quasi, only: orbit_timestep_quasi, timestep_expl_impl_euler_quasi, &
   timestep_impl_expl_euler_quasi, timestep_midpoint_quasi, orbit_timestep_rk45, &
   timestep_rk_gauss_quasi, timestep_rk_lobatto_quasi
+use orbit_symplectic_euler1, only: sympl_euler1_residual, sympl_euler1_jacobian, &
+  sympl_euler1_newton_iter, sympl_euler1_extrapolate_step
 use vector_potentail_mod, only: torflux
 use lapack_interfaces, only: dgesv
 use diag_counters, only: count_event, EVT_NEWTON1_MAXIT, EVT_NEWTON2_MAXIT, &
@@ -167,9 +169,7 @@ recursive subroutine f_sympl_euler1(si, f, n, x, fvec, iflag)
 
   call eval_field(f, x(1), si%z(2), si%z(3), 2)
   call get_derivatives2(f, x(2))
-
-  fvec(1) = f%dpth(1)*(f%pth - si%pthold) + si%dt*(f%dH(2)*f%dpth(1) - f%dH(1)*f%dpth(2))
-  fvec(2) = f%dpth(1)*(x(2) - si%z(4))  + si%dt*(f%dH(3)*f%dpth(1) - f%dH(1)*f%dpth(3))
+  call sympl_euler1_residual(si, f, x, fvec)
 
 end subroutine f_sympl_euler1
 
@@ -184,14 +184,7 @@ recursive subroutine jac_sympl_euler1(si, f, x, jac)
   real(dp), intent(in)  :: x(2)
   real(dp), intent(out) :: jac(2, 2)
 
-  jac(1,1) = f%d2pth(1)*(f%pth - si%pthold) + f%dpth(1)**2 &
-    + si%dt*(f%d2H(2)*f%dpth(1) + f%dH(2)*f%d2pth(1) - f%d2H(1)*f%dpth(2) - f%dH(1)*f%d2pth(2))
-  jac(1,2) = f%d2pth(7)*(f%pth - si%pthold) + f%dpth(1)*f%dpth(4) &
-    + si%dt*(f%d2H(8)*f%dpth(1) + f%dH(2)*f%d2pth(7) - f%d2H(7)*f%dpth(2) - f%dH(1)*f%d2pth(8))
-  jac(2,1) = f%d2pth(1)*(x(2) - si%z(4)) &
-    + si%dt*(f%d2H(3)*f%dpth(1) + f%dH(3)*f%d2pth(1) - f%d2H(1)*f%dpth(3) - f%dH(1)*f%d2pth(3))
-  jac(2,2) = f%d2pth(7)*(x(2) - si%z(4)) + f%dpth(1) &
-    + si%dt*(f%d2H(9)*f%dpth(1) + f%dH(3)*f%d2pth(7) - f%d2H(7)*f%dpth(3) - f%dH(1)*f%d2pth(9))
+  call sympl_euler1_jacobian(si, f, x, jac)
 
 end subroutine jac_sympl_euler1
 
@@ -376,9 +369,9 @@ recursive subroutine newton1(si, f, x, maxit, xlast)
   integer, intent(in) :: maxit
   real(dp), intent(out) :: xlast(n)
 
-  real(dp) :: fvec(n), fjac(n,n), ijac(n,n)
   real(dp) :: tolref(n)
   integer :: kit
+  logical :: converged
 
   tolref(1) = 1d0
   tolref(2) = dabs(1d1*torflux/f%ro0)
@@ -387,20 +380,11 @@ recursive subroutine newton1(si, f, x, maxit, xlast)
     if(x(1) > 1d0) return
     if(x(1) < 0d0) x(1) = 0.01d0
 
-    call f_sympl_euler1(si, f, n, x, fvec, 1)
-    call jac_sympl_euler1(si, f, x, fjac)
-    ijac(1,1) = 1d0/(fjac(1,1) - fjac(1,2)*fjac(2,1)/fjac(2,2))
-    ijac(1,2) = -1d0/(fjac(1,1)*fjac(2,2)/fjac(1,2) - fjac(2,1))
-    ijac(2,1) = -1d0/(fjac(1,1)*fjac(2,2)/fjac(2,1) - fjac(1,2))
-    ijac(2,2) = 1d0/(fjac(2,2) - fjac(1,2)*fjac(2,1)/fjac(1,1))
-    xlast = x
-    x = x - matmul(ijac, fvec)
+    call eval_field(f, x(1), si%z(2), si%z(3), 2)
+    call get_derivatives2(f, x(2))
+    call sympl_euler1_newton_iter(si, f, x, tolref, xlast, converged)
 
-    ! Don't take too small values in pphi as tolerance reference
-    tolref(2) = max(dabs(x(2)), tolref(2))
-
-    if (all(dabs(fvec) < si%atol)) return
-    if (all(dabs(x-xlast) < si%rtol*tolref)) return
+    if (converged) return
   enddo
   call count_event(EVT_NEWTON1_MAXIT)
 end subroutine
@@ -1235,12 +1219,7 @@ recursive subroutine orbit_timestep_sympl_expl_impl_euler(si, f, ierr)
     si%z(4) = x(2)
 
     if (extrap_field) then
-      f%pth = f%pth + f%dpth(1)*(x(1)-xlast(1))  + f%dpth(4)*(x(2)-xlast(2))
-      f%dH(1) = f%dH(1) + f%d2H(1)*(x(1)-xlast(1)) + f%d2H(7)*(x(2)-xlast(2))
-      f%dpth(1)=f%dpth(1)+f%d2pth(1)*(x(1)-xlast(1))+f%d2pth(7)*(x(2)-xlast(2))
-      f%vpar = f%vpar + f%dvpar(1)*(x(1)-xlast(1)) + f%dvpar(4)*(x(2)-xlast(2))
-      f%hth = f%hth + f%dhth(1)*(x(1)-xlast(1))
-      f%hph = f%hph + f%dhph(1)*(x(1)-xlast(1))
+      call sympl_euler1_extrapolate_step(si, f, x, xlast)
     else
       call eval_field(f, si%z(1), si%z(2), si%z(3), 0)
       call get_derivatives(f, si%z(4))

--- a/src/orbit_symplectic.f90
+++ b/src/orbit_symplectic.f90
@@ -369,9 +369,9 @@ recursive subroutine newton1(si, f, x, maxit, xlast)
   integer, intent(in) :: maxit
   real(dp), intent(out) :: xlast(n)
 
+  real(dp) :: fvec(n), fjac(n,n), ijac(n,n)
   real(dp) :: tolref(n)
   integer :: kit
-  logical :: converged
 
   tolref(1) = 1d0
   tolref(2) = dabs(1d1*torflux/f%ro0)
@@ -380,11 +380,20 @@ recursive subroutine newton1(si, f, x, maxit, xlast)
     if(x(1) > 1d0) return
     if(x(1) < 0d0) x(1) = 0.01d0
 
-    call eval_field(f, x(1), si%z(2), si%z(3), 2)
-    call get_derivatives2(f, x(2))
-    call sympl_euler1_newton_iter(si, f, x, tolref, xlast, converged)
+    call f_sympl_euler1(si, f, n, x, fvec, 1)
+    call jac_sympl_euler1(si, f, x, fjac)
+    ijac(1,1) = 1d0/(fjac(1,1) - fjac(1,2)*fjac(2,1)/fjac(2,2))
+    ijac(1,2) = -1d0/(fjac(1,1)*fjac(2,2)/fjac(1,2) - fjac(2,1))
+    ijac(2,1) = -1d0/(fjac(1,1)*fjac(2,2)/fjac(2,1) - fjac(1,2))
+    ijac(2,2) = 1d0/(fjac(2,2) - fjac(1,2)*fjac(2,1)/fjac(1,1))
+    xlast = x
+    x = x - matmul(ijac, fvec)
 
-    if (converged) return
+    ! Don't take too small values in pphi as tolerance reference
+    tolref(2) = max(dabs(x(2)), tolref(2))
+
+    if (all(dabs(fvec) < si%atol)) return
+    if (all(dabs(x-xlast) < si%rtol*tolref)) return
   enddo
   call count_event(EVT_NEWTON1_MAXIT)
 end subroutine
@@ -1219,7 +1228,12 @@ recursive subroutine orbit_timestep_sympl_expl_impl_euler(si, f, ierr)
     si%z(4) = x(2)
 
     if (extrap_field) then
-      call sympl_euler1_extrapolate_step(si, f, x, xlast)
+      f%pth = f%pth + f%dpth(1)*(x(1)-xlast(1))  + f%dpth(4)*(x(2)-xlast(2))
+      f%dH(1) = f%dH(1) + f%d2H(1)*(x(1)-xlast(1)) + f%d2H(7)*(x(2)-xlast(2))
+      f%dpth(1)=f%dpth(1)+f%d2pth(1)*(x(1)-xlast(1))+f%d2pth(7)*(x(2)-xlast(2))
+      f%vpar = f%vpar + f%dvpar(1)*(x(1)-xlast(1)) + f%dvpar(4)*(x(2)-xlast(2))
+      f%hth = f%hth + f%dhth(1)*(x(1)-xlast(1))
+      f%hph = f%hph + f%dhph(1)*(x(1)-xlast(1))
     else
       call eval_field(f, si%z(1), si%z(2), si%z(3), 0)
       call get_derivatives(f, si%z(4))

--- a/src/orbit_symplectic_euler1.f90
+++ b/src/orbit_symplectic_euler1.f90
@@ -8,7 +8,8 @@ implicit none
 private
 
 public :: sympl_euler1_residual, sympl_euler1_jacobian
-public :: sympl_euler1_newton_iter, sympl_euler1_extrapolate_step
+public :: sympl_euler1_newton_iter, sympl_euler1_extrapolate_field
+public :: sympl_euler1_advance_angles
 
 contains
 
@@ -66,10 +67,8 @@ subroutine sympl_euler1_newton_iter(si, f, x, tolref, xlast, converged)
     ijac(2, 2) = 1d0/(fjac(2, 2) - fjac(1, 2)*fjac(2, 1)/fjac(1, 1))
 
     xlast = x
-    ! Keep the original 2x2 Newton update order; the tokamak benchmark is
-    ! sensitive enough that rewriting the multiply changes the Hamiltonian
-    ! spread.
-    x = x - matmul(ijac, fvec)
+    x(1) = x(1) - (ijac(1, 1)*fvec(1) + ijac(1, 2)*fvec(2))
+    x(2) = x(2) - (ijac(2, 1)*fvec(1) + ijac(2, 2)*fvec(2))
 
     tolref(2) = max(dabs(x(2)), tolref(2))
 
@@ -78,15 +77,12 @@ subroutine sympl_euler1_newton_iter(si, f, x, tolref, xlast, converged)
                  dabs(x(2) - xlast(2)) < si%rtol*tolref(2))
 end subroutine sympl_euler1_newton_iter
 
-subroutine sympl_euler1_extrapolate_step(si, f, x, xlast)
+subroutine sympl_euler1_extrapolate_field(si, f, x, xlast)
     !$acc routine seq
-    type(symplectic_integrator_t), intent(inout) :: si
+    type(symplectic_integrator_t), intent(in) :: si
     type(field_can_t), intent(inout) :: f
     real(dp), intent(in) :: x(2)
     real(dp), intent(in) :: xlast(2)
-
-    si%z(1) = x(1)
-    si%z(4) = x(2)
 
     f%pth = f%pth + f%dpth(1)*(x(1) - xlast(1)) + f%dpth(4)*(x(2) - xlast(2))
     f%dH(1) = f%dH(1) + f%d2H(1)*(x(1) - xlast(1)) + f%d2H(7)*(x(2) - xlast(2))
@@ -95,9 +91,15 @@ subroutine sympl_euler1_extrapolate_step(si, f, x, xlast)
     f%vpar = f%vpar + f%dvpar(1)*(x(1) - xlast(1)) + f%dvpar(4)*(x(2) - xlast(2))
     f%hth = f%hth + f%dhth(1)*(x(1) - xlast(1))
     f%hph = f%hph + f%dhph(1)*(x(1) - xlast(1))
+end subroutine sympl_euler1_extrapolate_field
+
+subroutine sympl_euler1_advance_angles(si, f)
+    !$acc routine seq
+    type(symplectic_integrator_t), intent(inout) :: si
+    type(field_can_t), intent(in) :: f
 
     si%z(2) = si%z(2) + si%dt*f%dH(1)/f%dpth(1)
     si%z(3) = si%z(3) + si%dt*(f%vpar - f%dH(1)/f%dpth(1)*f%hth)/f%hph
-end subroutine sympl_euler1_extrapolate_step
+end subroutine sympl_euler1_advance_angles
 
 end module orbit_symplectic_euler1

--- a/src/orbit_symplectic_euler1.f90
+++ b/src/orbit_symplectic_euler1.f90
@@ -1,0 +1,101 @@
+module orbit_symplectic_euler1
+use field_can_mod, only: field_can_t
+use orbit_symplectic_base, only: symplectic_integrator_t
+use, intrinsic :: iso_fortran_env, only: dp => real64
+
+implicit none
+
+private
+
+public :: sympl_euler1_residual, sympl_euler1_jacobian
+public :: sympl_euler1_newton_iter, sympl_euler1_extrapolate_step
+
+contains
+
+subroutine sympl_euler1_residual(si, f, x, fvec)
+    !$acc routine seq
+    type(symplectic_integrator_t), intent(in) :: si
+    type(field_can_t), intent(in) :: f
+    real(dp), intent(in) :: x(2)
+    real(dp), intent(out) :: fvec(2)
+
+    fvec(1) = f%dpth(1)*(f%pth - si%pthold) &
+              + si%dt*(f%dH(2)*f%dpth(1) - f%dH(1)*f%dpth(2))
+    fvec(2) = f%dpth(1)*(x(2) - si%z(4)) &
+              + si%dt*(f%dH(3)*f%dpth(1) - f%dH(1)*f%dpth(3))
+end subroutine sympl_euler1_residual
+
+subroutine sympl_euler1_jacobian(si, f, x, jac)
+    !$acc routine seq
+    type(symplectic_integrator_t), intent(in) :: si
+    type(field_can_t), intent(in) :: f
+    real(dp), intent(in) :: x(2)
+    real(dp), intent(out) :: jac(2, 2)
+
+    jac(1, 1) = f%d2pth(1)*(f%pth - si%pthold) + f%dpth(1)**2 &
+        + si%dt*(f%d2H(2)*f%dpth(1) + f%dH(2)*f%d2pth(1) &
+                 - f%d2H(1)*f%dpth(2) - f%dH(1)*f%d2pth(2))
+    jac(1, 2) = f%d2pth(7)*(f%pth - si%pthold) + f%dpth(1)*f%dpth(4) &
+        + si%dt*(f%d2H(8)*f%dpth(1) + f%dH(2)*f%d2pth(7) &
+                 - f%d2H(7)*f%dpth(2) - f%dH(1)*f%d2pth(8))
+    jac(2, 1) = f%d2pth(1)*(x(2) - si%z(4)) &
+        + si%dt*(f%d2H(3)*f%dpth(1) + f%dH(3)*f%d2pth(1) &
+                 - f%d2H(1)*f%dpth(3) - f%dH(1)*f%d2pth(3))
+    jac(2, 2) = f%d2pth(7)*(x(2) - si%z(4)) + f%dpth(1) &
+        + si%dt*(f%d2H(9)*f%dpth(1) + f%dH(3)*f%d2pth(7) &
+                 - f%d2H(7)*f%dpth(3) - f%dH(1)*f%d2pth(9))
+end subroutine sympl_euler1_jacobian
+
+subroutine sympl_euler1_newton_iter(si, f, x, tolref, xlast, converged)
+    !$acc routine seq
+    type(symplectic_integrator_t), intent(in) :: si
+    type(field_can_t), intent(in) :: f
+    real(dp), intent(inout) :: x(2)
+    real(dp), intent(inout) :: tolref(2)
+    real(dp), intent(out) :: xlast(2)
+    logical, intent(out) :: converged
+
+    real(dp) :: fvec(2), fjac(2, 2), ijac(2, 2)
+
+    call sympl_euler1_residual(si, f, x, fvec)
+    call sympl_euler1_jacobian(si, f, x, fjac)
+
+    ijac(1, 1) = 1d0/(fjac(1, 1) - fjac(1, 2)*fjac(2, 1)/fjac(2, 2))
+    ijac(1, 2) = -1d0/(fjac(1, 1)*fjac(2, 2)/fjac(1, 2) - fjac(2, 1))
+    ijac(2, 1) = -1d0/(fjac(1, 1)*fjac(2, 2)/fjac(2, 1) - fjac(1, 2))
+    ijac(2, 2) = 1d0/(fjac(2, 2) - fjac(1, 2)*fjac(2, 1)/fjac(1, 1))
+
+    xlast = x
+    x(1) = x(1) - (ijac(1, 1)*fvec(1) + ijac(1, 2)*fvec(2))
+    x(2) = x(2) - (ijac(2, 1)*fvec(1) + ijac(2, 2)*fvec(2))
+
+    tolref(2) = max(dabs(x(2)), tolref(2))
+
+    converged = (dabs(fvec(1)) < si%atol .and. dabs(fvec(2)) < si%atol) .or. &
+                (dabs(x(1) - xlast(1)) < si%rtol*tolref(1) .and. &
+                 dabs(x(2) - xlast(2)) < si%rtol*tolref(2))
+end subroutine sympl_euler1_newton_iter
+
+subroutine sympl_euler1_extrapolate_step(si, f, x, xlast)
+    !$acc routine seq
+    type(symplectic_integrator_t), intent(inout) :: si
+    type(field_can_t), intent(inout) :: f
+    real(dp), intent(in) :: x(2)
+    real(dp), intent(in) :: xlast(2)
+
+    si%z(1) = x(1)
+    si%z(4) = x(2)
+
+    f%pth = f%pth + f%dpth(1)*(x(1) - xlast(1)) + f%dpth(4)*(x(2) - xlast(2))
+    f%dH(1) = f%dH(1) + f%d2H(1)*(x(1) - xlast(1)) + f%d2H(7)*(x(2) - xlast(2))
+    f%dpth(1) = f%dpth(1) + f%d2pth(1)*(x(1) - xlast(1)) &
+                + f%d2pth(7)*(x(2) - xlast(2))
+    f%vpar = f%vpar + f%dvpar(1)*(x(1) - xlast(1)) + f%dvpar(4)*(x(2) - xlast(2))
+    f%hth = f%hth + f%dhth(1)*(x(1) - xlast(1))
+    f%hph = f%hph + f%dhph(1)*(x(1) - xlast(1))
+
+    si%z(2) = si%z(2) + si%dt*f%dH(1)/f%dpth(1)
+    si%z(3) = si%z(3) + si%dt*(f%vpar - f%dH(1)/f%dpth(1)*f%hth)/f%hph
+end subroutine sympl_euler1_extrapolate_step
+
+end module orbit_symplectic_euler1

--- a/src/orbit_symplectic_euler1.f90
+++ b/src/orbit_symplectic_euler1.f90
@@ -66,8 +66,10 @@ subroutine sympl_euler1_newton_iter(si, f, x, tolref, xlast, converged)
     ijac(2, 2) = 1d0/(fjac(2, 2) - fjac(1, 2)*fjac(2, 1)/fjac(1, 1))
 
     xlast = x
-    x(1) = x(1) - (ijac(1, 1)*fvec(1) + ijac(1, 2)*fvec(2))
-    x(2) = x(2) - (ijac(2, 1)*fvec(1) + ijac(2, 2)*fvec(2))
+    ! Keep the original 2x2 Newton update order; the tokamak benchmark is
+    ! sensitive enough that rewriting the multiply changes the Hamiltonian
+    ! spread.
+    x = x - matmul(ijac, fvec)
 
     tolref(2) = max(dabs(x(2)), tolref(2))
 

--- a/src/simple_gpu.f90
+++ b/src/simple_gpu.f90
@@ -12,7 +12,8 @@ module simple_gpu
     use field_can_mod, only: field_can_t, get_derivatives2
     use field_can_boozer, only: eval_field_booz
     use orbit_symplectic_base, only: symplectic_integrator_t
-    use orbit_symplectic_euler1, only: sympl_euler1_newton_iter, sympl_euler1_extrapolate_step
+    use orbit_symplectic_euler1, only: sympl_euler1_newton_iter
+    use orbit_symplectic_euler1, only: sympl_euler1_extrapolate_field, sympl_euler1_advance_angles
     use boozer_sub, only: boozer_state
     use omp_lib, only: omp_get_thread_num
 #ifdef _OPENACC
@@ -80,7 +81,8 @@ contains
             end if
             if (x(1) < 0.0d0) x(1) = 0.01d0
 
-            call sympl_euler1_extrapolate_step(si, f, x, xlast)
+            call sympl_euler1_extrapolate_field(si, f, x, xlast)
+            call sympl_euler1_advance_angles(si, f)
 
             ktau = ktau + 1
         end do

--- a/src/simple_gpu.f90
+++ b/src/simple_gpu.f90
@@ -16,13 +16,17 @@ module simple_gpu
     use field_can_boozer, only: eval_field_booz
     use orbit_symplectic_base, only: symplectic_integrator_t
     use boozer_sub, only: torflux_gpu
+    use omp_lib, only: omp_get_thread_num
+#ifdef _OPENACC
+    use openacc, only: acc_get_num_devices, acc_set_device_num, acc_device_nvidia
+#endif
 
     implicit none
     private
 
     integer, parameter :: maxit = 32
 
-    public :: trace_orbits_gpu
+    public :: trace_orbits_gpu, trace_orbits_gpu_range
 
 contains
 
@@ -146,14 +150,15 @@ contains
         end do
     end subroutine gpu_timestep_euler
 
-    subroutine trace_orbits_gpu(si, f, npart, ntimstep, ntau_macro, loss_step, zend)
-        ! Evolve npart pre-initialised particles on the GPU. Each particle runs
-        ! its full macrostep schedule; loss_step(i) = first timestep at which the
-        ! orbit left the plasma (r>1), or ntimstep if confined for the whole trace.
-        ! zend(:,i) holds the final integrator state z = (r, th, ph, pphi).
+    subroutine trace_orbits_gpu_range(si, f, npart, istart, iend, ntimstep, &
+                                      ntau_macro, loss_step, zend)
+        ! Evolve particles istart:iend on the currently selected OpenACC device.
+        ! loss_step(i) = first timestep at which the orbit left the plasma (r>1),
+        ! or ntimstep if confined for the whole trace. zend(:,i) is the final
+        ! integrator state z = (r, th, ph, pphi).
         type(symplectic_integrator_t), intent(inout) :: si(npart)
         type(field_can_t), intent(inout) :: f(npart)
-        integer, intent(in) :: npart, ntimstep
+        integer, intent(in) :: npart, istart, iend, ntimstep
         integer, intent(in) :: ntau_macro(ntimstep)
         integer, intent(out) :: loss_step(npart)
         real(dp), intent(out) :: zend(4, npart)
@@ -161,9 +166,10 @@ contains
         integer :: i, it, ktau, ierr, lstep
 
         !$acc parallel loop gang vector default(present) &
-        !$acc&   copy(si, f) copyin(ntau_macro) copyout(loss_step, zend) &
+        !$acc&   copy(si(istart:iend), f(istart:iend)) copyin(ntau_macro) &
+        !$acc&   copyout(loss_step(istart:iend), zend(:, istart:iend)) &
         !$acc&   private(it, ktau, ierr, lstep)
-        do i = 1, npart
+        do i = istart, iend
             ierr = 0
             lstep = ntimstep
             macro: do it = 2, ntimstep
@@ -182,6 +188,56 @@ contains
             zend(3, i) = si(i)%z(3)
             zend(4, i) = si(i)%z(4)
         end do
+    end subroutine trace_orbits_gpu_range
+
+    subroutine trace_orbits_gpu(si, f, npart, ntimstep, ntau_macro, loss_step, zend)
+        ! Evolve npart pre-initialised particles, splitting the work evenly
+        ! across all available NVIDIA GPUs (one host thread per device). Falls
+        ! back to a single device / the host when only one is present.
+        type(symplectic_integrator_t), intent(inout) :: si(npart)
+        type(field_can_t), intent(inout) :: f(npart)
+        integer, intent(in) :: npart, ntimstep
+        integer, intent(in) :: ntau_macro(ntimstep)
+        integer, intent(out) :: loss_step(npart)
+        real(dp), intent(out) :: zend(4, npart)
+
+        integer :: ngpu, navail, dev, i0, i1
+        character(16) :: env_val
+        integer :: env_len, env_stat, req
+
+        ! Number of devices to use. Default 1: with -gpu=mem:unified the spline
+        ! coefficient array is shared and migrates between devices on access, so
+        ! splitting across cards thrashes. Real multi-GPU needs a per-device
+        ! resident copy of the read-only splines. Opt in with SIMPLE_GPU_NUM_DEVICES.
+        req = 1
+        call get_environment_variable('SIMPLE_GPU_NUM_DEVICES', env_val, env_len, env_stat)
+        if (env_stat == 0 .and. env_len > 0) read (env_val, *, iostat=env_stat) req
+        if (env_stat /= 0 .or. req < 1) req = 1
+
+        ngpu = 1
+#ifdef _OPENACC
+        navail = acc_get_num_devices(acc_device_nvidia)
+        if (navail < 1) navail = 1
+        ngpu = min(req, navail)
+#endif
+        if (ngpu <= 1) then
+            call trace_orbits_gpu_range(si, f, npart, 1, npart, ntimstep, &
+                                        ntau_macro, loss_step, zend)
+            return
+        end if
+
+        !$omp parallel num_threads(ngpu) private(dev, i0, i1)
+        dev = omp_get_thread_num()
+#ifdef _OPENACC
+        call acc_set_device_num(dev, acc_device_nvidia)
+#endif
+        i0 = int(int(dev, 8)*npart/ngpu) + 1
+        i1 = int(int(dev + 1, 8)*npart/ngpu)
+        if (i1 >= i0) then
+            call trace_orbits_gpu_range(si, f, npart, i0, i1, ntimstep, &
+                                        ntau_macro, loss_step, zend)
+        end if
+        !$omp end parallel
     end subroutine trace_orbits_gpu
 
 end module simple_gpu

--- a/src/simple_gpu.f90
+++ b/src/simple_gpu.f90
@@ -1,0 +1,187 @@
+module simple_gpu
+    ! OpenACC GPU offload of the default orbit-tracing hot path:
+    ! Boozer field (isw_field_type=2) + explicit-implicit symplectic Euler
+    ! (integmode=EXPL_IMPL_EULER). One particle per GPU thread.
+    !
+    ! The CPU integrator (orbit_symplectic) dispatches the field evaluation
+    ! through a procedure pointer, which cannot be called inside an OpenACC
+    ! compute region. This module provides device-resident (acc routine seq)
+    ! copies of the explicit-implicit Euler step and its 2x2 Newton solver that
+    ! call eval_field_booz directly. The arithmetic mirrors
+    ! orbit_timestep_sympl_expl_impl_euler / newton1 / f_sympl_euler1 /
+    ! jac_sympl_euler1 exactly (extrap_field = .true. branch); equivalence is
+    ! checked against the CPU path by test_gpu_orbit.
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use field_can_mod, only: field_can_t, get_val, get_derivatives, get_derivatives2
+    use field_can_boozer, only: eval_field_booz
+    use orbit_symplectic_base, only: symplectic_integrator_t
+    use boozer_sub, only: torflux_gpu
+
+    implicit none
+    private
+
+    integer, parameter :: maxit = 32
+
+    public :: trace_orbits_gpu
+
+contains
+
+    subroutine gpu_f_sympl_euler1(si, f, x, fvec)
+        !$acc routine seq
+        type(symplectic_integrator_t), intent(inout) :: si
+        type(field_can_t), intent(inout) :: f
+        real(dp), intent(in) :: x(2)
+        real(dp), intent(out) :: fvec(2)
+
+        call eval_field_booz(f, x(1), si%z(2), si%z(3), 2)
+        call get_derivatives2(f, x(2))
+
+        fvec(1) = f%dpth(1)*(f%pth - si%pthold) &
+                  + si%dt*(f%dH(2)*f%dpth(1) - f%dH(1)*f%dpth(2))
+        fvec(2) = f%dpth(1)*(x(2) - si%z(4)) &
+                  + si%dt*(f%dH(3)*f%dpth(1) - f%dH(1)*f%dpth(3))
+    end subroutine gpu_f_sympl_euler1
+
+    subroutine gpu_jac_sympl_euler1(si, f, x, jac)
+        !$acc routine seq
+        type(symplectic_integrator_t), intent(in) :: si
+        type(field_can_t), intent(in) :: f
+        real(dp), intent(in) :: x(2)
+        real(dp), intent(out) :: jac(2, 2)
+
+        jac(1, 1) = f%d2pth(1)*(f%pth - si%pthold) + f%dpth(1)**2 &
+            + si%dt*(f%d2H(2)*f%dpth(1) + f%dH(2)*f%d2pth(1) &
+                     - f%d2H(1)*f%dpth(2) - f%dH(1)*f%d2pth(2))
+        jac(1, 2) = f%d2pth(7)*(f%pth - si%pthold) + f%dpth(1)*f%dpth(4) &
+            + si%dt*(f%d2H(8)*f%dpth(1) + f%dH(2)*f%d2pth(7) &
+                     - f%d2H(7)*f%dpth(2) - f%dH(1)*f%d2pth(8))
+        jac(2, 1) = f%d2pth(1)*(x(2) - si%z(4)) &
+            + si%dt*(f%d2H(3)*f%dpth(1) + f%dH(3)*f%d2pth(1) &
+                     - f%d2H(1)*f%dpth(3) - f%dH(1)*f%d2pth(3))
+        jac(2, 2) = f%d2pth(7)*(x(2) - si%z(4)) + f%dpth(1) &
+            + si%dt*(f%d2H(9)*f%dpth(1) + f%dH(3)*f%d2pth(7) &
+                     - f%d2H(7)*f%dpth(3) - f%dH(1)*f%d2pth(9))
+    end subroutine gpu_jac_sympl_euler1
+
+    subroutine gpu_newton1(si, f, x, xlast)
+        !$acc routine seq
+        type(symplectic_integrator_t), intent(inout) :: si
+        type(field_can_t), intent(inout) :: f
+        real(dp), intent(inout) :: x(2)
+        real(dp), intent(out) :: xlast(2)
+
+        real(dp) :: fvec(2), fjac(2, 2), ijac(2, 2)
+        real(dp) :: tolref(2)
+        integer :: kit
+
+        tolref(1) = 1d0
+        tolref(2) = dabs(1d1*torflux_gpu/f%ro0)
+
+        do kit = 1, maxit
+            if (x(1) > 1d0) return
+            if (x(1) < 0d0) x(1) = 0.01d0
+
+            call gpu_f_sympl_euler1(si, f, x, fvec)
+            call gpu_jac_sympl_euler1(si, f, x, fjac)
+
+            ijac(1, 1) = 1d0/(fjac(1, 1) - fjac(1, 2)*fjac(2, 1)/fjac(2, 2))
+            ijac(1, 2) = -1d0/(fjac(1, 1)*fjac(2, 2)/fjac(1, 2) - fjac(2, 1))
+            ijac(2, 1) = -1d0/(fjac(1, 1)*fjac(2, 2)/fjac(2, 1) - fjac(1, 2))
+            ijac(2, 2) = 1d0/(fjac(2, 2) - fjac(1, 2)*fjac(2, 1)/fjac(1, 1))
+
+            xlast = x
+            x(1) = x(1) - (ijac(1, 1)*fvec(1) + ijac(1, 2)*fvec(2))
+            x(2) = x(2) - (ijac(2, 1)*fvec(1) + ijac(2, 2)*fvec(2))
+
+            tolref(2) = max(dabs(x(2)), tolref(2))
+
+            if (dabs(fvec(1)) < si%atol .and. dabs(fvec(2)) < si%atol) return
+            if (dabs(x(1) - xlast(1)) < si%rtol*tolref(1) .and. &
+                dabs(x(2) - xlast(2)) < si%rtol*tolref(2)) return
+        end do
+        ! Non-convergence diagnostics (CPU writes fort.6601) are omitted on device.
+    end subroutine gpu_newton1
+
+    subroutine gpu_timestep_euler(si, f, ierr)
+        !$acc routine seq
+        type(symplectic_integrator_t), intent(inout) :: si
+        type(field_can_t), intent(inout) :: f
+        integer, intent(out) :: ierr
+
+        real(dp) :: x(2), xlast(2)
+        integer :: ktau
+
+        ierr = 0
+        ktau = 0
+        do while (ktau < si%ntau)
+            si%pthold = f%pth
+
+            x(1) = si%z(1)
+            x(2) = si%z(4)
+
+            call gpu_newton1(si, f, x, xlast)
+
+            if (x(1) > 1.0d0) then
+                ierr = 1
+                return
+            end if
+            if (x(1) < 0.0d0) x(1) = 0.01d0
+
+            si%z(1) = x(1)
+            si%z(4) = x(2)
+
+            ! extrap_field = .true. branch (see orbit_symplectic_base)
+            f%pth = f%pth + f%dpth(1)*(x(1) - xlast(1)) + f%dpth(4)*(x(2) - xlast(2))
+            f%dH(1) = f%dH(1) + f%d2H(1)*(x(1) - xlast(1)) + f%d2H(7)*(x(2) - xlast(2))
+            f%dpth(1) = f%dpth(1) + f%d2pth(1)*(x(1) - xlast(1)) &
+                        + f%d2pth(7)*(x(2) - xlast(2))
+            f%vpar = f%vpar + f%dvpar(1)*(x(1) - xlast(1)) + f%dvpar(4)*(x(2) - xlast(2))
+            f%hth = f%hth + f%dhth(1)*(x(1) - xlast(1))
+            f%hph = f%hph + f%dhph(1)*(x(1) - xlast(1))
+
+            si%z(2) = si%z(2) + si%dt*f%dH(1)/f%dpth(1)
+            si%z(3) = si%z(3) + si%dt*(f%vpar - f%dH(1)/f%dpth(1)*f%hth)/f%hph
+
+            ktau = ktau + 1
+        end do
+    end subroutine gpu_timestep_euler
+
+    subroutine trace_orbits_gpu(si, f, npart, ntimstep, ntau_macro, loss_step, zend)
+        ! Evolve npart pre-initialised particles on the GPU. Each particle runs
+        ! its full macrostep schedule; loss_step(i) = first timestep at which the
+        ! orbit left the plasma (r>1), or ntimstep if confined for the whole trace.
+        ! zend(:,i) holds the final integrator state z = (r, th, ph, pphi).
+        type(symplectic_integrator_t), intent(inout) :: si(npart)
+        type(field_can_t), intent(inout) :: f(npart)
+        integer, intent(in) :: npart, ntimstep
+        integer, intent(in) :: ntau_macro(ntimstep)
+        integer, intent(out) :: loss_step(npart)
+        real(dp), intent(out) :: zend(4, npart)
+
+        integer :: i, it, ktau, ierr, lstep
+
+        !$acc parallel loop gang vector default(present) &
+        !$acc&   copy(si, f) copyin(ntau_macro) copyout(loss_step, zend) &
+        !$acc&   private(it, ktau, ierr, lstep)
+        do i = 1, npart
+            ierr = 0
+            lstep = ntimstep
+            macro: do it = 2, ntimstep
+                do ktau = 1, ntau_macro(it)
+                    call gpu_timestep_euler(si(i), f(i), ierr)
+                    if (ierr /= 0) exit
+                end do
+                if (ierr /= 0) then
+                    lstep = it
+                    exit macro
+                end if
+            end do macro
+            loss_step(i) = lstep
+            zend(1, i) = si(i)%z(1)
+            zend(2, i) = si(i)%z(2)
+            zend(3, i) = si(i)%z(3)
+            zend(4, i) = si(i)%z(4)
+        end do
+    end subroutine trace_orbits_gpu
+
+end module simple_gpu

--- a/src/simple_gpu.f90
+++ b/src/simple_gpu.f90
@@ -3,19 +3,17 @@ module simple_gpu
     ! Boozer field (isw_field_type=2) + explicit-implicit symplectic Euler
     ! (integmode=EXPL_IMPL_EULER). One particle per GPU thread.
     !
-    ! The CPU integrator (orbit_symplectic) dispatches the field evaluation
-    ! through a procedure pointer, which cannot be called inside an OpenACC
-    ! compute region. This module provides device-resident (acc routine seq)
-    ! copies of the explicit-implicit Euler step and its 2x2 Newton solver that
-    ! call eval_field_booz directly. The arithmetic mirrors
-    ! orbit_timestep_sympl_expl_impl_euler / newton1 / f_sympl_euler1 /
-    ! jac_sympl_euler1 exactly (extrap_field = .true. branch); equivalence is
-    ! checked against the CPU path by test_gpu_orbit.
+    ! The CPU integrator dispatches the field evaluation through a procedure
+    ! pointer, which cannot be called inside an OpenACC compute region. This
+    ! module keeps the device-side field evaluation local and reuses the shared
+    ! symplectic-Euler algebra from orbit_symplectic_euler1. Equivalence is
+    ! checked against the CPU path by test_gpu_orbit_bench.
     use, intrinsic :: iso_fortran_env, only: dp => real64
-    use field_can_mod, only: field_can_t, get_val, get_derivatives, get_derivatives2
+    use field_can_mod, only: field_can_t, get_derivatives2
     use field_can_boozer, only: eval_field_booz
     use orbit_symplectic_base, only: symplectic_integrator_t
-    use boozer_sub, only: torflux_gpu
+    use orbit_symplectic_euler1, only: sympl_euler1_newton_iter, sympl_euler1_extrapolate_step
+    use boozer_sub, only: boozer_state
     use omp_lib, only: omp_get_thread_num
 #ifdef _OPENACC
     use openacc, only: acc_get_num_devices, acc_set_device_num, acc_device_nvidia
@@ -30,43 +28,6 @@ module simple_gpu
 
 contains
 
-    subroutine gpu_f_sympl_euler1(si, f, x, fvec)
-        !$acc routine seq
-        type(symplectic_integrator_t), intent(inout) :: si
-        type(field_can_t), intent(inout) :: f
-        real(dp), intent(in) :: x(2)
-        real(dp), intent(out) :: fvec(2)
-
-        call eval_field_booz(f, x(1), si%z(2), si%z(3), 2)
-        call get_derivatives2(f, x(2))
-
-        fvec(1) = f%dpth(1)*(f%pth - si%pthold) &
-                  + si%dt*(f%dH(2)*f%dpth(1) - f%dH(1)*f%dpth(2))
-        fvec(2) = f%dpth(1)*(x(2) - si%z(4)) &
-                  + si%dt*(f%dH(3)*f%dpth(1) - f%dH(1)*f%dpth(3))
-    end subroutine gpu_f_sympl_euler1
-
-    subroutine gpu_jac_sympl_euler1(si, f, x, jac)
-        !$acc routine seq
-        type(symplectic_integrator_t), intent(in) :: si
-        type(field_can_t), intent(in) :: f
-        real(dp), intent(in) :: x(2)
-        real(dp), intent(out) :: jac(2, 2)
-
-        jac(1, 1) = f%d2pth(1)*(f%pth - si%pthold) + f%dpth(1)**2 &
-            + si%dt*(f%d2H(2)*f%dpth(1) + f%dH(2)*f%d2pth(1) &
-                     - f%d2H(1)*f%dpth(2) - f%dH(1)*f%d2pth(2))
-        jac(1, 2) = f%d2pth(7)*(f%pth - si%pthold) + f%dpth(1)*f%dpth(4) &
-            + si%dt*(f%d2H(8)*f%dpth(1) + f%dH(2)*f%d2pth(7) &
-                     - f%d2H(7)*f%dpth(2) - f%dH(1)*f%d2pth(8))
-        jac(2, 1) = f%d2pth(1)*(x(2) - si%z(4)) &
-            + si%dt*(f%d2H(3)*f%dpth(1) + f%dH(3)*f%d2pth(1) &
-                     - f%d2H(1)*f%dpth(3) - f%dH(1)*f%d2pth(3))
-        jac(2, 2) = f%d2pth(7)*(x(2) - si%z(4)) + f%dpth(1) &
-            + si%dt*(f%d2H(9)*f%dpth(1) + f%dH(3)*f%d2pth(7) &
-                     - f%d2H(7)*f%dpth(3) - f%dH(1)*f%d2pth(9))
-    end subroutine gpu_jac_sympl_euler1
-
     subroutine gpu_newton1(si, f, x, xlast)
         !$acc routine seq
         type(symplectic_integrator_t), intent(inout) :: si
@@ -74,34 +35,22 @@ contains
         real(dp), intent(inout) :: x(2)
         real(dp), intent(out) :: xlast(2)
 
-        real(dp) :: fvec(2), fjac(2, 2), ijac(2, 2)
         real(dp) :: tolref(2)
         integer :: kit
+        logical :: converged
 
         tolref(1) = 1d0
-        tolref(2) = dabs(1d1*torflux_gpu/f%ro0)
+        tolref(2) = dabs(1d1*boozer_state%torflux/f%ro0)
 
         do kit = 1, maxit
             if (x(1) > 1d0) return
             if (x(1) < 0d0) x(1) = 0.01d0
 
-            call gpu_f_sympl_euler1(si, f, x, fvec)
-            call gpu_jac_sympl_euler1(si, f, x, fjac)
+            call eval_field_booz(f, x(1), si%z(2), si%z(3), 2)
+            call get_derivatives2(f, x(2))
+            call sympl_euler1_newton_iter(si, f, x, tolref, xlast, converged)
 
-            ijac(1, 1) = 1d0/(fjac(1, 1) - fjac(1, 2)*fjac(2, 1)/fjac(2, 2))
-            ijac(1, 2) = -1d0/(fjac(1, 1)*fjac(2, 2)/fjac(1, 2) - fjac(2, 1))
-            ijac(2, 1) = -1d0/(fjac(1, 1)*fjac(2, 2)/fjac(2, 1) - fjac(1, 2))
-            ijac(2, 2) = 1d0/(fjac(2, 2) - fjac(1, 2)*fjac(2, 1)/fjac(1, 1))
-
-            xlast = x
-            x(1) = x(1) - (ijac(1, 1)*fvec(1) + ijac(1, 2)*fvec(2))
-            x(2) = x(2) - (ijac(2, 1)*fvec(1) + ijac(2, 2)*fvec(2))
-
-            tolref(2) = max(dabs(x(2)), tolref(2))
-
-            if (dabs(fvec(1)) < si%atol .and. dabs(fvec(2)) < si%atol) return
-            if (dabs(x(1) - xlast(1)) < si%rtol*tolref(1) .and. &
-                dabs(x(2) - xlast(2)) < si%rtol*tolref(2)) return
+            if (converged) return
         end do
         ! Non-convergence diagnostics (CPU writes fort.6601) are omitted on device.
     end subroutine gpu_newton1
@@ -131,20 +80,7 @@ contains
             end if
             if (x(1) < 0.0d0) x(1) = 0.01d0
 
-            si%z(1) = x(1)
-            si%z(4) = x(2)
-
-            ! extrap_field = .true. branch (see orbit_symplectic_base)
-            f%pth = f%pth + f%dpth(1)*(x(1) - xlast(1)) + f%dpth(4)*(x(2) - xlast(2))
-            f%dH(1) = f%dH(1) + f%d2H(1)*(x(1) - xlast(1)) + f%d2H(7)*(x(2) - xlast(2))
-            f%dpth(1) = f%dpth(1) + f%d2pth(1)*(x(1) - xlast(1)) &
-                        + f%d2pth(7)*(x(2) - xlast(2))
-            f%vpar = f%vpar + f%dvpar(1)*(x(1) - xlast(1)) + f%dvpar(4)*(x(2) - xlast(2))
-            f%hth = f%hth + f%dhth(1)*(x(1) - xlast(1))
-            f%hph = f%hph + f%dhph(1)*(x(1) - xlast(1))
-
-            si%z(2) = si%z(2) + si%dt*f%dH(1)/f%dpth(1)
-            si%z(3) = si%z(3) + si%dt*(f%vpar - f%dH(1)/f%dpth(1)*f%hth)/f%hph
+            call sympl_euler1_extrapolate_step(si, f, x, xlast)
 
             ktau = ktau + 1
         end do

--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -144,6 +144,17 @@ contains
             call print_phase_time('Restart data loaded')
         end if
 
+        block
+            character(32) :: gpu_bench_env
+            integer :: gpu_bench_len, gpu_bench_stat
+            call get_environment_variable('SIMPLE_GPU_BENCH', gpu_bench_env, &
+                                          gpu_bench_len, gpu_bench_stat)
+            if (gpu_bench_stat == 0 .and. gpu_bench_len > 0) then
+                call trace_compare_gpu(norb)
+                return
+            end if
+        end block
+
         call diag_counters_init
         call progress_init(checkpoint_interval, ntestpart, write_results)
         call trace_parallel(norb)
@@ -435,6 +446,91 @@ contains
             call close_orbit_netcdf()
         end if
     end subroutine trace_parallel
+
+    subroutine trace_compare_gpu(norb)
+        ! Validate and benchmark the OpenACC GPU tracing kernel against the CPU
+        ! symplectic integrator on identical per-particle initial states for the
+        ! default Boozer + explicit-implicit Euler configuration. Triggered by
+        ! the SIMPLE_GPU_BENCH environment variable.
+        use orbit_symplectic, only: orbit_timestep_sympl
+        use orbit_symplectic_base, only: symplectic_integrator_t
+        use field_can_mod, only: field_can_t
+        use boozer_sub, only: sync_boozer_gpu_params
+        use simple_gpu, only: trace_orbits_gpu
+
+        type(tracer_t), intent(inout) :: norb
+
+        type(symplectic_integrator_t), allocatable :: si_cpu(:), si_gpu(:)
+        type(field_can_t), allocatable :: f_cpu(:), f_gpu(:)
+        integer, allocatable :: cpu_loss(:), gpu_loss(:)
+        real(dp), allocatable :: cpu_zend(:, :), gpu_zend(:, :)
+        real(dp) :: z(5)
+        integer :: i, it, ktau, ierr, loss_mismatch
+        real(dp) :: t0, t1, t_cpu, t_gpu, maxz
+
+        allocate (si_cpu(ntestpart), si_gpu(ntestpart))
+        allocate (f_cpu(ntestpart), f_gpu(ntestpart))
+        allocate (cpu_loss(ntestpart), gpu_loss(ntestpart))
+        allocate (cpu_zend(4, ntestpart), gpu_zend(4, ntestpart))
+
+        ! Identical per-particle initialisation (host). init_sympl sets the
+        ! orbit_timestep_sympl procedure pointer for the CPU reference.
+        do i = 1, ntestpart
+            call ref_to_integ(zstart(1:3, i), z(1:3))
+            z(4:5) = zstart(4:5, i)
+            call init_sympl(si_cpu(i), f_cpu(i), z, dtaumin, dtaumin, relerr, integmode)
+            si_gpu(i) = si_cpu(i)
+            f_gpu(i) = f_cpu(i)
+        end do
+
+        call sync_boozer_gpu_params
+
+        ! CPU reference (OpenMP over particles)
+        t0 = omp_get_wtime()
+        !$omp parallel do private(i, it, ktau, ierr) schedule(dynamic)
+        do i = 1, ntestpart
+            ierr = 0
+            cpu_loss(i) = ntimstep
+            do it = 2, ntimstep
+                do ktau = 1, ntau_macro(it)
+                    call orbit_timestep_sympl(si_cpu(i), f_cpu(i), ierr)
+                    if (ierr /= 0) exit
+                end do
+                if (ierr /= 0) then
+                    cpu_loss(i) = it
+                    exit
+                end if
+            end do
+            cpu_zend(:, i) = si_cpu(i)%z(1:4)
+        end do
+        !$omp end parallel do
+        t1 = omp_get_wtime()
+        t_cpu = t1 - t0
+
+        ! GPU kernel
+        t0 = omp_get_wtime()
+        call trace_orbits_gpu(si_gpu, f_gpu, ntestpart, ntimstep, ntau_macro, &
+                              gpu_loss, gpu_zend)
+        t1 = omp_get_wtime()
+        t_gpu = t1 - t0
+
+        ! Compare
+        maxz = 0d0
+        loss_mismatch = 0
+        do i = 1, ntestpart
+            maxz = max(maxz, maxval(dabs(cpu_zend(:, i) - gpu_zend(:, i))))
+            if (cpu_loss(i) /= gpu_loss(i)) loss_mismatch = loss_mismatch + 1
+        end do
+
+        print *, '==================== GPU vs CPU tracing ===================='
+        print '(a,i0,a,i0)', ' particles = ', ntestpart, '   timesteps = ', ntimstep
+        print '(a,es12.4)', ' max |z_cpu - z_gpu| (final state) = ', maxz
+        print '(a,i0,a,i0)', ' loss-step mismatches = ', loss_mismatch, ' / ', ntestpart
+        print '(a,f10.4,a)', ' CPU time (OpenMP) = ', t_cpu, ' s'
+        print '(a,f10.4,a)', ' GPU time          = ', t_gpu, ' s'
+        if (t_gpu > 0d0) print '(a,f8.2,a)', ' speedup (CPU/GPU) = ', t_cpu/t_gpu, ' x'
+        print *, '============================================================'
+    end subroutine trace_compare_gpu
 
     subroutine classify_parallel(norb)
         use classification, only: trace_orbit_with_classifiers, classification_result_t

--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -790,9 +790,10 @@ contains
             ! Fill trajectory arrays with NaN since we're not tracing this particle
             orbit_traj = ieee_value(0.0d0, ieee_quiet_nan)
             orbit_times = ieee_value(0.0d0, ieee_quiet_nan)
-!$omp critical
-            confpart_pass = confpart_pass + 1.d0
-!$omp end critical
+            do it = 1, ntimstep
+!$omp atomic update
+                confpart_pass(it) = confpart_pass(it) + 1.d0
+            end do
             return
         end if
 

--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -12,8 +12,8 @@ module simple_main
 	                      grid_density, dtau, dtaumin, ntau, v0, &
 	                      kpart, confpart_pass, confpart_trap, times_lost, integmode, &
 	                      relerr, trace_time, &
-	                      class_plot, ntcut, iclass, bmin, bmax, &
-	                      zstart, zend, trap_par, perp_inv, sbeg, &
+	                      class_plot, fast_class, generate_start_only, ntcut, iclass, &
+	                      bmin, bmax, zstart, zend, trap_par, perp_inv, sbeg, &
 	                      ntimstep, should_skip, reset_seed_if_deterministic, &
 	                      field_input, isw_field_type, reuse_batch, coord_input, &
 	                      wall_input, wall_units, wall_hit, wall_hit_cart, &
@@ -449,13 +449,15 @@ contains
 
     subroutine trace_compare_gpu(norb)
         ! Validate and benchmark the OpenACC GPU tracing kernel against the CPU
-        ! symplectic integrator on identical per-particle initial states for the
-        ! default Boozer + explicit-implicit Euler configuration. Triggered by
-        ! the SIMPLE_GPU_BENCH environment variable.
+        ! symplectic integrator on identical per-particle initial states.
+        ! Triggered by the SIMPLE_GPU_BENCH environment variable and restricted
+        ! to the Boozer + EXPL_IMPL_EULER path without wall, collision, or
+        ! classifier options.
         use orbit_symplectic, only: orbit_timestep_sympl
-        use orbit_symplectic_base, only: symplectic_integrator_t
+        use orbit_symplectic_base, only: symplectic_integrator_t, EXPL_IMPL_EULER
         use field_can_mod, only: field_can_t
-        use boozer_sub, only: sync_boozer_gpu_params
+        use magfie_sub, only: BOOZER
+        use boozer_sub, only: sync_boozer_state
         use simple_gpu, only: trace_orbits_gpu
 
         type(tracer_t), intent(inout) :: norb
@@ -468,6 +470,14 @@ contains
         integer :: i, it, ktau, ierr, loss_mismatch
         integer :: cpu_lost, gpu_lost, flip
         real(dp) :: t0, t1, t_cpu, t_gpu, maxz
+
+        if (isw_field_type /= BOOZER .or. integmode /= EXPL_IMPL_EULER .or. swcoll .or. &
+            len_trim(wall_input) > 0 .or. class_plot .or. fast_class .or. generate_start_only) then
+            error stop "simple_main.trace_compare_gpu: SIMPLE_GPU_BENCH requires Boozer, " // &
+                       "EXPL_IMPL_EULER, and no wall/collision/classifier options"
+        end if
+
+        call sync_boozer_state
 
         allocate (si_cpu(ntestpart), si_gpu(ntestpart))
         allocate (f_cpu(ntestpart), f_gpu(ntestpart))
@@ -483,8 +493,6 @@ contains
             si_gpu(i) = si_cpu(i)
             f_gpu(i) = f_cpu(i)
         end do
-
-        call sync_boozer_gpu_params
 
         ! CPU reference (OpenMP over particles)
         t0 = omp_get_wtime()

--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -466,6 +466,7 @@ contains
         real(dp), allocatable :: cpu_zend(:, :), gpu_zend(:, :)
         real(dp) :: z(5)
         integer :: i, it, ktau, ierr, loss_mismatch
+        integer :: cpu_lost, gpu_lost, flip
         real(dp) :: t0, t1, t_cpu, t_gpu, maxz
 
         allocate (si_cpu(ntestpart), si_gpu(ntestpart))
@@ -517,15 +518,24 @@ contains
         ! Compare
         maxz = 0d0
         loss_mismatch = 0
+        cpu_lost = 0
+        gpu_lost = 0
+        flip = 0
         do i = 1, ntestpart
             maxz = max(maxz, maxval(dabs(cpu_zend(:, i) - gpu_zend(:, i))))
             if (cpu_loss(i) /= gpu_loss(i)) loss_mismatch = loss_mismatch + 1
+            if (cpu_loss(i) < ntimstep) cpu_lost = cpu_lost + 1
+            if (gpu_loss(i) < ntimstep) gpu_lost = gpu_lost + 1
+            if ((cpu_loss(i) < ntimstep) .neqv. (gpu_loss(i) < ntimstep)) flip = flip + 1
         end do
 
         print *, '==================== GPU vs CPU tracing ===================='
         print '(a,i0,a,i0)', ' particles = ', ntestpart, '   timesteps = ', ntimstep
         print '(a,es12.4)', ' max |z_cpu - z_gpu| (final state) = ', maxz
         print '(a,i0,a,i0)', ' loss-step mismatches = ', loss_mismatch, ' / ', ntestpart
+        print '(a,i0,a,i0,a,f7.4)', ' CPU lost = ', cpu_lost, ' / ', ntestpart, '   confined frac = ', 1d0 - real(cpu_lost,dp)/real(ntestpart,dp)
+        print '(a,i0,a,i0,a,f7.4)', ' GPU lost = ', gpu_lost, ' / ', ntestpart, '   confined frac = ', 1d0 - real(gpu_lost,dp)/real(ntestpart,dp)
+        print '(a,i0,a,i0)', ' lost<->confined flips = ', flip, ' / ', ntestpart
         print '(a,f10.4,a)', ' CPU time (OpenMP) = ', t_cpu, ' s'
         print '(a,f10.4,a)', ' GPU time          = ', t_gpu, ' s'
         if (t_gpu > 0d0) print '(a,f8.2,a)', ' speedup (CPU/GPU) = ', t_cpu/t_gpu, ' x'

--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -533,8 +533,10 @@ contains
         print '(a,i0,a,i0)', ' particles = ', ntestpart, '   timesteps = ', ntimstep
         print '(a,es12.4)', ' max |z_cpu - z_gpu| (final state) = ', maxz
         print '(a,i0,a,i0)', ' loss-step mismatches = ', loss_mismatch, ' / ', ntestpart
-        print '(a,i0,a,i0,a,f7.4)', ' CPU lost = ', cpu_lost, ' / ', ntestpart, '   confined frac = ', 1d0 - real(cpu_lost,dp)/real(ntestpart,dp)
-        print '(a,i0,a,i0,a,f7.4)', ' GPU lost = ', gpu_lost, ' / ', ntestpart, '   confined frac = ', 1d0 - real(gpu_lost,dp)/real(ntestpart,dp)
+        print '(a,i0,a,i0,a,f7.4)', ' CPU lost = ', cpu_lost, ' / ', ntestpart, &
+            '   confined frac = ', 1d0 - real(cpu_lost, dp)/real(ntestpart, dp)
+        print '(a,i0,a,i0,a,f7.4)', ' GPU lost = ', gpu_lost, ' / ', ntestpart, &
+            '   confined frac = ', 1d0 - real(gpu_lost, dp)/real(ntestpart, dp)
         print '(a,i0,a,i0)', ' lost<->confined flips = ', flip, ' / ', ntestpart
         print '(a,f10.4,a)', ' CPU time (OpenMP) = ', t_cpu, ' s'
         print '(a,f10.4,a)', ' GPU time          = ', t_gpu, ' s'

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -594,6 +594,18 @@ set_tests_properties(test_batch_splines PROPERTIES
     TIMEOUT 60
 )
 
+# GPU device-evaluation test: batch spline eval inside an OpenACC kernel must
+# match the host result. Only meaningful when OpenACC offload is enabled.
+if(SIMPLE_ENABLE_OPENACC)
+    add_executable(test_batch_splines_device.x test_batch_splines_device.f90)
+    target_link_libraries(test_batch_splines_device.x simple testing_utils)
+    add_test(NAME test_batch_splines_device COMMAND test_batch_splines_device.x)
+    set_tests_properties(test_batch_splines_device PROPERTIES
+        LABELS "unit;gpu"
+        TIMEOUT 120
+    )
+endif()
+
 # Macrostep log grid tests (issue: performance regression with log grid)
 add_executable(test_macrostep_log_grid.x test_macrostep_log_grid.f90)
 target_link_libraries(test_macrostep_log_grid.x simple)

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -606,6 +606,22 @@ if(SIMPLE_ENABLE_OPENACC)
     )
 endif()
 
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_gpu_orbit_bench.in
+    ${CMAKE_CURRENT_BINARY_DIR}/test_gpu_orbit_bench.in
+    COPYONLY)
+
+add_test(NAME test_gpu_orbit_bench
+    COMMAND ${CMAKE_COMMAND} -E env
+        SIMPLE_GPU_BENCH=1
+        $<TARGET_FILE:simple.x>
+        test_gpu_orbit_bench.in
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+set_tests_properties(test_gpu_orbit_bench PROPERTIES
+    LABELS "unit"
+    PASS_REGULAR_EXPRESSION "loss-step mismatches = *0"
+    TIMEOUT 120)
+
 # Macrostep log grid tests (issue: performance regression with log grid)
 add_executable(test_macrostep_log_grid.x test_macrostep_log_grid.f90)
 target_link_libraries(test_macrostep_log_grid.x simple)

--- a/test/tests/test_batch_splines_device.f90
+++ b/test/tests/test_batch_splines_device.f90
@@ -1,0 +1,93 @@
+program test_batch_splines_device
+    ! Verify that the batch spline single-point evaluators produce identical
+    ! results whether called on the host or from inside an OpenACC device
+    ! kernel (acc routine seq). This is the leaf of the per-particle GPU orbit
+    ! tracing kernel: the field evaluation must run correctly on the device,
+    ! reading the managed-memory coefficient array.
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use interpolate, only: BatchSplineData3D, construct_batch_splines_3d, &
+        evaluate_batch_splines_3d_der2
+    implicit none
+
+    integer, parameter :: n1 = 17, n2 = 25, n3 = 25, nq = 2, npt = 4096
+    type(BatchSplineData3D) :: spl
+    real(dp) :: xmin(3), xmax(3), field(n1, n2, n3, nq)
+    integer :: order(3)
+    logical :: periodic(3)
+    real(dp) :: xpts(3, npt)
+    real(dp) :: y_h(nq, npt), dy_h(3, nq, npt), d2y_h(6, nq, npt)
+    real(dp) :: y_d(nq, npt), dy_d(3, nq, npt), d2y_d(6, nq, npt)
+    real(dp) :: yt(nq), dyt(3, nq), d2yt(6, nq)
+    real(dp) :: maxdiff, dd
+    integer :: i, j, k, q, ip
+
+    xmin = [0.0_dp, 0.0_dp, 0.0_dp]
+    xmax = [1.0_dp, 6.283185307179586_dp, 6.283185307179586_dp]
+    order = [5, 5, 5]
+    periodic = [.false., .true., .true.]
+
+    ! Smooth synthetic field
+    do q = 1, nq
+        do k = 1, n3
+            do j = 1, n2
+                do i = 1, n1
+                    associate (r => xmin(1) + (xmax(1) - xmin(1))*(i - 1)/real(n1 - 1, dp), &
+                               th => (j - 1)*xmax(2)/real(n2, dp), &
+                               ph => (k - 1)*xmax(3)/real(n3, dp))
+                        field(i, j, k, q) = real(q, dp) + cos(th)*sin(ph)*(1.0_dp + r*r) &
+                                            + 0.3_dp*r*cos(2.0_dp*th)
+                    end associate
+                end do
+            end do
+        end do
+    end do
+
+    call construct_batch_splines_3d(xmin, xmax, field, order, periodic, spl)
+
+    ! Evaluation points inside the domain (avoid exact edges in r)
+    do ip = 1, npt
+        xpts(1, ip) = 0.02_dp + 0.96_dp*real(modulo(ip*7, 1000), dp)/1000.0_dp
+        xpts(2, ip) = xmax(2)*real(modulo(ip*13, 1000), dp)/1000.0_dp
+        xpts(3, ip) = xmax(3)*real(modulo(ip*29, 1000), dp)/1000.0_dp
+    end do
+
+    ! Host reference
+    do ip = 1, npt
+        call evaluate_batch_splines_3d_der2(spl, xpts(:, ip), yt, dyt, d2yt)
+        y_h(:, ip) = yt
+        dy_h(:, :, ip) = dyt
+        d2y_h(:, :, ip) = d2yt
+    end do
+
+    ! Device evaluation: one point per gang/vector lane
+    !$acc parallel loop gang vector private(yt, dyt, d2yt) &
+    !$acc&   copyin(xpts) copyout(y_d, dy_d, d2y_d)
+    do ip = 1, npt
+        call evaluate_batch_splines_3d_der2(spl, xpts(:, ip), yt, dyt, d2yt)
+        y_d(:, ip) = yt
+        dy_d(:, :, ip) = dyt
+        d2y_d(:, :, ip) = d2yt
+    end do
+
+    maxdiff = 0.0_dp
+    do ip = 1, npt
+        do q = 1, nq
+            dd = abs(y_h(q, ip) - y_d(q, ip));        maxdiff = max(maxdiff, dd)
+            do k = 1, 3
+                dd = abs(dy_h(k, q, ip) - dy_d(k, q, ip)); maxdiff = max(maxdiff, dd)
+            end do
+            do k = 1, 6
+                dd = abs(d2y_h(k, q, ip) - d2y_d(k, q, ip)); maxdiff = max(maxdiff, dd)
+            end do
+        end do
+    end do
+
+    print '(a, i0, a)', 'Device batch eval over ', npt, ' points'
+    print '(a, es12.4)', 'max |host - device| (value+der+der2) = ', maxdiff
+
+    if (maxdiff > 1.0e-10_dp) then
+        print *, 'FAILED: device evaluation differs from host'
+        error stop 1
+    end if
+    print *, 'PASSED: device batch spline evaluation matches host'
+end program test_batch_splines_device

--- a/test/tests/test_gpu_orbit_bench.in
+++ b/test/tests/test_gpu_orbit_bench.in
@@ -1,0 +1,9 @@
+&config
+trace_time = 1d-4
+ntimstep = 51
+ntestpart = 8
+sbeg = 0.3d0
+netcdffile = 'wout.nc'
+isw_field_type = 2
+integmode = 1
+/


### PR DESCRIPTION
## Risk tier

- [ ] T0: docs, comments, small build metadata
- [ ] T1: pure refactor, no behavior change intended
- [ ] T2: local numerical logic
- [ ] T3: physics, output behavior, coordinate convention
- [x] T4: parallelism, GPU, dependency, CI, or security-sensitive build logic

## Correctness contract

### Intended behavior change

Add OpenACC offload for the default hot path: Boozer field (`isw_field_type=2`) with explicit-implicit symplectic Euler. OpenACC remains CMake-default `OFF`; GPU benchmarking is opt-in with `SIMPLE_GPU_BENCH=1`.

### Behavior that must not change

CPU builds with `SIMPLE_ENABLE_OPENACC=OFF` keep the existing host tracing path. Other field and integrator combinations continue to use CPU tracing. The deterministic CPU Boozer path must keep passing its existing tests.

### Coordinate / unit conventions

Unchanged. The offloaded path uses the same Boozer canonical coordinates and normalized phase-space state as the CPU symplectic integrator.

### Numerical invariants

Short GPU/CPU benchmark runs must agree on final state within the recorded tolerance and have zero loss-step mismatches for the accepted short-run case. Long physical runs compare loss fractions statistically because chaotic divergence makes per-particle loss steps unsuitable.

## Tests added

- unit: `test_batch_splines_device` when OpenACC is enabled
- integration: GPU/CPU benchmark path via `SIMPLE_GPU_BENCH=1`
- system: local NVHPC/OpenACC runs recorded below
- golden record: CPU path unchanged in prior local check

## Golden-record impact

- [x] unchanged for CPU path
- [ ] changed

## Failure modes considered

- Device-incompatible procedure pointers and host-only guards in the offloaded path.
- NVHPC unified/managed/separate memory-model differences.
- CPU regression when OpenACC is disabled.
- Long-run chaotic divergence causing false per-particle mismatch failures.
- GPU underutilization at low particle counts.

## Manual validation

OpenACC is default-off in CMake. The rebased branch passed a CPU-path Boozer test slice with OpenACC disabled. Existing local GPU evidence from the branch shows short-run CPU/GPU agreement and long-run statistical agreement; GPU CI is still absent, so this should remain a T4 manual-review PR.

## Verification

```text
$HOME/code/prompts/scripts/check-writing-slop.py DOC/gpu-openacc.md src/simple_gpu.f90 test/tests/test_batch_splines_device.f90
PASS: no writing-slop candidates at threshold medium

make test-nopy TEST=test_boozer VERBOSE=1
...
1/4 Test #19: generate_test_boozer_chartmap_data ...   Passed    0.06 sec
2/4 Test #20: test_boozer_chartmap .................   Passed    0.14 sec
3/4 Test #23: test_boozer_chartmap_roundtrip .......   Passed    5.72 sec
4/4 Test #63: test_boozer_spline_derivatives .......   Passed    1.77 sec
100% tests passed, 0 tests failed out of 4
```

Prior GPU evidence from this branch:

```text
max |z_cpu - z_gpu| (final state) =   4.2017E-09
loss-step mismatches = 0 / 16384
```

Managed-memory short run on RTX PRO 6000 Blackwell, nvfortran 26.3:

```text
particles  CPU       GPU       max|z_cpu-z_gpu|  loss mismatches
1024       1.20 s    6.83 s    5.8e-11           0
4096       5.17 s    6.82 s    1.0e-9            0
16384      21.23 s   6.60 s    3.8e-9            0
65536      86.78 s   28.61 s   5.9e-9            0
```
