### PR TITLE
Integrate coil clearance with port optimizer

### DIFF
--- a/python/pysimple/engineering.py
+++ b/python/pysimple/engineering.py
@@ -77,6 +77,13 @@ from typing import Optional
 
 import numpy as np
 
+from pysimple.coil_clearance import (
+    CoilClearanceConstraint,
+    CoilSegments,
+    WallSurface,
+    clearance_map_on_heatmap_grid,
+)
+
 try:
     import netCDF4 as nc
     HAS_NETCDF4 = True
@@ -736,6 +743,7 @@ class PortOptimizer:
         self._ports: list[dict] = []
         self._exclusion_zones: list[tuple[float, float, float, float]] = []
         self._max_flux_constraint: Optional[float] = None
+        self._coil_clearance: Optional[CoilClearanceConstraint] = None
 
     def add_port(
         self,
@@ -780,6 +788,37 @@ class PortOptimizer:
         self._max_flux_constraint = max_flux
         return self
 
+    def set_coil_clearance_constraint(
+        self,
+        coil_file: str | Path,
+        *,
+        chartmap_file: str | Path,
+        min_clearance_m: float,
+        use_zero_current_separators: bool = True,
+        jump_factor: float = 25.0,
+    ) -> "PortOptimizer":
+        """
+        Enforce a minimum distance from ports to coils (geometric feasibility).
+
+        This constraint requires a chartmap file to map (theta, zeta) port
+        locations to physical-space coordinates on the wall.
+        """
+        if min_clearance_m <= 0.0:
+            raise ValueError("min_clearance_m must be positive")
+
+        wall = WallSurface.from_chartmap(chartmap_file)
+        coils = CoilSegments.from_file(
+            coil_file,
+            use_zero_current_separators=use_zero_current_separators,
+            jump_factor=jump_factor,
+        )
+        self._coil_clearance = CoilClearanceConstraint(
+            wall=wall,
+            coils=coils,
+            min_clearance_m=float(min_clearance_m),
+        )
+        return self
+
     def _objective(self, x: np.ndarray) -> float:
         """Objective: minimize total flux on all ports, penalize constraints."""
         total = 0.0
@@ -812,6 +851,9 @@ class PortOptimizer:
             # Penalty for port overlapping exclusion zones (check all corners + center)
             if self._port_overlaps_exclusion(theta_c, zeta_c, theta_w, zeta_w):
                 penalty += 1e6
+            if self._coil_clearance is not None:
+                if self._coil_clearance.port_violates(theta_c, zeta_c, theta_w, zeta_w):
+                    penalty += 1e6
 
         # Penalty for exceeding max flux constraint
         if self._max_flux_constraint is not None:
@@ -1040,6 +1082,69 @@ def plot_heat_flux_2d(
                 fontsize=10,
             )
 
+    return ax
+
+
+def plot_heat_flux_with_coil_clearance(
+    heat_map: WallHeatMap,
+    *,
+    coil_file: str | Path,
+    chartmap_file: str | Path,
+    min_clearance_m: float,
+    ax=None,
+    cmap: str = "hot",
+    vmax: Optional[float] = None,
+    show_colorbar: bool = True,
+    ports: Optional[list[Port]] = None,
+    forbidden_alpha: float = 0.35,
+):
+    """
+    Plot heat flux with an overlaid forbidden region based on coil clearance.
+
+    The forbidden region is where the minimum distance from the wall to any
+    coil segment is less than min_clearance_m.
+    """
+    import matplotlib.pyplot as plt
+
+    if min_clearance_m <= 0.0:
+        raise ValueError("min_clearance_m must be positive")
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=(12, 6))
+
+    ax = plot_heat_flux_2d(
+        heat_map,
+        ax=ax,
+        cmap=cmap,
+        vmax=vmax,
+        show_colorbar=show_colorbar,
+        ports=ports,
+    )
+
+    wall = WallSurface.from_chartmap(chartmap_file)
+    coils = CoilSegments.from_file(coil_file)
+    clearance = clearance_map_on_heatmap_grid(
+        wall,
+        coils,
+        heat_map.theta_centers,
+        heat_map.zeta_centers,
+    )
+    forbidden = clearance < min_clearance_m
+
+    forbidden_grid = forbidden.astype(float)
+    ax.pcolormesh(
+        np.degrees(heat_map.zeta_edges),
+        np.degrees(heat_map.theta_edges),
+        forbidden_grid,
+        cmap="Greys",
+        vmin=0.0,
+        vmax=1.0,
+        shading="flat",
+        alpha=forbidden_alpha,
+    )
+    ax.set_title(
+        f"Wall Heat Flux + Coil Clearance (d > {min_clearance_m:.3f} m)"
+    )
     return ax
 
 

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -114,7 +114,7 @@ add_test(NAME test_engineering
     COMMAND ${Python_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/test_engineering.py -v
 )
 set_tests_properties(test_engineering PROPERTIES
-    ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}/python"
+    ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}/python;SIMPLE_TEST_ARTIFACTS_DIR=${CMAKE_CURRENT_BINARY_DIR}/test_artifacts"
     LABELS "python;engineering"
     TIMEOUT 300
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
## Risk tier

- [ ] T0: docs, comments, small build metadata
- [ ] T1: pure refactor, no behavior change intended
- [x] T2: local numerical logic
- [ ] T3: physics, output behavior, coordinate convention
- [ ] T4: parallelism, GPU, dependency, CI, or security-sensitive build logic

## Correctness contract

### Intended behavior change

Wire the coil-clearance geometry helpers from #364 into `PortOptimizer`. Candidate ports that violate the minimum coil clearance receive the same large penalty style used by the existing exclusion-zone constraint. Add a heat-flux plotting helper that overlays the forbidden clearance region.

### Behavior that must not change

Existing heat-map loading, area calculations, port optimization without a coil-clearance constraint, exclusion zones, and max-flux constraints keep their behavior.

### Coordinate / unit conventions

Port centers and widths use heat-map `theta`/`zeta` radians. The chartmap wall maps those angles to meters before distance checks. `min_clearance_m` is in meters.

### Numerical invariants

A mock coil placed near the outboard midplane penalizes ports near `zeta=0` and leaves a port at `zeta=pi` lower-cost. Plot artifact generation must produce a nonempty image with the forbidden region overlay.

## Tests added

- unit: optimizer penalty and plot checks in `test_engineering.py`
- integration: `test_engineering` CTest target uses `SIMPLE_TEST_ARTIFACTS_DIR`
- system: none
- golden record: unchanged

## Golden-record impact

- [x] unchanged
- [ ] changed

## Failure modes considered

- Negative or zero clearance values.
- Constraint accidentally affecting optimizers that do not call `set_coil_clearance_constraint`.
- Plot artifact paths depending on the current working directory.

## Manual validation

Focused engineering CTest target passed.

## Verification

```text
$HOME/code/prompts/scripts/check-writing-slop.py python/pysimple/engineering.py test/python/test_engineering.py test/python/CMakeLists.txt
PASS: no writing-slop candidates at threshold medium

make test TEST=test_engineering VERBOSE=1
...
test/python/test_engineering.py::TestCoilClearance::test_coil_clearance_penalizes_forbidden_ports PASSED [ 75%]
test/python/test_engineering.py::TestCoilClearance::test_plot_heat_flux_with_coil_clearance_writes_artifact PASSED [ 77%]
============================== 40 passed in 2.63s ==============================
1/1 Test #90: test_engineering .................   Passed    3.02 sec
100% tests passed, 0 tests failed out of 1
```
