### PR TITLE
build(cgal): use CGAL_DISABLE_GMP, drop the GMP dependency

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,38 +61,15 @@
 
     if(SIMPLE_ENABLE_CGAL)
         add_library(stl_wall_cgal STATIC wall/stl_wall_cgal.cpp)
-        # CGAL 5.x is header-only, just need include paths for CGAL and Boost
         target_include_directories(stl_wall_cgal PUBLIC ${CGAL_INCLUDE_DIR})
 
-        # CGAL requires GMP for exact arithmetic - try system first, then build
-        find_library(GMP_LIBRARY gmp)
-        find_path(GMP_INCLUDE_DIR gmp.h)
-        if(GMP_LIBRARY AND GMP_INCLUDE_DIR)
-            message(STATUS "GMP found (system): ${GMP_LIBRARY}")
-            target_include_directories(stl_wall_cgal PUBLIC ${GMP_INCLUDE_DIR})
-            target_link_libraries(stl_wall_cgal PUBLIC Boost::headers ${GMP_LIBRARY})
-        else()
-            message(STATUS "GMP not found on system, building from source...")
-            include(ExternalProject)
-            set(GMP_VERSION "6.3.0")
-            set(GMP_INSTALL_DIR "${CMAKE_BINARY_DIR}/gmp-install")
-            ExternalProject_Add(gmp_external
-                URL https://ftp.gnu.org/gnu/gmp/gmp-${GMP_VERSION}.tar.xz
-                URL_HASH SHA256=a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898
-                DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-                PREFIX ${CMAKE_BINARY_DIR}/gmp
-                CONFIGURE_COMMAND <SOURCE_DIR>/configure
-                    --prefix=${GMP_INSTALL_DIR}
-                    --enable-cxx
-                    --with-pic
-                BUILD_COMMAND make -j${CMAKE_BUILD_PARALLEL_LEVEL}
-                INSTALL_COMMAND make install
-                BUILD_BYPRODUCTS ${GMP_INSTALL_DIR}/lib/libgmp.a
-            )
-            add_dependencies(stl_wall_cgal gmp_external)
-            target_include_directories(stl_wall_cgal PUBLIC ${GMP_INSTALL_DIR}/include)
-            target_link_libraries(stl_wall_cgal PUBLIC Boost::headers ${GMP_INSTALL_DIR}/lib/libgmp.a)
-        endif()
+        # CGAL_DISABLE_GMP makes CGAL's bundled CORE use Boost.Multiprecision
+        # cpp_int instead of GMP-backed mpz_int, so the wall feature needs only
+        # Boost headers. Without it, CORE pulls in GMP (CORE::BigInt is
+        # boost::multiprecision::mpz_int) and the build fails wherever gmp.h is
+        # absent, which is most HPC nodes (only libgmp.so, no -dev package).
+        target_compile_definitions(stl_wall_cgal PUBLIC CGAL_DISABLE_GMP)
+        target_link_libraries(stl_wall_cgal PUBLIC Boost::headers)
     endif()
 
 # Add diagnostic sources


### PR DESCRIPTION
## Summary

Enabling `SIMPLE_ENABLE_CGAL` pulled in GMP and broke the build on machines
without GMP development headers (most HPC nodes ship `libgmp.so` but no
`gmp.h`). CGAL 6.0.1's bundled CORE defines `CORE::BigInt` as
`boost::multiprecision::mpz_int`, which requires `gmp.h`. The previous CMake
tried the system GMP, then fell back to building GMP 6.3.0 from source via an
`ExternalProject`. Both paths are fragile, and the CORE + GMP + Boost.Multiprecision
combination fails to compile regardless (`CORE::BigInt does not name a type`,
`mpz_int in namespace boost::multiprecision does not name a type`), which is
what kills the gfortran build whenever a stale cache leaves `SIMPLE_ENABLE_CGAL=ON`.

`CGAL_DISABLE_GMP` switches CORE to `boost::multiprecision::cpp_int`, which is
header-only and always available with Boost. The wall feature then needs only
Boost headers, no GMP at all.

- Define `CGAL_DISABLE_GMP` on the `stl_wall_cgal` target.
- Remove the system-GMP probe and the GMP-from-source `ExternalProject`.

## Verification

Before, compiling the CGAL wall TU without `gmp.h` on the include path fails:

```
$ g++ -std=c++17 -DSIMPLE_ENABLE_CGAL -I<cgal>/include -c src/wall/stl_wall_cgal.cpp
CGAL/CORE_arithmetic_kernel.h:44:19: error: 'BigInt' in namespace 'CORE' does not name a type
... (771 errors, CORE needs GMP)
```

After (this change adds `-DCGAL_DISABLE_GMP`):

```
$ g++ -std=c++17 -DSIMPLE_ENABLE_CGAL -DCGAL_DISABLE_GMP -I<cgal>/include -c src/wall/stl_wall_cgal.cpp
exit 0   (0 errors)
```

g++ 12.2, CGAL 6.0.1, no GMP on the system. The wall feature builds with Boost
headers only.
