### PR TITLE
Allow external libneo_ref trigger in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
+    inputs:
+      libneo_ref:
+        description: libneo branch, tag or commit to build against
+        required: false
+        default: ''
 
 permissions:
   contents: write
@@ -15,7 +20,7 @@ permissions:
   actions: read
 
 env:
-  LIBNEO_BRANCH: ${{ github.head_ref || github.ref_name }}
+  LIBNEO_BRANCH: ${{ inputs.libneo_ref || github.head_ref || github.ref_name }}
 
 jobs:
   test:
@@ -23,6 +28,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
 
     steps:
@@ -102,6 +108,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
 
     steps:


### PR DESCRIPTION
Lets libneo's release gate build SIMPLE against a candidate ref. Standalone: SIMPLE's resolver already reads `LIBNEO_BRANCH` on main.

`main.yml` takes a `libneo_ref` dispatch input. `LIBNEO_BRANCH` now resolves to `inputs.libneo_ref || github.head_ref || github.ref_name`: a dispatched ref wins, otherwise the existing follow-branch default holds. The full suite runs on dispatch.