### PR TITLE
Derive Boozer chartmap rmajor from geometry; drop the attribute

### DIFF
--- a/src/boozer_converter.F90
+++ b/src/boozer_converter.F90
@@ -1072,7 +1072,7 @@ contains
         !> get_boozer_coordinates() and while VMEC splines are still active
         !> (needed for X, Y, Z geometry evaluation).
         use vector_potentail_mod, only: torflux
-        use new_vmec_stuff_mod, only: nper, rmajor
+        use new_vmec_stuff_mod, only: nper
         use boozer_coordinates_mod, only: ns_B, n_theta_B, n_phi_B, &
                                           hs_B, h_theta_B, h_phi_B, &
                                           s_Bcovar_tp_B
@@ -1219,10 +1219,8 @@ contains
                         "att boozer_field")
         call nc_assert(nf90_put_att(ncid, nf90_global, "torflux", torflux), &
                         "att torflux")
-        ! Major radius (metres, base units) so the chartmap reader can restore
-        ! new_vmec_stuff_mod::rmajor; stevvo/params_init need it for dtaumin.
-        call nc_assert(nf90_put_att(ncid, nf90_global, "rmajor", rmajor), &
-                        "att rmajor")
+        ! No rmajor attribute: the chartmap reader derives the major radius
+        ! from the innermost-surface geometry (see boozer_chartmap_io).
 
         call nc_assert(nf90_enddef(ncid), "enddef")
 

--- a/src/field/boozer_chartmap_io.f90
+++ b/src/field/boozer_chartmap_io.f90
@@ -8,8 +8,8 @@ module boozer_chartmap_io
     !>
     !> Bmod is read on the endpoint-included field grid (theta_field/zeta_field),
     !> which spans the full 2*pi (poloidal) and 2*pi/nfp (toroidal) period. The
-    !> geometry grid (theta/zeta) is endpoint-excluded and is only used here to
-    !> recover the angular step sizes.
+    !> geometry grid (theta/zeta) is endpoint-excluded and is used here to
+    !> recover the angular step sizes and the major radius.
 
     use, intrinsic :: iso_fortran_env, only: dp => real64
     use netcdf
@@ -25,7 +25,7 @@ module boozer_chartmap_io
         integer :: n_phi = 0         !< field grid, endpoint-included (period span)
         integer :: nfp = 1
         real(dp) :: torflux = 0.0_dp
-        real(dp) :: rmajor = 0.0_dp
+        real(dp) :: rmajor = 0.0_dp  !< metres, derived from innermost-surface geometry
         real(dp) :: rho_min = 0.0_dp
         real(dp) :: rho_max = 0.0_dp
         real(dp) :: h_s = 0.0_dp     !< uniform rho step
@@ -81,7 +81,14 @@ contains
                     "inq_var num_field_periods")
         call check(nf90_get_var(ncid, varid, d%nfp), "get num_field_periods")
 
-        call check(nf90_get_att(ncid, nf90_global, "rmajor", d%rmajor), "att rmajor")
+        ! Major radius from geometry: (theta,zeta)-average of sqrt(x^2+y^2) on
+        ! the innermost rho surface (the chartmap analogue of libneo's
+        ! rmajor = rmnc(1,0) axis fallback in vmecinm_m.f90). x,y are stored in
+        ! cm at base scale; rmajor is kept in metres like the former global
+        ! attribute, so the vmec_RZ_scale applied downstream by the field
+        ! loaders stays correct. A leftover "rmajor" attribute in older files
+        ! is ignored.
+        call derive_rmajor(ncid, n_theta_geom, n_phi_geom, d%rmajor)
 
         ! 1D profiles on the rho grid.
         allocate (d%A_phi(n_rho), d%B_theta(n_rho), d%B_phi(n_rho))
@@ -106,6 +113,28 @@ contains
 
         call check(nf90_close(ncid), "close")
     end subroutine read_boozer_chartmap
+
+    subroutine derive_rmajor(ncid, n_theta_geom, n_phi_geom, rmajor)
+        integer, intent(in) :: ncid, n_theta_geom, n_phi_geom
+        real(dp), intent(out) :: rmajor
+
+        integer :: varid
+        real(dp), allocatable :: x_in(:, :, :), y_in(:, :, :)
+        real(dp), parameter :: cm_to_m = 1.0e-2_dp
+
+        allocate (x_in(1, n_theta_geom, n_phi_geom), &
+                  y_in(1, n_theta_geom, n_phi_geom))
+
+        call check(nf90_inq_varid(ncid, "x", varid), "inq_var x")
+        call check(nf90_get_var(ncid, varid, x_in, start=[1, 1, 1], &
+                                 count=[1, n_theta_geom, n_phi_geom]), "get x")
+        call check(nf90_inq_varid(ncid, "y", varid), "inq_var y")
+        call check(nf90_get_var(ncid, varid, y_in, start=[1, 1, 1], &
+                                 count=[1, n_theta_geom, n_phi_geom]), "get y")
+
+        rmajor = sum(sqrt(x_in**2 + y_in**2))*cm_to_m &
+                 /real(n_theta_geom*n_phi_geom, dp)
+    end subroutine derive_rmajor
 
     subroutine check(status, location)
         integer, intent(in) :: status

--- a/test/tests/generate_test_boozer_chartmap.c
+++ b/test/tests/generate_test_boozer_chartmap.c
@@ -33,7 +33,6 @@ int main(int argc, char **argv)
     const double twopi = 2.0 * acos(-1.0);
     const double epsilon = a / r0;
     const double torflux = 0.5 * b0 * a * a;
-    const double rmajor = r0;
     const char *filename = argc > 1 ? argv[1] : "test_boozer_chartmap.nc";
 
     double rho[n_rho];
@@ -164,8 +163,6 @@ int main(int argc, char **argv)
              "put boozer_field");
     CHECK_NC(nc_put_att_double(ncid, NC_GLOBAL, "torflux", NC_DOUBLE, 1, &torflux),
              "put torflux");
-    CHECK_NC(nc_put_att_double(ncid, NC_GLOBAL, "rmajor", NC_DOUBLE, 1, &rmajor),
-             "put rmajor");
 
     CHECK_NC(nc_enddef(ncid), "enddef");
 

--- a/test/tests/test_chartmap_aphi_abscissa.f90
+++ b/test/tests/test_chartmap_aphi_abscissa.f90
@@ -9,7 +9,12 @@ program test_chartmap_aphi_abscissa
     real(dp), parameter :: twopi = 8.0_dp*atan(1.0_dp)
     real(dp), parameter :: aphi_amp = 0.3_dp, aphi_freq = 1.7_dp
     real(dp), parameter :: torflux_val = 1.0_dp
+    ! The reader derives rmajor as the (theta,zeta)-average of sqrt(x^2+y^2)
+    ! on the innermost rho surface (cm -> m). For the circular-torus geometry
+    ! below that average is exactly r0_cm/1e2 on the uniform endpoint-excluded
+    ! theta grid.
     real(dp), parameter :: rmajor_val = 7.5_dp
+    real(dp), parameter :: r0_cm = rmajor_val*1.0e2_dp, a_cm = 1.0e2_dp
     integer, parameter :: n_rho = 65, n_theta = 8, n_zeta = 8
     integer, parameter :: n_theta_field = 9, n_zeta_field = 9, nfp = 2
     character(len=*), parameter :: fname = 'test_aphi_abscissa.nc'
@@ -119,7 +124,7 @@ contains
         call expect_int(d%n_phi, n_zeta_field, 'n_phi field grid', n_fail)
         call expect_int(d%nfp, nfp, 'nfp', n_fail)
         call expect_real(d%torflux, torflux_val, 'torflux', n_fail)
-        call expect_real(d%rmajor, rmajor_val, 'rmajor', n_fail)
+        call expect_real(d%rmajor, rmajor_val, 'rmajor (geometry-derived)', n_fail)
         call expect_real(real(d%n_theta - 1, dp)*d%h_theta, twopi, &
                          'poloidal period', n_fail)
         call expect_real(real(d%n_phi - 1, dp)*d%h_phi, twopi/real(nfp, dp), &
@@ -152,10 +157,12 @@ contains
     subroutine write_synthetic_chartmap()
         integer :: ncid, did_rho, did_th, did_ze, did_thf, did_zef
         integer :: vid_rho, vid_th, vid_ze, vid_aphi, vid_bth, vid_bph
-        integer :: vid_bmod, vid_nfp
+        integer :: vid_bmod, vid_nfp, vid_x, vid_y, vid_z
         real(dp) :: theta(n_theta), zeta(n_zeta)
         real(dp) :: a_phi_arr(n_rho), b_theta_arr(n_rho), b_phi_arr(n_rho)
         real(dp) :: bmod_arr(n_rho, n_theta_field, n_zeta_field)
+        real(dp) :: x_arr(n_rho, n_theta, n_zeta), y_arr(n_rho, n_theta, n_zeta)
+        real(dp) :: z_arr(n_rho, n_theta, n_zeta), radius
         integer :: ir, it, iz, j
 
         do j = 1, n_theta
@@ -176,6 +183,16 @@ contains
                 end do
             end do
         end do
+        do iz = 1, n_zeta
+            do it = 1, n_theta
+                do ir = 1, n_rho
+                    radius = r0_cm + a_cm*rho(ir)*cos(theta(it))
+                    x_arr(ir, it, iz) = radius*cos(zeta(iz))
+                    y_arr(ir, it, iz) = radius*sin(zeta(iz))
+                    z_arr(ir, it, iz) = a_cm*rho(ir)*sin(theta(it))
+                end do
+            end do
+        end do
 
         call nc(nf90_create(fname, nf90_clobber, ncid), 'create')
         call nc(nf90_def_dim(ncid, 'rho', n_rho, did_rho), 'dim rho')
@@ -190,18 +207,26 @@ contains
         call nc(nf90_def_var(ncid, 'A_phi', nf90_double, [did_rho], vid_aphi), 'var aphi')
         call nc(nf90_def_var(ncid, 'B_theta', nf90_double, [did_rho], vid_bth), 'var bth')
         call nc(nf90_def_var(ncid, 'B_phi', nf90_double, [did_rho], vid_bph), 'var bph')
+        call nc(nf90_def_var(ncid, 'x', nf90_double, &
+                             [did_rho, did_th, did_ze], vid_x), 'var x')
+        call nc(nf90_def_var(ncid, 'y', nf90_double, &
+                             [did_rho, did_th, did_ze], vid_y), 'var y')
+        call nc(nf90_def_var(ncid, 'z', nf90_double, &
+                             [did_rho, did_th, did_ze], vid_z), 'var z')
         call nc(nf90_def_var(ncid, 'Bmod', nf90_double, &
                              [did_rho, did_thf, did_zef], vid_bmod), 'var bmod')
         call nc(nf90_def_var(ncid, 'num_field_periods', nf90_int, vid_nfp), 'var nfp')
 
         call nc(nf90_put_att(ncid, nf90_global, 'torflux', torflux_val), 'att torflux')
-        call nc(nf90_put_att(ncid, nf90_global, 'rmajor', rmajor_val), 'att rmajor')
         call nc(nf90_put_att(ncid, nf90_global, 'boozer_field', 1), 'att boozer')
         call nc(nf90_enddef(ncid), 'enddef')
 
         call nc(nf90_put_var(ncid, vid_rho, rho), 'put rho')
         call nc(nf90_put_var(ncid, vid_th, theta), 'put th')
         call nc(nf90_put_var(ncid, vid_ze, zeta), 'put ze')
+        call nc(nf90_put_var(ncid, vid_x, x_arr), 'put x')
+        call nc(nf90_put_var(ncid, vid_y, y_arr), 'put y')
+        call nc(nf90_put_var(ncid, vid_z, z_arr), 'put z')
         call nc(nf90_put_var(ncid, vid_aphi, a_phi_arr), 'put aphi')
         call nc(nf90_put_var(ncid, vid_bth, b_theta_arr), 'put bth')
         call nc(nf90_put_var(ncid, vid_bph, b_phi_arr), 'put bph')

--- a/test/tests/test_e2e_boozer_chartmap.py
+++ b/test/tests/test_e2e_boozer_chartmap.py
@@ -236,26 +236,41 @@ def assert_boozer_chartmap_file(path: Path) -> None:
             raise RuntimeError(f"{path}: expected zeta_convention='boozer'")
         if str(getattr(ds, "rho_convention")) != "rho_tor":
             raise RuntimeError(f"{path}: expected rho_convention='rho_tor'")
-        rmajor = float(getattr(ds, "rmajor", 0.0))
-        if not np.isfinite(rmajor) or rmajor <= 0.0:
-            raise RuntimeError(f"{path}: rmajor attribute missing or invalid")
+        if "rmajor" in ds.ncattrs():
+            raise RuntimeError(
+                f"{path}: rmajor attribute is no longer part of the format; "
+                "the reader derives it from geometry"
+            )
 
 
 def assert_matching_microstep(name: str, ref_stdout: str, chartmap_stdout: str) -> None:
+    # The chartmap run derives rmajor from the innermost-surface geometry
+    # (axis-average R) while the VMEC run uses the volume-based Rmajor_p from
+    # the wout. For the QA test case they differ by 1.2 percent, which feeds
+    # linearly into dtaumin = 2*pi*rmajor*1e2/npoiper2 and ntau. 5 percent
+    # bounds that geometric difference with margin while still catching the
+    # order-of-magnitude rmajor bugs this check was introduced for (350b0f2).
+    tol = 5.0e-2
     ref_dtaumin, ref_ntau = parse_tau_line(ref_stdout)
     chartmap_dtaumin, chartmap_ntau = parse_tau_line(chartmap_stdout)
     if ref_dtaumin is None or ref_ntau is None:
         raise RuntimeError(f"{name}: VMEC run did not print a tau line")
     if chartmap_dtaumin is None or chartmap_ntau is None:
         raise RuntimeError(f"{name}: chartmap run did not print a tau line")
-    if chartmap_ntau != ref_ntau:
-        raise RuntimeError(f"{name}: chartmap ntau={chartmap_ntau}, VMEC ntau={ref_ntau}")
+    rel_ntau = abs(chartmap_ntau - ref_ntau) / max(ref_ntau, 1)
+    if rel_ntau > tol:
+        raise RuntimeError(
+            f"{name}: chartmap ntau={chartmap_ntau}, VMEC ntau={ref_ntau}, "
+            f"rel={rel_ntau:.3e} > {tol:.0e}"
+        )
     rel = abs(chartmap_dtaumin - ref_dtaumin) / max(abs(ref_dtaumin), 1.0)
-    if rel > 1.0e-12:
+    if rel > tol:
         raise RuntimeError(
             f"{name}: chartmap dtaumin={chartmap_dtaumin:.17e}, "
-            f"VMEC dtaumin={ref_dtaumin:.17e}, rel={rel:.3e}"
+            f"VMEC dtaumin={ref_dtaumin:.17e}, rel={rel:.3e} > {tol:.0e}"
         )
+    print(f"[{name}] microstep: dtaumin rel diff {rel:.3e}, "
+          f"ntau {ref_ntau} -> {chartmap_ntau} (rel {rel_ntau:.3e})")
 
 
 def _compare_and_summarize(

--- a/tools/gvec_to_boozer_chartmap.py
+++ b/tools/gvec_to_boozer_chartmap.py
@@ -65,7 +65,7 @@ def main():
     # Evaluate field quantities in Boozer coordinates (endpoint-included grid)
     print(f"Evaluating field & geometry on {n_rho} x {n_theta_field} x {n_phi_field}...")
     ev = state.evaluate_sfl(
-        "mod_B", "B_theta_B", "B_zeta_B", "chi", "Phi_edge", "pos", "r_major",
+        "mod_B", "B_theta_B", "B_zeta_B", "chi", "Phi_edge", "pos",
         rho=rho_grid,
         theta=-theta_field if args.flip == "pol" else theta_field,  # Flip poloidal angle if requested
         zeta=-zeta_field if args.flip == "tor" else zeta_field,  # Flip toroidal angle if requested
@@ -101,9 +101,6 @@ def main():
     # Geometry on endpoint-excluded grid (Boozer angles)
     pos = ev_geom.pos.values  # (3, n_rho, n_theta_geom, n_phi_geom)
     X, Y, Z = pos[0], pos[1], pos[2]
-
-    rmajor = ev.r_major  # GVEC's definition of r_major differs from VMEC's!
-    # rmajor = np.mean(np.sqrt(X**2 + Y**2))
 
     # GVEC right-handed coordinates -> SIMPLE left-handed coordinates
     if args.flip == "tor":
@@ -159,13 +156,12 @@ def main():
     ds.rho_lcfs = float(rho_grid[-1])
     ds.boozer_field = np.int32(1)
     ds.torflux = A_theta_edge
-    ds.rmajor = rmajor
     ds.gvec2chartmap_boozer_factor = args.boozer_factor
     ds.gvec2chartmap_Bcov_method = args.Bcov
     ds.gvec2chartmap_flip = args.flip
 
     ds.close()
-    print(f"Done. nfp={nfp}, torflux={A_theta_edge:.6e}, rmajor={rmajor:.6e}")
+    print(f"Done. nfp={nfp}, torflux={A_theta_edge:.6e}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements the scope change from https://github.com/itpplasma/SIMPLE/issues/372#issuecomment-4670352814: the `rmajor` global attribute is removed from the extended Boozer chartmap format. Part of #372; the converter that consumes this change follows in a stacked PR. Split out of #373 for focused review of the contract change.

## Format change

- Writers (`export_boozer_chartmap`, `tools/gvec_to_boozer_chartmap.py`, the synthetic test generators) no longer write an `rmajor` attribute.
- The reader (`boozer_chartmap_io.f90`) derives rmajor as the (theta, zeta)-average of `sqrt(x^2 + y^2)` on the innermost rho surface, converted cm to metres so the downstream `vmec_RZ_scale` handling is unchanged. This is the chartmap analogue of libneo's `rmajor = rmnc(1,0)` axis fallback in `vmecinm_m.f90`.
- Older files that still carry the attribute read fine; the attribute is ignored.
- A follow-up definition based on the magnetic axis length is tracked in #374.

## Test contract change

rmajor enters only through `dtaumin = 2*pi*rmajor*1e2/npoiper2`. The geometry-derived value (axis-average R, 10.347 m for the QA case) differs from the wout volume-based `Rmajor_p` (10.227 m) by 1.18 percent, so the exact dtaumin/ntau parity assertion from 350b0f2 becomes a 5 percent tolerance check in `test_e2e_boozer_chartmap.py`. Observed: dtaumin rel diff 1.177e-02, ntau 8598 -> 8498 (rel 1.163e-02). The tolerance still catches the order-of-magnitude rmajor bug the check was introduced for (dtaumin 2.45 vs 24.90). The reader-contract test (`test_chartmap_aphi_abscissa`) now writes circular-torus geometry into its synthetic file and asserts the derived value instead of the attribute.

## Risk tier

- [ ] T0: docs, comments, small build metadata
- [ ] T1: pure refactor, no behavior change intended
- [ ] T2: local numerical logic
- [x] T3: physics, output behavior, coordinate convention
- [ ] T4: parallelism, GPU, dependency, CI, or security-sensitive build logic

## Correctness contract

### Intended behavior change

- Extended Boozer chartmap files no longer carry an `rmajor` attribute; the reader derives rmajor from the innermost-surface geometry.
- Chartmap runs use the axis-average major radius for `dtaumin`, 1.18 percent away from the wout `Rmajor_p` for the QA case. ntau shifts by the same factor.

### Behavior that must not change

- VMEC-direct runs: untouched (`rmajor` still comes from the wout).
- Chartmap field data, torflux, scaling knobs (`vmec_B_scale`, `vmec_RZ_scale`): unchanged paths; `rmajor*rz_scale` applied downstream as before.
- Older chartmap files with the attribute still load.

### Coordinate / unit conventions

- Chartmap x, y, z are cm; derived rmajor is metres, matching what the attribute stored, so `field_boozer_chartmap.f90` and `load_boozer_from_chartmap` keep `rmajor = d%rmajor*rz_scale`.

### Numerical invariants

- Derived rmajor equals the axis-average R of the file geometry; for the synthetic circular-torus test exactly `r0`.

## Tests added

- unit: `test_chartmap_aphi_abscissa` extended (geometry in the synthetic file, derived-rmajor reader contract)
- integration: none beyond the updated e2e contract
- system: `test_e2e_boozer_chartmap.py` updated to the tolerance contract
- golden record: not touched (chartmap-only paths)

## Golden-record impact

- [x] unchanged
- [ ] changed

VMEC-direct runs do not read chartmaps; rmajor handling there is untouched. Evidence below.

## Failure modes considered

- Missing x/y geometry in a chartmap: reader now errors at `inq_var x` instead of `att rmajor`; geometry is mandatory in the format (the coordinate system needs it).
- Order-of-magnitude rmajor regressions (the 350b0f2 bug class): still caught by the 5 percent dtaumin tolerance.

## Manual validation

Derived value cross-checked against SIMPLE's own `export_boozer_chartmap` output for the QA equilibrium: derived rmajor rel diff 6.277e-05 against the value the exporter previously stored.

## Verification

Evidence gathered on the stacked pair (this change plus the converter); this commit is the only one touching the reader/writer paths. CI re-runs per PR.

Failing before (main-branch reader on a new-format file without the attribute):

```
 PASS: is_boozer_chartmap detected file correctly
 read_boozer_chartmap: NetCDF error at att rmajor: NetCDF: Attribute not found
ERROR STOP read_boozer_chartmap failed
```

Passing after, updated `test_e2e_boozer_chartmap` (QA):

```
[QA] microstep: dtaumin rel diff 1.177e-02, ntau 8598 -> 8498 (rel 1.163e-02)
[QA] max |total diff| VMEC-Boozer vs VMEC chartmap = 0.000000e+00
[QA] PASS
```

Full suite (`make test`): 100 percent passed, 0 failed out of 58. Golden records (`make test-golden`, deterministic build): 13/13 pass, 489 s; CI regression step green on the combined branch: https://github.com/itpplasma/SIMPLE/actions/runs/27279802255/job/80570833928
