### PR TITLE
Fix test_bminmax_lifecycle segfault from procedure-pointer trampoline

### DIFF
--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -1,3 +1,14 @@
+# Enforce no procedure-pointer trampolines in test executables. A pointer to an
+# internal procedure builds a stack trampoline that faults on a non-executable
+# stack; keep procedure-pointer targets (e.g. test magfie backends) as module
+# procedures. Inherited by the field_can/magfie/orbit subdirectories below.
+if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+    add_compile_options(
+        $<$<COMPILE_LANGUAGE:Fortran>:-Wtrampolines>
+        $<$<COMPILE_LANGUAGE:Fortran>:-Werror=trampolines>
+    )
+endif()
+
 ##################################################
 # DOWNLOAD TEST DATA
 ##################################################

--- a/test/tests/test_bminmax_lifecycle.f90
+++ b/test/tests/test_bminmax_lifecycle.f90
@@ -1,3 +1,40 @@
+! The analytic magfie backend lives in a module so it is an ordinary module
+! procedure. A pointer to a program-internal procedure forces gfortran to build
+! a trampoline on the stack, which faults on a non-executable stack.
+module test_bminmax_backend
+    use magfie_sub, only: dp
+    use new_vmec_stuff_mod, only: nper
+    implicit none
+
+contains
+
+    subroutine test_magfie_backend(x, bmod, sqrtg, bder, hcovar, hctrvr, hcurl)
+        real(dp), intent(in) :: x(3)
+        real(dp), intent(out) :: bmod, sqrtg
+        real(dp), intent(out) :: bder(3), hcovar(3), hctrvr(3), hcurl(3)
+
+        real(dp), parameter :: amp_theta = 0.1_dp
+        real(dp), parameter :: amp_phi = 0.05_dp
+        real(dp), parameter :: theta0 = 0.2_dp
+        real(dp), parameter :: phi0 = 0.4_dp
+        real(dp) :: phase_theta, phase_phi, kphi
+
+        kphi = real(max(1, nper), dp)
+        phase_theta = x(2) - theta0
+        phase_phi = kphi*x(3) - phi0
+
+        bmod = 2.0_dp + x(1) + amp_theta*cos(phase_theta) + amp_phi*cos(phase_phi)
+        sqrtg = 1.0_dp
+        bder(1) = 1.0_dp/bmod
+        bder(2) = -amp_theta*sin(phase_theta)/bmod
+        bder(3) = -amp_phi*kphi*sin(phase_phi)/bmod
+        hcovar = 0.0_dp
+        hctrvr = [0.0_dp, 0.0_dp, 1.0_dp]
+        hcurl = 0.0_dp
+    end subroutine test_magfie_backend
+
+end module test_bminmax_backend
+
 program test_bminmax_lifecycle
     use bminmax_mod, only: prop
     use find_bminmax_sub, only: get_bminmax, init_bminmax_arrays
@@ -5,6 +42,7 @@ program test_bminmax_lifecycle
     use new_vmec_stuff_mod, only: nper
     use params, only: class_plot, ntcut, num_surf
     use simple_main, only: needs_bminmax_cache
+    use test_bminmax_backend, only: test_magfie_backend
     use test_utils, only: check, check_close
 
     implicit none
@@ -82,30 +120,5 @@ contains
 
         prop = .true.
     end subroutine test_active_backend_cache
-
-    subroutine test_magfie_backend(x, bmod, sqrtg, bder, hcovar, hctrvr, hcurl)
-        real(dp), intent(in) :: x(3)
-        real(dp), intent(out) :: bmod, sqrtg
-        real(dp), intent(out) :: bder(3), hcovar(3), hctrvr(3), hcurl(3)
-
-        real(dp), parameter :: amp_theta = 0.1_dp
-        real(dp), parameter :: amp_phi = 0.05_dp
-        real(dp), parameter :: theta0 = 0.2_dp
-        real(dp), parameter :: phi0 = 0.4_dp
-        real(dp) :: phase_theta, phase_phi, kphi
-
-        kphi = real(max(1, nper), dp)
-        phase_theta = x(2) - theta0
-        phase_phi = kphi*x(3) - phi0
-
-        bmod = 2.0_dp + x(1) + amp_theta*cos(phase_theta) + amp_phi*cos(phase_phi)
-        sqrtg = 1.0_dp
-        bder(1) = 1.0_dp/bmod
-        bder(2) = -amp_theta*sin(phase_theta)/bmod
-        bder(3) = -amp_phi*kphi*sin(phase_phi)/bmod
-        hcovar = 0.0_dp
-        hctrvr = [0.0_dp, 0.0_dp, 1.0_dp]
-        hcurl = 0.0_dp
-    end subroutine test_magfie_backend
 
 end program test_bminmax_lifecycle


### PR DESCRIPTION
## Risk tier

- [ ] T0
- [x] T1: test-only, no production behavior change
- [ ] T2
- [ ] T3
- [ ] T4

## Intended behavior change

None. Test portability fix.

## Problem

`test_bminmax_lifecycle` segfaults: it assigns the `magfie` procedure
pointer to `test_magfie_backend`, a program-internal procedure. gfortran
implements a pointer to an internal procedure with a trampoline placed on
the stack. The indirect call through `magfie` (in `getbmod`,
`find_bminmax.f90`) then jumps into the stack and faults where the stack
is not executable.

```
#1  getbmod () at src/find_bminmax.f90:82
#2  find_bminmax (s=1e-08) ...
#3  init_bminmax_arrays ()
Program received signal SIGSEGV
```

## Fix

Move the analytic backend into a module (`test_bminmax_backend`) so it is
an ordinary module procedure, which needs no trampoline. Production magfie
backends are already module procedures, so only the test was affected.

## Verification

```text
# before (program-internal backend)
./test_bminmax_lifecycle.x bminmax_cache_cases.tsv
Segmentation fault (core dumped)   exit=139

# after (module backend)
./test_bminmax_lifecycle.x bminmax_cache_cases.tsv
 test_bminmax_lifecycle passed     exit=0

make test-fast   ->  all tests pass (was 1 failed: test_bminmax_lifecycle SEGFAULT)
```

## Golden-record impact

- [x] unchanged (test-only)
