### PR TITLE
Add booz_xform to Boozer chartmap converter

### DIFF
--- a/DOC/coordinates-and-fields.md
+++ b/DOC/coordinates-and-fields.md
@@ -151,13 +151,23 @@ Attributes: num_field_periods, zeta_convention, rho_convention
 #### Extended Boozer chartmap (field profiles)
 
 A chartmap with `boozer_field = 1` also stores `A_phi`, `B_theta`, `B_phi`,
-and `Bmod` on the file `rho` grid, plus `torflux` and `rmajor`. `rho_tor`
-means `s = rho^2`. The reader splines all 1D profiles on `rho` and converts
+and `Bmod` on the file `rho` grid, plus `torflux`. `rho_tor` means
+`s = rho^2`. The reader splines all 1D profiles on `rho` and converts
 radial derivatives to `s` by chain rule; `A_theta = torflux*s` stays linear
 in `s`. `Bmod` uses the endpoint-included `theta_field`/`zeta_field` grid,
-while `theta`/`zeta` provide the period steps. Both chartmap consumers use
+while `theta`/`zeta` provide the period steps. The major radius is not
+stored: the reader derives it as the `(theta, zeta)`-average of
+`sqrt(x^2 + y^2)` on the innermost `rho` surface (cm in the file, metres in
+`new_vmec_stuff_mod::rmajor`); a leftover `rmajor` attribute in older files
+is ignored. Both chartmap consumers use
 `boozer_chartmap_io.read_boozer_chartmap`, so metadata, scaling, and grid
 layout stay shared.
+
+Writers of the extended format: `export_boozer_chartmap`
+(`boozer_converter.F90`), `tools/gvec_to_boozer_chartmap.py`, and
+`tools/booz_xform_to_boozer_chartmap.py` (from booz_xform `boozmn*.nc`
+harmonics; recovers `torflux` from the surface geometry when `phi_b` is
+absent).
 
 ### 2.4 Cartesian Coordinates
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,11 @@ without requiring them at runtime.
    ```
    Run `python tools/gvec_to_boozer_chartmap.py --help` for grid resolution options (`--nrho`, `--ntheta`, `--nphi`).
 
+   booz_xform output (`boozmn*.nc`) converts the same way; the boozmn file alone is sufficient:
+   ```bash
+   python tools/booz_xform_to_boozer_chartmap.py boozmn_case.nc boozer_chartmap.nc
+   ```
+
 2. Use `examples/simple_chartmap.in` as a starting point, pointing `field_input` and `coord_input` to your chartmap file.
 
 3. Run as usual: `./build/simple.x`

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -43,6 +43,17 @@ else()
     message(STATUS "gvec Python package not found; skipping GVEC chartmap QA test")
 endif()
 
+set(SIMPLE_HAVE_BOOZ_XFORM OFF)
+execute_process(
+    COMMAND ${BOOZER_CHARTMAP_PYTHON} -c "import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('booz_xform') else 1)"
+    RESULT_VARIABLE BOOZ_XFORM_IMPORT_RESULT
+)
+if(BOOZ_XFORM_IMPORT_RESULT EQUAL 0)
+    set(SIMPLE_HAVE_BOOZ_XFORM ON)
+else()
+    message(STATUS "booz_xform Python package not found; skipping booz_xform chartmap test")
+endif()
+
 # Generate chartmap file from VMEC for testing chartmap coordinate detection
 # Uses libneo's vmec_to_chartmap tool built as part of dependencies
 set(CHARTMAP_FILE "${CMAKE_CURRENT_BINARY_DIR}/wout.chartmap.nc")
@@ -475,6 +486,18 @@ add_test(NAME test_array_utils COMMAND test_array_utils.x)
         LABELS "slow;plot;python"
         ENVIRONMENT "SIMPLE_BOOZER_CASES=QA"
         TIMEOUT 7200)
+
+    # booz_xform -> Boozer chartmap converter: spectral reference, golden
+    # cross-check against export_boozer_chartmap, end-to-end orbit comparison.
+    if(SIMPLE_HAVE_BOOZ_XFORM)
+        add_test(NAME test_booz_xform_chartmap
+            COMMAND ${BOOZER_CHARTMAP_PYTHON}
+                ${CMAKE_CURRENT_SOURCE_DIR}/test_booz_xform_chartmap.py)
+        set_tests_properties(test_booz_xform_chartmap PROPERTIES
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            LABELS "slow;python"
+            TIMEOUT 7200)
+    endif()
 
 
     if(SIMPLE_ENABLE_CGAL)

--- a/test/tests/test_booz_xform_chartmap.py
+++ b/test/tests/test_booz_xform_chartmap.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Validate the booz_xform -> Boozer chartmap converter on the QA equilibrium.
+
+Three layers, all against independent references:
+  1. Spectral reference with grid convergence: cubic interpolation of the
+     tabulated chartmap must approach direct summation of the boozmn
+     harmonics as the chartmap grid is refined.
+  2. Golden cross-check: the converted chartmap must agree with the chartmap
+     written by SIMPLE's own export_boozer_chartmap from the same wout.
+  3. End-to-end orbits: confined fractions of a SIMPLE run on the converted
+     chartmap must match the VMEC-direct run within the 1/npart resolution,
+     and the derived rmajor must keep dtaumin within 5 percent.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+import netCDF4
+import numpy as np
+from scipy.interpolate import CubicSpline, RegularGridInterpolator
+
+from boozer_chartmap_artifacts import (
+    confined_metrics,
+    download_if_missing,
+    load_confined_fraction,
+    run_cmd,
+)
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+BUILD_DIR = SCRIPT_DIR.parent.parent / "build"
+SIMPLE_X = BUILD_DIR / "simple.x"
+TOOL_X = BUILD_DIR / "test" / "tests" / "export_boozer_chartmap_tool.x"
+TOOLS_DIR = SCRIPT_DIR.parent.parent / "tools"
+CONVERTER = TOOLS_DIR / "booz_xform_to_boozer_chartmap.py"
+TEST_DATA = SCRIPT_DIR.parent / "test_data"
+WOUT = TEST_DATA / "wout.nc"
+WOUT_URL = (
+    "https://raw.githubusercontent.com/hiddenSymmetries/simsopt/master/"
+    "tests/test_files/wout_LandremanPaul2021_QA_reactorScale_lowres_reference.nc"
+)
+
+sys.path.insert(0, str(TOOLS_DIR))
+from booz_xform_to_boozer_chartmap import (  # noqa: E402
+    fourier_eval,
+    interp_coeffs,
+    read_boozmn,
+)
+
+TWOPI = 2.0 * np.pi
+
+
+def fail(msg: str) -> None:
+    raise SystemExit(f"FAIL: {msg}")
+
+
+def check(label: str, value: float, tol: float) -> None:
+    status = "ok" if value <= tol else "FAIL"
+    print(f"  {label}: {value:.3e} (tol {tol:.0e}) {status}")
+    if value > tol:
+        fail(f"{label} = {value:.3e} exceeds {tol:.0e}")
+
+
+def make_boozmn(workdir: Path) -> Path:
+    import booz_xform
+
+    boozmn = workdir / "boozmn_qa.nc"
+    b = booz_xform.Booz_xform()
+    b.read_wout(str(WOUT))
+    b.mboz = 48
+    b.nboz = 48
+    b.verbose = 0
+    b.run()
+    b.write_boozmn(str(boozmn))
+    return boozmn
+
+
+def convert(boozmn: Path, output: Path, nrho: int, ntheta: int, nzeta: int) -> Path:
+    run_cmd(
+        [
+            sys.executable,
+            str(CONVERTER),
+            str(boozmn),
+            str(output),
+            "--nrho", str(nrho),
+            "--ntheta", str(ntheta),
+            "--nzeta", str(nzeta),
+        ],
+        cwd=output.parent,
+        label=f"convert {output.name}",
+    )
+    return output
+
+
+def load_chartmap(path: Path) -> dict:
+    with netCDF4.Dataset(path) as ds:
+        out = {
+            "rho": ds.variables["rho"][:].data,
+            "theta": ds.variables["theta"][:].data,
+            "zeta": ds.variables["zeta"][:].data,
+            "A_phi": ds.variables["A_phi"][:].data,
+            "B_theta": ds.variables["B_theta"][:].data,
+            "B_phi": ds.variables["B_phi"][:].data,
+            "Bmod": np.transpose(ds.variables["Bmod"][:].data, (2, 1, 0)),
+            "x": np.transpose(ds.variables["x"][:].data, (2, 1, 0)),
+            "y": np.transpose(ds.variables["y"][:].data, (2, 1, 0)),
+            "z": np.transpose(ds.variables["z"][:].data, (2, 1, 0)),
+            "nfp": int(ds.variables["num_field_periods"][:]),
+            "torflux": float(ds.torflux),
+            "attrs": list(ds.ncattrs()),
+        }
+    return out
+
+
+def bmod_interpolator(c: dict) -> RegularGridInterpolator:
+    n_th, n_ze = c["Bmod"].shape[1], c["Bmod"].shape[2]
+    theta_f = np.linspace(0.0, TWOPI, n_th)
+    zeta_f = np.linspace(0.0, TWOPI / c["nfp"], n_ze)
+    return RegularGridInterpolator((c["rho"], theta_f, zeta_f), c["Bmod"],
+                                   method="cubic")
+
+
+def spectral_bmod(d: dict, pts: np.ndarray) -> np.ndarray:
+    """Direct boozmn summation at (rho, theta, zeta) points, in Gauss."""
+    rho_half = np.sqrt(d["s_half"])
+    out = np.empty(len(pts))
+    for i, (rho, th, ze) in enumerate(pts):
+        c = interp_coeffs(d["bmnc"], d["ixm"], rho_half, np.array([rho]))
+        val = fourier_eval(c, d["ixm"], d["ixn"], np.array([th]),
+                           np.array([ze]), "cos")[0, 0, 0]
+        out[i] = val * 1.0e4
+    return out
+
+
+def check_spectral_convergence(d: dict, workdir: Path, boozmn: Path) -> None:
+    print("== Spectral reference with grid convergence ==")
+    coarse = convert(boozmn, workdir / "chartmap_coarse.nc", 25, 16, 32)
+    fine = convert(boozmn, workdir / "chartmap_fine.nc", 50, 48, 96)
+
+    rng = np.random.default_rng(20260610)
+    n_pts = 200
+    pts = np.column_stack([
+        rng.uniform(0.2, 0.9, n_pts),
+        rng.uniform(0.0, TWOPI, n_pts),
+        rng.uniform(0.0, TWOPI / d["nfp"], n_pts),
+    ])
+    ref = spectral_bmod(d, pts)
+
+    errs = {}
+    for name, path in (("coarse", coarse), ("fine", fine)):
+        c = load_chartmap(path)
+        approx = bmod_interpolator(c)(pts)
+        errs[name] = float(np.max(np.abs(approx - ref) / np.abs(ref)))
+        print(f"  Bmod {name} grid max rel err vs spectral: {errs[name]:.3e}")
+
+    if errs["fine"] >= 0.5 * errs["coarse"]:
+        fail(
+            f"no grid convergence: fine err {errs['fine']:.3e} "
+            f">= 0.5 * coarse err {errs['coarse']:.3e}"
+        )
+    check("Bmod fine-grid spectral error", errs["fine"], 1.0e-4)
+
+
+def check_golden_export(workdir: Path, chartmap: Path) -> Path:
+    print("== Golden cross-check against export_boozer_chartmap ==")
+    export_dir = workdir / "export"
+    export_dir.mkdir(exist_ok=True)
+    start_vmec = export_dir / "start_vmec.dat"
+    start_vmec.write_text("0.3 0.5 0.5 1.0 0.1\n", encoding="utf-8")
+    ref_chartmap = export_dir / "chartmap_vmec.nc"
+    run_cmd(
+        [
+            str(TOOL_X),
+            str(WOUT),
+            str(ref_chartmap),
+            str(start_vmec),
+            str(export_dir / "start_boozer.dat"),
+        ],
+        cwd=export_dir,
+        label="export_boozer_chartmap",
+    )
+
+    ref = load_chartmap(ref_chartmap)
+    new = load_chartmap(chartmap)
+    for c, name in ((ref, "exported"), (new, "converted")):
+        if "rmajor" in c["attrs"]:
+            fail(f"{name} chartmap still carries the removed rmajor attribute")
+
+    check("torflux rel diff",
+          abs(new["torflux"] - ref["torflux"]) / abs(ref["torflux"]), 1.0e-6)
+
+    b_scale = float(np.max(np.abs(ref["B_phi"])))
+    for q, scale, tol in (
+        ("A_phi", float(np.max(np.abs(ref["A_phi"]))), 1.0e-5),
+        ("B_theta", b_scale, 1.0e-4),
+        ("B_phi", b_scale, 1.0e-4),
+    ):
+        interp = CubicSpline(new["rho"], new[q])(ref["rho"])
+        check(f"{q} max diff / scale",
+              float(np.max(np.abs(interp - ref[q])) / scale), tol)
+
+    rng = np.random.default_rng(42)
+    n_pts = 400
+    pts = np.column_stack([
+        rng.uniform(0.15, 0.95, n_pts),
+        rng.uniform(0.0, TWOPI, n_pts),
+        rng.uniform(0.0, TWOPI / ref["nfp"], n_pts),
+    ])
+    b_ref = bmod_interpolator(ref)(pts)
+    b_new = bmod_interpolator(new)(pts)
+    check("Bmod max rel diff",
+          float(np.max(np.abs(b_new - b_ref) / np.abs(b_ref))), 5.0e-3)
+
+    geom_new = {
+        q: RegularGridInterpolator(
+            (new["rho"], new["theta"], new["zeta"]), new[q],
+            method="cubic", bounds_error=False, fill_value=None)
+        for q in ("x", "y", "z")
+    }
+    th_grid, ze_grid = np.meshgrid(ref["theta"], ref["zeta"], indexing="ij")
+    max_diff = 0.0
+    for ir in (5, 25, 45):
+        p = np.column_stack([
+            np.full(th_grid.size, ref["rho"][ir]),
+            th_grid.ravel(),
+            ze_grid.ravel(),
+        ])
+        for q in ("x", "y", "z"):
+            diff = np.max(np.abs(geom_new[q](p) - ref[q][ir].ravel()))
+            max_diff = max(max_diff, float(diff))
+    check("geometry max |diff| [cm]", max_diff, 1.0)
+
+    # Derived major radius (axis-average R) must agree between the two
+    # writers; it intentionally differs from the wout volume-based Rmajor_p.
+    r_ref = float(np.mean(np.sqrt(ref["x"][0]**2 + ref["y"][0]**2))) / 100.0
+    r_new = float(np.mean(np.sqrt(new["x"][0]**2 + new["y"][0]**2))) / 100.0
+    check("derived rmajor rel diff", abs(r_new - r_ref) / r_ref, 1.0e-3)
+    return export_dir / "start_boozer.dat"
+
+
+SIMPLE_IN_VMEC = """\
+&config
+multharm = 5
+contr_pp = -1e10
+trace_time = 1d-2
+macrostep_time_grid = 'log'
+ntimstep = 61
+sbeg = 0.3d0
+ntestpart = 32
+netcdffile = 'wout.nc'
+isw_field_type = 2
+deterministic = .True.
+integmode = 1
+facE_al = 1.0d0
+/
+"""
+
+SIMPLE_IN_CHARTMAP = """\
+&config
+multharm = 5
+contr_pp = -1e10
+trace_time = 1d-2
+macrostep_time_grid = 'log'
+ntimstep = 61
+sbeg = 0.3d0
+ntestpart = 32
+field_input = 'boozer_chartmap.nc'
+coord_input = 'boozer_chartmap.nc'
+isw_field_type = 2
+deterministic = .True.
+integmode = 1
+startmode = 2
+facE_al = 1.0d0
+/
+"""
+
+
+def parse_tau_line(stdout: str) -> tuple[float, int]:
+    for line in stdout.splitlines():
+        if line.strip().startswith("tau:"):
+            parts = line.split()
+            return float(parts[2].replace("D", "E")), int(parts[4])
+    fail("run did not print a tau line")
+
+
+def check_e2e_orbits(workdir: Path, chartmap: Path) -> None:
+    print("== End-to-end VMEC vs booz_xform chartmap orbits ==")
+    vmec_dir = workdir / "vmec_run"
+    chart_dir = workdir / "chartmap_run"
+    for run_dir in (vmec_dir, chart_dir):
+        if run_dir.exists():
+            shutil.rmtree(run_dir)
+        run_dir.mkdir()
+
+    shutil.copy2(WOUT, vmec_dir / "wout.nc")
+    (vmec_dir / "simple.in").write_text(SIMPLE_IN_VMEC, encoding="utf-8")
+    vmec_stdout = run_cmd([str(SIMPLE_X)], cwd=vmec_dir, label="VMEC run")
+
+    # Convert the VMEC start.dat to Boozer/chartmap reference coordinates.
+    start_boozer = chart_dir / "start.dat"
+    run_cmd(
+        [
+            str(TOOL_X),
+            str(WOUT),
+            str(chart_dir / "chartmap_unused.nc"),
+            str(vmec_dir / "start.dat"),
+            str(start_boozer),
+        ],
+        cwd=chart_dir,
+        label="start.dat conversion",
+    )
+    (chart_dir / "chartmap_unused.nc").unlink()
+    shutil.copy2(chartmap, chart_dir / "boozer_chartmap.nc")
+    (chart_dir / "simple.in").write_text(SIMPLE_IN_CHARTMAP, encoding="utf-8")
+    chart_stdout = run_cmd([str(SIMPLE_X)], cwd=chart_dir, label="chartmap run")
+
+    # Microstep: rmajor is now the geometry-derived axis-average R, which for
+    # QA differs from the wout volume-based Rmajor_p by 1.2 percent; dtaumin
+    # and ntau inherit that difference linearly. 5 percent bounds it with
+    # margin while still catching order-of-magnitude rmajor bugs (350b0f2).
+    tau_tol = 5.0e-2
+    ref_dtaumin, ref_ntau = parse_tau_line(vmec_stdout)
+    new_dtaumin, new_ntau = parse_tau_line(chart_stdout)
+    check("dtaumin rel diff",
+          abs(new_dtaumin - ref_dtaumin) / abs(ref_dtaumin), tau_tol)
+    check("ntau rel diff", abs(new_ntau - ref_ntau) / ref_ntau, tau_tol)
+
+    ref = confined_metrics(load_confined_fraction(vmec_dir / "confined_fraction.dat"))
+    new = confined_metrics(load_confined_fraction(chart_dir / "confined_fraction.dat"))
+    tol = 1.0 / ref["npart"]
+    for key in ("total_conf", "pass_conf", "trap_conf"):
+        n = min(len(ref[key]), len(new[key]))
+        diff = float(np.max(np.abs(np.asarray(ref[key][:n]) - np.asarray(new[key][:n]))))
+        check(f"confined fraction max |{key} diff|", diff, tol)
+
+
+def main() -> None:
+    for path, label in ((SIMPLE_X, "simple.x"), (TOOL_X, "export tool"),
+                        (CONVERTER, "converter script")):
+        if not path.exists():
+            raise SystemExit(f"Missing {label}: {path}")
+    download_if_missing(WOUT, WOUT_URL)
+
+    workdir = Path.cwd() / "booz_xform_chartmap_test"
+    if workdir.exists():
+        shutil.rmtree(workdir)
+    workdir.mkdir(parents=True)
+
+    print("== Running booz_xform on QA wout ==")
+    boozmn = make_boozmn(workdir)
+    d = read_boozmn(boozmn)
+
+    check_spectral_convergence(d, workdir, boozmn)
+    chartmap = workdir / "chartmap_fine.nc"
+    check_golden_export(workdir, chartmap)
+    check_e2e_orbits(workdir, chartmap)
+    print("BOOZ_XFORM CHARTMAP CONVERTER TEST PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/booz_xform_to_boozer_chartmap.py
+++ b/tools/booz_xform_to_boozer_chartmap.py
@@ -223,8 +223,10 @@ def main():
     n_theta_field = n_theta_geom + 1
     n_phi_field = n_phi_geom + 1
 
-    rho_grid = np.linspace(0.0, 1.0, n_rho)
-    rho_grid[0] = 1.0e-3
+    # Uniform from rho_min: the chartmap reader assumes a strictly uniform rho
+    # grid (h_s = rho(2)-rho(1)), so clipping the first point of a [0,1] grid
+    # to rho_min would misplace every interior sample by up to half a cell.
+    rho_grid = np.linspace(1.0e-3, 1.0, n_rho)
     s_grid = rho_grid**2
     theta_geom = np.linspace(0.0, TWOPI, n_theta_geom, endpoint=False)
     zeta_geom = np.linspace(0.0, TWOPI / nfp, n_phi_geom, endpoint=False)

--- a/tools/booz_xform_to_boozer_chartmap.py
+++ b/tools/booz_xform_to_boozer_chartmap.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Convert booz_xform output (boozmn*.nc) to a Boozer chartmap NetCDF file.
+
+Reads the Boozer-coordinate Fourier harmonics produced by booz_xform and
+writes the extended chartmap format that SIMPLE reads without any VMEC or
+booz_xform library at runtime. The boozmn file alone is sufficient: the
+toroidal flux is taken from phi_b when present and otherwise recovered from
+the surface geometry via the Boozer identity sqrt(g) B^2 = psi' (G + iota I).
+
+Units: booz_xform is SI (T, m), the chartmap stores Gauss and cm.
+
+Radial staggering: bmnc_b/rmnc_b/zmns_b/pmns_b live on the half grid
+(pack_rad, surfaces jlist), iota_b/buco_b/bvco_b/phi_b on the full grid
+(ns_b surfaces, index jlist[k]-1 holds the matching half-grid value for
+surface k).
+
+Half-grid s: s_half[k] = (jlist[k] - 1.5) / (ns_b - 1), the midpoint of the
+interval between full-grid surfaces jlist[k]-1 and jlist[k] (1-based); this
+matches booz_xform's own s_in for jlist[0] = 2.
+
+Usage:
+    python tools/booz_xform_to_boozer_chartmap.py <boozmn.nc> <output.nc>
+        [--nrho N] [--ntheta N] [--nzeta N]
+"""
+
+import argparse
+import sys
+
+import numpy as np
+
+try:
+    import netCDF4
+except ImportError:
+    print("ERROR: netCDF4 required. pip install netCDF4")
+    sys.exit(1)
+
+try:
+    from scipy.interpolate import CubicSpline
+except ImportError:
+    print("ERROR: scipy required. pip install scipy")
+    sys.exit(1)
+
+TWOPI = 2.0 * np.pi
+
+
+def read_boozmn(filename):
+    """Read a boozmn file into a plain dict of numpy arrays."""
+    d = {}
+    with netCDF4.Dataset(filename) as ds:
+        def var(n):
+            return np.asarray(ds.variables[n][:])
+
+        d["ns"] = int(var("ns_b"))
+        d["nfp"] = int(var("nfp_b"))
+        d["lasym"] = bool(var("lasym__logical__"))
+        d["jlist"] = var("jlist").astype(int)
+        d["ixm"] = var("ixm_b").astype(int)
+        d["ixn"] = var("ixn_b").astype(int)
+        d["iota"] = var("iota_b")
+        d["buco"] = var("buco_b")
+        d["bvco"] = var("bvco_b")
+        d["phi"] = var("phi_b")
+        d["bmnc"] = var("bmnc_b")
+        d["rmnc"] = var("rmnc_b")
+        d["zmns"] = var("zmns_b")
+        d["pmns"] = var("pmns_b")
+        if d["lasym"]:
+            d["bmns"] = var("bmns_b")
+            d["rmns"] = var("rmns_b")
+            d["zmnc"] = var("zmnc_b")
+            d["pmnc"] = var("pmnc_b")
+    # VMEC half-grid convention: s at the midpoint between full-grid surfaces
+    # jlist[k]-1 and jlist[k] (1-based) is (jlist[k] - 1.5) / (ns_b - 1).
+    d["s_half"] = (d["jlist"] - 1.5) / (d["ns"] - 1)
+    return d
+
+
+def interp_coeffs(coeffs, ixm, rho_half, rho_out):
+    """Interpolate packed Fourier coefficients from the half grid to rho_out.
+
+    Cubic spline in rho per mode; below the innermost half-grid surface the
+    poloidal mode number sets the near-axis behaviour c ~ rho^m, so modes are
+    continued with a power law instead of the spline's polynomial tail.
+    """
+    out = CubicSpline(rho_half, coeffs, axis=0)(rho_out)
+    inner = rho_out < rho_half[0]
+    if np.any(inner):
+        ratio = rho_out[inner, None] / rho_half[0]
+        m = np.minimum(ixm[None, :], 50)
+        out[inner, :] = coeffs[0][None, :] * ratio**m
+    return out
+
+
+def fourier_eval(coeffs_grid, ixm, ixn, theta, zeta, parity):
+    """Sum coeffs(rho, mn) * trig(m*theta - n*zeta) on a tensor angle grid.
+
+    parity is 'cos' or 'sin'. Returns an (n_rho, n_theta, n_zeta) array.
+    """
+    angle = (ixm[:, None, None] * theta[None, :, None]
+             - ixn[:, None, None] * zeta[None, None, :])
+    basis = np.cos(angle) if parity == "cos" else np.sin(angle)
+    return np.tensordot(coeffs_grid, basis, axes=([1], [0]))
+
+
+def derive_psi_prime(d):
+    """Recover psi' = Phi'(s)/(2*pi) from geometry when phi_b is absent.
+
+    On each surface sqrt(g) B^2 = psi' (G + iota I) with sqrt(g) the Jacobian
+    of (s, theta_B, zeta_B), so the angle average of J B^2 / (G + iota I)
+    gives psi'. J comes from spectral angle derivatives plus radial spline
+    derivatives of the geometry harmonics. s is the normalized toroidal
+    flux, so psi' is one constant (carrying the VMEC handedness sign, equal
+    to -phi_wout(ns)/(2*pi)); the spread over mid-radius surfaces, where the
+    radial splines are accurate, is a consistency check.
+    """
+    ixm, ixn = d["ixm"], d["ixn"]
+    s_half = d["s_half"]
+    mid = np.where((s_half > 0.25) & (s_half < 0.95))[0]
+    if len(mid) < 3:
+        mid = np.arange(1, len(s_half) - 1)
+    nth, nze = 73, 73
+    theta = np.linspace(0.0, TWOPI, nth, endpoint=False)
+    zeta = np.linspace(0.0, TWOPI / d["nfp"], nze, endpoint=False)
+    angle = (ixm[:, None, None] * theta[None, :, None]
+             - ixn[:, None, None] * zeta[None, None, :])
+    cosg, sing = np.cos(angle), np.sin(angle)
+
+    def ev(c, basis):
+        return np.tensordot(c, basis, axes=([0], [0]))
+
+    names = ["rmnc", "zmns", "pmns"]
+    if d["lasym"]:
+        names += ["rmns", "zmnc", "pmnc"]
+    ds_coeffs = {name: CubicSpline(s_half, d[name], axis=0)(s_half[mid], nu=1)
+                 for name in names}
+
+    psi_primes = []
+    for i, k in enumerate(mid):
+        R = ev(d["rmnc"][k], cosg)
+        B = ev(d["bmnc"][k], cosg)
+        R_s = ev(ds_coeffs["rmnc"][i], cosg)
+        Z_s = ev(ds_coeffs["zmns"][i], sing)
+        phi_s = ev(ds_coeffs["pmns"][i], sing)
+        R_t = ev(-ixm * d["rmnc"][k], sing)
+        Z_t = ev(ixm * d["zmns"][k], cosg)
+        phi_t = ev(ixm * d["pmns"][k], cosg)
+        R_z = ev(ixn * d["rmnc"][k], sing)
+        Z_z = ev(-ixn * d["zmns"][k], cosg)
+        phi_z = 1.0 + ev(-ixn * d["pmns"][k], cosg)
+        if d["lasym"]:
+            R += ev(d["rmns"][k], sing)
+            B += ev(d["bmns"][k], sing)
+            R_s += ev(ds_coeffs["rmns"][i], sing)
+            Z_s += ev(ds_coeffs["zmnc"][i], cosg)
+            phi_s += ev(ds_coeffs["pmnc"][i], cosg)
+            R_t += ev(ixm * d["rmns"][k], cosg)
+            Z_t += ev(-ixm * d["zmnc"][k], sing)
+            phi_t += ev(-ixm * d["pmnc"][k], sing)
+            R_z += ev(-ixn * d["rmns"][k], cosg)
+            Z_z += ev(ixn * d["zmnc"][k], sing)
+            phi_z += ev(ixn * d["pmnc"][k], sing)
+
+        # Jacobian in cylindrical components (dR, R dphi, dZ) of the three
+        # tangent vectors; the e_phi factor contributes the leading R.
+        J = R * (R_s * (phi_t * Z_z - phi_z * Z_t)
+                 + phi_s * (Z_t * R_z - Z_z * R_t)
+                 + Z_s * (R_t * phi_z - R_z * phi_t))
+
+        jidx = d["jlist"][k] - 1
+        G, I, iota = d["bvco"][jidx], d["buco"][jidx], d["iota"][jidx]
+        psi_primes.append(np.mean(J * B**2) / (G + iota * I))
+
+    psi_primes = np.array(psi_primes)
+    spread = np.ptp(psi_primes) / np.abs(np.median(psi_primes))
+    if spread > 1.0e-3:
+        raise RuntimeError(
+            f"psi' from geometry varies by {spread:.2e} across surfaces; "
+            "boozmn file is inconsistent"
+        )
+    return float(np.median(psi_primes))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert booz_xform boozmn output to a Boozer chartmap "
+                    "NetCDF file"
+    )
+    parser.add_argument("boozmn", help="booz_xform output file (boozmn*.nc)")
+    parser.add_argument("output", help="Output Boozer chartmap .nc file")
+    parser.add_argument("--nrho", type=int, default=50)
+    parser.add_argument("--ntheta", type=int, default=48,
+                        help="poloidal points, endpoint-excluded geometry grid")
+    parser.add_argument("--nzeta", type=int, default=96,
+                        help="toroidal points per field period, endpoint-excluded")
+    args = parser.parse_args()
+
+    print(f"Loading boozmn file: {args.boozmn}")
+    d = read_boozmn(args.boozmn)
+    nfp = d["nfp"]
+    j = d["jlist"] - 1  # full-grid indices matching each half-grid surface
+    s_half = d["s_half"]
+    rho_half = np.sqrt(s_half)
+
+    # Extract half-grid values of surface functions via full-grid index j.
+    # j[0] = jlist[0]-1 = 1 for jlist[0]=2; skip the axis point (index 0)
+    # where buco/bvco are set to zero as a boundary artefact.
+    iota_h = d["iota"][j]
+    buco_h = d["buco"][j]
+    bvco_h = d["bvco"][j]
+
+    # SIMPLE works with torflux = -phi_vmec[-1]/(2*pi); phi_b stores the
+    # cumulative toroidal flux in Wb so phi_b[-1] > 0 and torflux is negative.
+    if np.any(d["phi"] != 0.0):
+        torflux_si = -float(d["phi"][-1]) / TWOPI
+        print(f"Toroidal flux from phi_b: torflux = {torflux_si:.6e} T m^2")
+    else:
+        torflux_si = derive_psi_prime(d)
+        print(f"Toroidal flux from geometry: torflux = {torflux_si:.6e} T m^2")
+
+    n_rho = args.nrho
+    n_theta_geom = args.ntheta
+    n_phi_geom = args.nzeta
+    n_theta_field = n_theta_geom + 1
+    n_phi_field = n_phi_geom + 1
+
+    rho_grid = np.linspace(0.0, 1.0, n_rho)
+    rho_grid[0] = 1.0e-3
+    s_grid = rho_grid**2
+    theta_geom = np.linspace(0.0, TWOPI, n_theta_geom, endpoint=False)
+    zeta_geom = np.linspace(0.0, TWOPI / nfp, n_phi_geom, endpoint=False)
+    theta_field = np.linspace(0.0, TWOPI, n_theta_field)
+    zeta_field = np.linspace(0.0, TWOPI / nfp, n_phi_field)
+
+    # Surface functions on uniform rho grid.
+    # buco/bvco start at jlist[0]-1 = 1 (not 0); the axis value (index 0) is
+    # a boundary-condition zero and must not be included in the spline.
+    iota_spline = CubicSpline(s_half, iota_h)
+    B_theta = CubicSpline(s_half, buco_h)(s_grid)
+    B_phi = CubicSpline(s_half, bvco_h)(s_grid)
+    # A_phi(s) = -torflux * integral_0^s iota(s') ds'; sign follows SIMPLE's
+    # chi = -A_phi convention (libneo spline_vmec_data, compute_boozer_data).
+    iota_int = iota_spline.antiderivative()
+    A_phi = -torflux_si * (iota_int(s_grid) - iota_int(0.0))
+
+    print(f"Evaluating Bmod on {n_rho} x {n_theta_field} x {n_phi_field}...")
+    bmnc_g = interp_coeffs(d["bmnc"], d["ixm"], rho_half, rho_grid)
+    Bmod = fourier_eval(bmnc_g, d["ixm"], d["ixn"], theta_field, zeta_field,
+                        "cos")
+    if d["lasym"]:
+        bmns_g = interp_coeffs(d["bmns"], d["ixm"], rho_half, rho_grid)
+        Bmod += fourier_eval(bmns_g, d["ixm"], d["ixn"], theta_field,
+                             zeta_field, "sin")
+
+    print(f"Evaluating geometry on {n_rho} x {n_theta_geom} x {n_phi_geom}...")
+    rmnc_g = interp_coeffs(d["rmnc"], d["ixm"], rho_half, rho_grid)
+    zmns_g = interp_coeffs(d["zmns"], d["ixm"], rho_half, rho_grid)
+    pmns_g = interp_coeffs(d["pmns"], d["ixm"], rho_half, rho_grid)
+    R = fourier_eval(rmnc_g, d["ixm"], d["ixn"], theta_geom, zeta_geom, "cos")
+    Z = fourier_eval(zmns_g, d["ixm"], d["ixn"], theta_geom, zeta_geom, "sin")
+    p = fourier_eval(pmns_g, d["ixm"], d["ixn"], theta_geom, zeta_geom, "sin")
+    if d["lasym"]:
+        rmns_g = interp_coeffs(d["rmns"], d["ixm"], rho_half, rho_grid)
+        zmnc_g = interp_coeffs(d["zmnc"], d["ixm"], rho_half, rho_grid)
+        pmnc_g = interp_coeffs(d["pmnc"], d["ixm"], rho_half, rho_grid)
+        R += fourier_eval(rmns_g, d["ixm"], d["ixn"], theta_geom, zeta_geom,
+                          "sin")
+        Z += fourier_eval(zmnc_g, d["ixm"], d["ixn"], theta_geom, zeta_geom,
+                          "cos")
+        p += fourier_eval(pmnc_g, d["ixm"], d["ixn"], theta_geom, zeta_geom,
+                          "cos")
+    # Cylindrical angle: phi_cyl = zeta_B + p.
+    phi_cyl = zeta_geom[None, None, :] + p
+    X = R * np.cos(phi_cyl)
+    Y = R * np.sin(phi_cyl)
+
+    # SI -> CGS (chartmap stores Gauss and cm).
+    Bmod = Bmod * 1.0e4              # T -> G
+    B_theta = B_theta * 1.0e6        # T*m -> G*cm
+    B_phi = B_phi * 1.0e6            # T*m -> G*cm
+    A_phi = A_phi * 1.0e8            # T*m^2 -> G*cm^2
+    torflux = torflux_si * 1.0e8     # T*m^2 -> G*cm^2
+    X, Y, Z = X * 1.0e2, Y * 1.0e2, Z * 1.0e2  # m -> cm
+
+    print(f"Writing {args.output}")
+    ds = netCDF4.Dataset(args.output, "w", format="NETCDF4")
+    ds.createDimension("rho", n_rho)
+    ds.createDimension("theta", n_theta_geom)
+    ds.createDimension("zeta", n_phi_geom)
+    ds.createDimension("theta_field", n_theta_field)
+    ds.createDimension("zeta_field", n_phi_field)
+
+    v = ds.createVariable("rho", "f8", ("rho",)); v[:] = rho_grid
+    v = ds.createVariable("theta", "f8", ("theta",)); v[:] = theta_geom
+    v = ds.createVariable("zeta", "f8", ("zeta",)); v[:] = zeta_geom
+
+    # NetCDF dimensions are (zeta, theta, rho) so NF90 reads as (rho, theta, zeta).
+    for name, arr in [("x", X), ("y", Y), ("z", Z)]:
+        v = ds.createVariable(name, "f8", ("zeta", "theta", "rho"))
+        v[:] = np.transpose(arr, (2, 1, 0))
+        v.units = "cm"
+
+    v = ds.createVariable("A_phi", "f8", ("rho",)); v[:] = A_phi
+    v = ds.createVariable("B_theta", "f8", ("rho",)); v[:] = B_theta
+    v = ds.createVariable("B_phi", "f8", ("rho",)); v[:] = B_phi
+    v = ds.createVariable("Bmod", "f8", ("zeta_field", "theta_field", "rho"))
+    v[:] = np.transpose(Bmod, (2, 1, 0))
+
+    v = ds.createVariable("num_field_periods", "i4"); v[:] = np.int32(nfp)
+
+    ds.rho_convention = "rho_tor"
+    ds.zeta_convention = "boozer"
+    ds.rho_lcfs = float(rho_grid[-1])
+    ds.boozer_field = np.int32(1)
+    ds.torflux = torflux
+    # No rmajor attribute: the chartmap reader derives the major radius from
+    # the innermost-surface geometry (see boozer_chartmap_io.f90).
+    ds.booz2chartmap_source = args.boozmn
+
+    ds.close()
+    print(f"Done. nfp={nfp}, torflux={torflux:.6e} G cm^2")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes itpplasma/SIMPLE#372. Adds `tools/booz_xform_to_boozer_chartmap.py`: convert booz_xform output (`boozmn*.nc`) to the extended Boozer chartmap format, so SIMPLE can integrate orbits in the identical field representation other codes consume in the itpplasma/benchmark-orbit-proxima#1 cross-code benchmark. Stacked on itpplasma/SIMPLE#375 (merge that first); split out of itpplasma/SIMPLE#373.

## Converter

- `B_theta = buco_b`, `B_phi = bvco_b`; `A_phi(s) = -torflux * int_0^s iota ds'`.
- Bmod and geometry from spectral summation of the half-grid harmonics (`s_half = (jlist - 1.5)/(ns_b - 1)`, verified against booz_xform's own `s_in`); cylindrical angle `phi_cyl = zeta_B + p` with `p` from `pmns_b`. Cubic-spline radial interpolation per mode, `rho^m` power-law continuation inside the innermost half-grid surface. `lasym` partner coefficients included.
- torflux from `phi_b` when present. The Python booz_xform writer leaves `phi_b` zeroed; the converter then recovers psi' from the Boozer identity `sqrt(g) B^2 = psi' (G + iota I)` with the Jacobian built from spectral angle derivatives and radial spline derivatives. The spread across mid-radius surfaces is a consistency check (observed 8e-6 relative against the wout value, including the sign).
- Input is a boozmn file alone; no wout needed (rmajor is derived by the reader since the base PR).

## Risk tier

- [ ] T0: docs, comments, small build metadata
- [ ] T1: pure refactor, no behavior change intended
- [x] T2: local numerical logic
- [ ] T3: physics, output behavior, wall losses, collisions, coordinate conventions
- [ ] T4: parallelism, GPU offload, dependencies, CI, security-sensitive build logic

Additive: a new tool, a new test, docs. No existing code path changes.

## Correctness contract

### Intended behavior change

- New converter `tools/booz_xform_to_boozer_chartmap.py`. No change to existing behavior.

### Behavior that must not change

- All existing field paths, readers, writers: untouched by this commit.

### Coordinate / unit conventions

- boozmn is SI; converter writes Gauss, cm, G cm^2. SIMPLE's `torflux = -phi_wout(ns)/(2*pi)` sign convention reproduced (libneo `vmecinm_m.f90`).
- booz_xform half grid: `s_half = (jlist - 1.5)/(ns_b - 1)`; `phi_cyl = zeta_B + p`.

### Numerical invariants

- Converted chartmap reproduces the spectral boozmn field within the grid-convergent interpolation error (1.6e-5 relative on the default grid).

## Tests added

- unit: none (no existing path touched)
- integration: `test_booz_xform_chartmap.py` spectral-reference and golden cross-check stages (CTest-registered when booz_xform is importable; skipped with a status message otherwise)
- system: `test_booz_xform_chartmap.py` end-to-end VMEC vs converted-chartmap orbit run
- golden record: not touched

## Golden-record impact

- [x] unchanged
- [ ] changed

Additive tool; no simulation code path changes.

## Failure modes considered

- boozmn without `phi_b` (Python booz_xform writer): geometric flux recovery, guarded by a 1e-3 cross-surface consistency check that aborts on inconsistent files.
- Wrong half-grid convention: `(jlist - 0.5)` instead of `(jlist - 1.5)` shifts every profile by one half-cell; pinned by comparison against booz_xform's `s_in` and by the golden cross-check tolerances.
- Sign errors in `pmns`/torflux: caught by the geometry cross-check (0.4 cm max against 250 cm for the flipped sign) and the torflux comparison (3e-8 relative).

## Manual validation

Conventions were pinned against SIMPLE's own `export_boozer_chartmap` output for the QA equilibrium before writing the converter: `phi_cyl = zeta_B + p` gives 0.025 cm max geometry difference on a half-grid surface (the opposite sign gives 249 cm); the geometric psi' reproduces `-phi_wout(ns)/(2*pi) = -8.0345e8 G cm^2` including sign.

## Verification

`test_booz_xform_chartmap` on this branch:

```
== Spectral reference with grid convergence ==
  Bmod coarse grid max rel err vs spectral: 5.813e-05
  Bmod fine grid max rel err vs spectral: 1.639e-05
  Bmod fine-grid spectral error: 1.639e-05 (tol 1e-04) ok
== Golden cross-check against export_boozer_chartmap ==
  torflux rel diff: 3.066e-08 (tol 1e-06) ok
  A_phi max diff / scale: 4.381e-07 (tol 1e-05) ok
  B_theta max diff / scale: 3.710e-06 (tol 1e-04) ok
  B_phi max diff / scale: 1.720e-05 (tol 1e-04) ok
  Bmod max rel diff: 1.316e-03 (tol 5e-03) ok
  geometry max |diff| [cm]: 4.044e-01 (tol 1e+00) ok
  derived rmajor rel diff: 6.277e-05 (tol 1e-03) ok
== End-to-end VMEC vs booz_xform chartmap orbits ==
  dtaumin rel diff: 1.189e-02 (tol 5e-02) ok
  ntau rel diff: 1.175e-02 (tol 5e-02) ok
  confined fraction max |total_conf diff|: 0.000e+00 (tol 3e-02) ok
  confined fraction max |pass_conf diff|: 0.000e+00 (tol 3e-02) ok
  confined fraction max |trap_conf diff|: 0.000e+00 (tol 3e-02) ok
BOOZ_XFORM CHARTMAP CONVERTER TEST PASSED
```

Full suite (`make test`): 100 percent passed, 0 failed out of 58, 331 s. Golden records (`make test-golden`, deterministic build): 13/13 pass; CI regression step green on this branch: https://github.com/itpplasma/SIMPLE/actions/runs/27279802255/job/80570833928
