### PR TITLE
Add sub-minute smoke test tier for the libneo gate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,10 @@ on:
         description: libneo branch, tag or commit to build against
         required: false
         default: ''
+      full:
+        description: run the full suite (fast + slow + regression); nightly only
+        required: false
+        default: 'false'
 
 permissions:
   contents: write
@@ -81,18 +85,28 @@ jobs:
           make clean
           make build-deterministic
 
+      # libneo-gate dispatch (no full) runs only the sub-minute smoke set;
+      # push, PR and full=true run the complete suite below.
+      - name: Run Smoke Tests (libneo gate)
+        if: github.event_name == 'workflow_dispatch' && inputs.full != 'true'
+        run: make test-smoke
+
       - name: Run Fast Tests (Fortran only)
+        if: github.event_name != 'workflow_dispatch' || inputs.full == 'true'
         run: make test-fast
 
       - name: Install Python package
+        if: github.event_name != 'workflow_dispatch' || inputs.full == 'true'
         run: python -m pip install -e . --no-build-isolation -Ccmake.define.SIMPLE_DETERMINISTIC_FP=ON
 
       - name: Run Slow Tests (Python)
+        if: github.event_name != 'workflow_dispatch' || inputs.full == 'true'
         env:
           SIMPLE_GVEC_QA_CACHE_ROOT: ${{ github.workspace }}/.ci-data/gvec_qa_roundtrip
         run: make test-slow
 
       - name: Run Regression Tests (Golden Record)
+        if: github.event_name != 'workflow_dispatch' || inputs.full == 'true'
         run: make test-regression
 
       - name: Upload test results

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ NVHPC_HPCX := $(NVHPC_ROOT)/comm_libs/13.0/hpcx/hpcx-2.25.1/ompi
 NVHPC_BUILD_DIR := build_nvfortran
 NVHPC_ACC_BUILD_DIR := build_nvfortran_acc
 
-.PHONY: all configure reconfigure build build-deterministic build-deterministic-nopy test test-nopy test-fast test-slow test-regression test-all test-golden-main test-golden-tag test-golden install clean venv nvfortran nvfortran-test nvfortran-test-nopy nvfortran-configure nvfortran-clean
+.PHONY: all configure reconfigure build build-deterministic build-deterministic-nopy test test-nopy test-fast test-smoke test-slow test-regression test-all test-golden-main test-golden-tag test-golden install clean venv nvfortran nvfortran-test nvfortran-test-nopy nvfortran-configure nvfortran-clean
 .PHONY: nvfortran-acc nvfortran-acc-test nvfortran-acc-test-nopy nvfortran-acc-configure nvfortran-acc-clean
 .PHONY: gvec-qa-cache-fetch gvec-qa-cache-build gvec-qa-cache-sync-data gvec-qa-cache-refresh-data
 .PHONY: figure8-data-fetch
@@ -52,6 +52,10 @@ test-nopy: build-deterministic
 # Run only fast tests (exclude slow and regression tests)
 test-fast: build-deterministic
 	$(CTEST_CMD) -LE "slow|regression|performance|scalability"
+
+# Sub-minute libneo reverse-dependency gate set.
+test-smoke: build-deterministic
+	$(CTEST_CMD) -L smoke
 
 # Run only slow tests
 test-slow: build-deterministic

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -504,6 +504,14 @@ add_executable(test_field_base.x test_field_base.f90)
 target_link_libraries(test_field_base.x simple)
 add_test(NAME test_field_base COMMAND test_field_base.x)
 
+# Sub-second base-interface tests for the libneo reverse-dependency gate
+# (ctest -L smoke).
+set_property(TEST
+    test_lapack_interfaces
+    test_orbit_symplectic_base
+    test_field_base
+    APPEND PROPERTY LABELS smoke)
+
 add_executable(test_coordinates_simple.x test_coordinates_simple.f90)
 target_link_libraries(test_coordinates_simple.x simple)
 add_test(NAME test_coordinates_simple COMMAND test_coordinates_simple.x)

--- a/test/tests/magfie/CMakeLists.txt
+++ b/test/tests/magfie/CMakeLists.txt
@@ -49,6 +49,14 @@ add_test(NAME test_hctr_from_metric_vmec
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..
 )
 
+# Sub-second VMEC-coordinate tests that exercise libneo directly; the libneo
+# reverse-dependency gate runs this "smoke" set (ctest -L smoke).
+set_property(TEST
+    test_magfie_refcoords_vmec
+    test_jacobian_conventions_vmec
+    test_hctr_from_metric_vmec
+    APPEND PROPERTY LABELS smoke)
+
 add_test(NAME test_hcurl_from_dhcov_splines
     COMMAND $<TARGET_FILE:test_hcurl_from_dhcov_splines.x>
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..


### PR DESCRIPTION
Gives the libneo reverse-dependency gate a sub-minute SIMPLE test set.

- Labels six sub-second tests `smoke`: three VMEC-coordinate tests that call libneo directly (`test_magfie_refcoords_vmec`, `test_jacobian_conventions_vmec`, `test_hctr_from_metric_vmec`) so the gate actually catches a libneo break, plus the `lapack`/`orbit_symplectic`/`field` base tests. Measured ~1.8s total.
- Adds a `test-smoke` make target (`ctest -L smoke`).
- `main.yml`: a libneo-gate dispatch (`workflow_dispatch` without `full`) builds SIMPLE against the candidate libneo and runs only the smoke set. Push, PR and `full=true` keep the complete fast + slow + regression suite, unchanged.

Builds on #367 (already merged), which wired the `libneo_ref` dispatch input and `LIBNEO_BRANCH` resolver.