### PR TITLE
Drop legacy chartmap file support; fix chartmap example and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,6 @@ without requiring them at runtime.
 
 Key differences from VMEC mode:
 - Both `field_input` and `coord_input` reference the same chartmap NetCDF file
-- `startmode = 2` means particle coordinates are in chartmap Boozer space
 - No VMEC file is needed at runtime
 
 See `DOC/coordinates-and-fields.md` section 8.2.1 for full details on coordinate conventions and the chartmap format.

--- a/examples/simple_chartmap.in
+++ b/examples/simple_chartmap.in
@@ -5,7 +5,6 @@ ntestpart = 128          ! number of test particles
 field_input = 'boozer_chartmap.nc'  ! Boozer chartmap NetCDF file for field data
 coord_input = 'boozer_chartmap.nc'  ! same file for reference coordinates
 isw_field_type = 2       ! Boozer field type
-startmode = 2            ! particle coordinates given in chartmap Boozer space
 deterministic = .True.   ! fixed random seed for reproducibility
 integmode = 1            ! Euler symplectic integrator
 multharm = 5             ! angular grid factor

--- a/src/boozer_converter.F90
+++ b/src/boozer_converter.F90
@@ -994,7 +994,7 @@ contains
         ! Set global parameters used by splint_boozer_coord
         torflux = flux_scale*d%torflux
         nper = d%nfp
-        if (d%has_rmajor) rmajor = d%rmajor*rz_scale
+        rmajor = d%rmajor*rz_scale
 
         ! Set boozer_coordinates_mod parameters
         ns_s_B = 5

--- a/src/field/boozer_chartmap_io.f90
+++ b/src/field/boozer_chartmap_io.f90
@@ -26,7 +26,6 @@ module boozer_chartmap_io
         integer :: nfp = 1
         real(dp) :: torflux = 0.0_dp
         real(dp) :: rmajor = 0.0_dp
-        logical :: has_rmajor = .false.
         real(dp) :: rho_min = 0.0_dp
         real(dp) :: rho_max = 0.0_dp
         real(dp) :: h_s = 0.0_dp     !< uniform rho step
@@ -82,9 +81,7 @@ contains
                     "inq_var num_field_periods")
         call check(nf90_get_var(ncid, varid, d%nfp), "get num_field_periods")
 
-        ! rmajor is optional (older files lack it).
-        status = nf90_get_att(ncid, nf90_global, "rmajor", d%rmajor)
-        d%has_rmajor = (status == nf90_noerr)
+        call check(nf90_get_att(ncid, nf90_global, "rmajor", d%rmajor), "att rmajor")
 
         ! 1D profiles on the rho grid.
         allocate (d%A_phi(n_rho), d%B_theta(n_rho), d%B_phi(n_rho))
@@ -95,19 +92,13 @@ contains
         call check(nf90_inq_varid(ncid, "B_phi", varid), "inq_var B_phi")
         call check(nf90_get_var(ncid, varid, d%B_phi), "get B_phi")
 
-        ! Bmod on the endpoint-included field grid; fall back to the geometry
-        ! grid for legacy files that share dimensions.
-        status = nf90_inq_dimid(ncid, "theta_field", dimid)
-        if (status == nf90_noerr) then
-            call check(nf90_inquire_dimension(ncid, dimid, len=d%n_theta), &
-                        "len theta_field")
-            call check(nf90_inq_dimid(ncid, "zeta_field", dimid), "inq_dim zeta_field")
-            call check(nf90_inquire_dimension(ncid, dimid, len=d%n_phi), &
-                        "len zeta_field")
-        else
-            d%n_theta = n_theta_geom
-            d%n_phi = n_phi_geom
-        end if
+        ! Bmod lives on the endpoint-included field grid.
+        call check(nf90_inq_dimid(ncid, "theta_field", dimid), "inq_dim theta_field")
+        call check(nf90_inquire_dimension(ncid, dimid, len=d%n_theta), &
+                    "len theta_field")
+        call check(nf90_inq_dimid(ncid, "zeta_field", dimid), "inq_dim zeta_field")
+        call check(nf90_inquire_dimension(ncid, dimid, len=d%n_phi), &
+                    "len zeta_field")
 
         allocate (d%Bmod(n_rho, d%n_theta, d%n_phi))
         call check(nf90_inq_varid(ncid, "Bmod", varid), "inq_var Bmod")

--- a/src/field/field_boozer_chartmap.f90
+++ b/src/field/field_boozer_chartmap.f90
@@ -140,7 +140,7 @@ contains
         ! Restore equilibrium periods/major radius so stevvo and params_init
         ! produce the correct dphi/dtaumin/fper for a VMEC-free chartmap run.
         nper = d%nfp
-        if (d%has_rmajor) rmajor = d%rmajor*rz_scale
+        rmajor = d%rmajor*rz_scale
 
         ! Set up coordinate system from the same chartmap file
         call make_chartmap_coordinate_system(cs, filename)

--- a/test/tests/generate_test_boozer_chartmap.c
+++ b/test/tests/generate_test_boozer_chartmap.c
@@ -21,7 +21,9 @@ int main(int argc, char **argv)
         nfp = 2,
         n_rho = 17,
         n_theta = 33,
-        n_zeta = 33
+        n_zeta = 33,
+        n_theta_field = n_theta + 1,
+        n_zeta_field = n_zeta + 1
     };
 
     const double b0 = 2.0e4;
@@ -31,6 +33,7 @@ int main(int argc, char **argv)
     const double twopi = 2.0 * acos(-1.0);
     const double epsilon = a / r0;
     const double torflux = 0.5 * b0 * a * a;
+    const double rmajor = r0;
     const char *filename = argc > 1 ? argv[1] : "test_boozer_chartmap.nc";
 
     double rho[n_rho];
@@ -44,15 +47,16 @@ int main(int argc, char **argv)
     double *z = NULL;
     double *bmod = NULL;
     int ncid;
-    int dim_rho, dim_theta, dim_zeta;
+    int dim_rho, dim_theta, dim_zeta, dim_theta_field, dim_zeta_field;
     int dims_3d[3];
+    int dims_3d_field[3];
     int var_rho, var_theta, var_zeta, var_x, var_y, var_z, var_aphi, var_btheta;
     int var_bphi, var_bmod, var_nfp;
 
     x = malloc((size_t)n_rho * n_theta * n_zeta * sizeof(*x));
     y = malloc((size_t)n_rho * n_theta * n_zeta * sizeof(*y));
     z = malloc((size_t)n_rho * n_theta * n_zeta * sizeof(*z));
-    bmod = malloc((size_t)n_rho * n_theta * n_zeta * sizeof(*bmod));
+    bmod = malloc((size_t)n_rho * n_theta_field * n_zeta_field * sizeof(*bmod));
     if (x == NULL || y == NULL || z == NULL || bmod == NULL) {
         fprintf(stderr, "Allocation failure\n");
         free(x);
@@ -79,6 +83,7 @@ int main(int argc, char **argv)
         zeta[iz] = (twopi / (double)nfp) * (double)iz / (double)n_zeta;
     }
 
+    /* Geometry (x, y, z) on the endpoint-excluded geometry grid. */
     for (int iz = 0; iz < n_zeta; ++iz) {
         const double zeta_val = zeta[iz];
         for (int it = 0; it < n_theta; ++it) {
@@ -94,6 +99,20 @@ int main(int argc, char **argv)
                 x[idx] = radius * cos(zeta_val);
                 y[idx] = radius * sin(zeta_val);
                 z[idx] = r_minor * sin_theta;
+            }
+        }
+    }
+
+    /* Bmod on the endpoint-included field grid (theta_field/zeta_field), which
+       spans the full 2*pi (poloidal) and 2*pi/nfp (toroidal) period. */
+    for (int iz = 0; iz < n_zeta_field; ++iz) {
+        for (int it = 0; it < n_theta_field; ++it) {
+            const double cos_theta = cos(twopi * (double)it / (double)n_theta);
+            for (int ir = 0; ir < n_rho; ++ir) {
+                const double rho_val = rho[ir];
+                const size_t idx =
+                    ((size_t)iz * n_theta_field + (size_t)it) * n_rho +
+                    (size_t)ir;
                 bmod[idx] = b0 / (1.0 + rho_val * epsilon * cos_theta);
             }
         }
@@ -103,10 +122,18 @@ int main(int argc, char **argv)
     CHECK_NC(nc_def_dim(ncid, "rho", n_rho, &dim_rho), "def dim rho");
     CHECK_NC(nc_def_dim(ncid, "theta", n_theta, &dim_theta), "def dim theta");
     CHECK_NC(nc_def_dim(ncid, "zeta", n_zeta, &dim_zeta), "def dim zeta");
+    CHECK_NC(nc_def_dim(ncid, "theta_field", n_theta_field, &dim_theta_field),
+             "def dim theta_field");
+    CHECK_NC(nc_def_dim(ncid, "zeta_field", n_zeta_field, &dim_zeta_field),
+             "def dim zeta_field");
 
     dims_3d[0] = dim_zeta;
     dims_3d[1] = dim_theta;
     dims_3d[2] = dim_rho;
+
+    dims_3d_field[0] = dim_zeta_field;
+    dims_3d_field[1] = dim_theta_field;
+    dims_3d_field[2] = dim_rho;
 
     CHECK_NC(nc_def_var(ncid, "rho", NC_DOUBLE, 1, &dim_rho, &var_rho), "def rho");
     CHECK_NC(nc_def_var(ncid, "theta", NC_DOUBLE, 1, &dim_theta, &var_theta), "def theta");
@@ -117,7 +144,8 @@ int main(int argc, char **argv)
     CHECK_NC(nc_def_var(ncid, "A_phi", NC_DOUBLE, 1, &dim_rho, &var_aphi), "def A_phi");
     CHECK_NC(nc_def_var(ncid, "B_theta", NC_DOUBLE, 1, &dim_rho, &var_btheta), "def B_theta");
     CHECK_NC(nc_def_var(ncid, "B_phi", NC_DOUBLE, 1, &dim_rho, &var_bphi), "def B_phi");
-    CHECK_NC(nc_def_var(ncid, "Bmod", NC_DOUBLE, 3, dims_3d, &var_bmod), "def Bmod");
+    CHECK_NC(nc_def_var(ncid, "Bmod", NC_DOUBLE, 3, dims_3d_field, &var_bmod),
+             "def Bmod");
     CHECK_NC(nc_def_var(ncid, "num_field_periods", NC_INT, 0, NULL, &var_nfp),
              "def num_field_periods");
 
@@ -136,6 +164,8 @@ int main(int argc, char **argv)
              "put boozer_field");
     CHECK_NC(nc_put_att_double(ncid, NC_GLOBAL, "torflux", NC_DOUBLE, 1, &torflux),
              "put torflux");
+    CHECK_NC(nc_put_att_double(ncid, NC_GLOBAL, "rmajor", NC_DOUBLE, 1, &rmajor),
+             "put rmajor");
 
     CHECK_NC(nc_enddef(ncid), "enddef");
 

--- a/test/tests/test_chartmap_aphi_abscissa.f90
+++ b/test/tests/test_chartmap_aphi_abscissa.f90
@@ -119,10 +119,6 @@ contains
         call expect_int(d%n_phi, n_zeta_field, 'n_phi field grid', n_fail)
         call expect_int(d%nfp, nfp, 'nfp', n_fail)
         call expect_real(d%torflux, torflux_val, 'torflux', n_fail)
-        if (.not. d%has_rmajor) then
-            print *, 'FAIL: missing rmajor attribute'
-            n_fail = n_fail + 1
-        end if
         call expect_real(d%rmajor, rmajor_val, 'rmajor', n_fail)
         call expect_real(real(d%n_theta - 1, dp)*d%h_theta, twopi, &
                          'poloidal period', n_fail)


### PR DESCRIPTION
Follow-up to the review comments on #334 (cc @Rykath — this is now changed).

## Risk tier

- [x] T2: local numerical logic

## Correctness contract

### Intended behavior change
- `read_boozer_chartmap` no longer supports legacy chartmap files. It now requires:
  - the `rmajor` global attribute (previously optional via a `has_rmajor` flag that defaulted `rmajor` to `0.0`), and
  - the endpoint-included `theta_field`/`zeta_field` Bmod grid (previously fell back to the geometry grid).
  GVEC-exported chartmaps (`tools/gvec_to_boozer_chartmap.py`) always write both, so current files are unaffected. Pre-converter legacy files now abort with a clear NetCDF error instead of being silently accepted with `rmajor = 0`.

### Behavior that must not change
- map2disc-based chartmaps: unaffected. They are read through the libneo coordinate reader (`make_chartmap_coordinate_system`), not `read_boozer_chartmap`.
- Field values, scaling, and the symplectic/Boozer paths for valid current-format files.

### Coordinate / unit conventions
- Unchanged. Bmod stays on the endpoint-included field grid spanning the full 2*pi (poloidal) and 2*pi/nfp (toroidal) period.

### Numerical invariants
- Unchanged.

## Tests added
- unit: updated `generate_test_boozer_chartmap.c` to emit the current format (`rmajor` + field-grid Bmod); updated `test_chartmap_aphi_abscissa.f90` (the `rmajor`-present check is now covered by mandatory read + value assertion).

## Golden-record impact
- [x] unchanged

## Failure modes considered
- Legacy file fed to the strict reader: now aborts with `NetCDF error at att rmajor` / `inq_dim theta_field`, by design.

## Manual validation
Also addresses the two doc comments on #334:
- `examples/simple_chartmap.in`: dropped the forced `startmode = 2` (the comment was incorrect, and it required a `start.dat`). The default `startmode = 1` samples the `sbeg` flux surface and needs no `start.dat`.
- `README.md`: removed the incorrect "`startmode = 2` means particle coordinates are in chartmap Boozer space" bullet (startmode is field-type independent).

## Verification

Failing before (strict reader against the old legacy-format test generator):

```
read_boozer_chartmap: NetCDF error at att rmajor: NetCDF: Attribute not found
ERROR STOP read_boozer_chartmap failed
0% tests passed, 1 tests failed out of 1
	 20 - test_boozer_chartmap (Failed)
```

Passing after (generator updated to current format):

```
1/5 Test #18: test_chartmap_aphi_abscissa ......   Passed
2/5 Test #20: test_boozer_chartmap .............   Passed
3/5 Test #21: test_chartmap_startmode1 .........   Passed
4/5 Test #22: test_chartmap_scaling ............   Passed
5/5 Test #23: test_boozer_chartmap_roundtrip ...   Passed
100% tests passed, 0 tests failed out of 5
```

Pre-existing, unrelated to this PR: the `*_map2disc` chartmap tests fail on a clean `main` in this environment because the optional libneo Python binding `_efit_to_boozer` is not built (`ModuleNotFoundError: No module named '_efit_to_boozer'`). This PR introduces no new failures relative to that baseline.