### PR TITLE
Continue symplectic orbits through the magnetic axis instead of clamping r to 0.01

### DIFF
--- a/src/orbit_symplectic.f90
+++ b/src/orbit_symplectic.f90
@@ -373,6 +373,11 @@ recursive subroutine newton1(si, f, x, maxit, xlast)
 
   do kit = 1, maxit
     if (x(1) > 1d0) return
+    ! Transient guard: in s = rho^2 coordinates the Hamiltonian is not
+    ! smooth at the axis (sqrt(s) behavior), so there is no consistent
+    ! field extension to s < 0 for the solver itself. Intermediate
+    ! negative iterates are floored as before; a converged negative
+    ! solution is committed as an axis crossing by the caller (#370).
     if (x(1) < 0d0) x(1) = 0.01d0
 
     call eval_field(f, x(1), si%z(2), si%z(3), 2)
@@ -403,6 +408,8 @@ recursive subroutine newton2(si, f, x, atol, rtol, maxit, xlast)
 
   do kit = 1, maxit
     if(x(1) > 1.0) return
+    ! Transient guard for intermediate iterates; the converged-negative
+    ! case is handled by the caller via a chart switch (#370).
     if(x(1) < 0.0) x(1) = 0.01
     call f_sympl_euler2(si, f, n, x, fvec, 1)
     fabs = dabs(fvec)
@@ -469,6 +476,8 @@ recursive subroutine newton_midpoint(si, f, x, atol, rtol, maxit, xlast)
 
   do kit = 1, maxit
     if(x(1) > 1.0) return
+    ! Transient guards for intermediate iterates; the converged-negative
+    ! case is handled by the caller via a chart switch (#370).
     if(x(1) < 0.0) x(1) = 0.01
     if(x(5) < 0.0) x(5) = 0.01
     call f_midpoint_part1(si, f, n, x, fvec)
@@ -633,6 +642,8 @@ recursive subroutine newton_rk_gauss(si, fs, s, x, atol, rtol, maxit, xlast)
     ! Check if radius left the boundary
     do ks = 1, s
       if (x(4*ks-3) > 1d0) return
+      ! Transient guard for intermediate iterates; the converged-negative
+      ! case is handled by the caller via a chart switch (#370).
       if (x(4*ks-3) < 0.0) x(4*ks-3) = 0.01d0
     end do
 
@@ -688,6 +699,8 @@ recursive subroutine fixpoint_rk_gauss(si, fs, s, x, atol, rtol, maxit, xlast)
     ! Check if radius left the boundary
     do ks = 1, s
       if (x(4*ks-3) > 1d0) return
+      ! Transient guard for intermediate iterates; the converged-negative
+      ! case is handled by the caller via a chart switch (#370).
       if (x(4*ks-3) < 0.0) x(4*ks-3) = 0.01d0
     end do
 
@@ -908,6 +921,7 @@ recursive subroutine newton_rk_lobatto(si, fs, s, x, atol, rtol, maxit, xlast)
 
     ! Check if radius left the boundary
     if (x(1) > 1d0) return
+    ! Transient guard for intermediate iterates (#370).
     if (x(1) < 0.0) x(1) = 0.01d0
     do ks = 2, s
       if (x(4*ks-2-3) > 1d0) return
@@ -1193,6 +1207,7 @@ recursive subroutine orbit_timestep_sympl_expl_impl_euler(si, f, ierr)
 
   real(dp), dimension(n) :: x, xlast
   integer :: ktau
+  logical :: crossed
 
   ierr = 0
   ktau = 0
@@ -1209,17 +1224,29 @@ recursive subroutine orbit_timestep_sympl_expl_impl_euler(si, f, ierr)
       return
     end if
 
+    crossed = .false.
     if (x(1) < 0.0d0) then
+      ! The converged radius lies beyond the axis: commit the chart switch
+      ! (r, theta) -> (|r|, theta + pi) and continue the orbit (#370).
+      x(1) = -x(1)
+      si%z(2) = si%z(2) + pi
+      crossed = .true.
       call count_event(EVT_R_NEGATIVE)
-      x(1) = 0.01d0
+      if (x(1) > 1.0d0) then
+        ! Pathological solve (|r| beyond the boundary on the far side).
+        ierr = 1
+        return
+      end if
     end if
 
     si%z(1) = x(1)
     si%z(4) = x(2)
 
-    if (extrap_field) then
+    if (extrap_field .and. .not. crossed) then
       call sympl_euler1_extrapolate_field(si, f, x, xlast)
     else
+      ! After a chart switch xlast lives in the other chart; extrapolation
+      ! across the flip is invalid, evaluate the field fresh instead.
       call eval_field(f, si%z(1), si%z(2), si%z(3), 0)
       call get_derivatives(f, si%z(4))
     endif
@@ -1246,6 +1273,7 @@ recursive subroutine orbit_timestep_sympl_impl_expl_euler(si, f, ierr)
 
   real(dp), dimension(n) :: x, xlast, dz
   integer :: ktau
+  logical :: crossed
 
   ierr = 0
   ktau = 0
@@ -1261,14 +1289,23 @@ recursive subroutine orbit_timestep_sympl_impl_expl_euler(si, f, ierr)
       return
     end if
 
+    crossed = .false.
     if (x(1) < 0.0) then
-      print *, 'r<0, z = ', x(1), si%z(2), si%z(3), x(2)
-      x(1) = 0.01
+      ! The converged radius lies beyond the axis: commit the chart switch
+      ! (r, theta) -> (|r|, theta + pi) and continue the orbit (#370).
+      x(1) = -x(1)
+      x(2) = x(2) + pi
+      crossed = .true.
+      call count_event(EVT_R_NEGATIVE)
+      if (x(1) > 1.0) then
+        ierr = 1
+        return
+      end if
     end if
 
     si%z(1:3) = x
 
-    if (extrap_field) then
+    if (extrap_field .and. .not. crossed) then
       dz(1) = x(1)-xlast(1)
       dz(2) = x(2)-xlast(2)
       dz(3) = x(3)-xlast(3)
@@ -1325,8 +1362,15 @@ recursive subroutine orbit_timestep_sympl_midpoint(si, f, ierr)
     end if
 
     if (x(1) < 0.0) then
-      print *, 'r<0, z = ', x(1), si%z(2), si%z(3), x(2)
-      x(1) = 0.01
+      ! Axis crossing on the final iterate: continue on the opposite ray
+      ! (see newton1); x(2) is the corresponding theta.
+      x(1) = -x(1)
+      x(2) = x(2) + pi
+      call count_event(EVT_R_NEGATIVE)
+      if (x(1) > 1.0) then
+        ierr = 1
+        return
+      end if
     end if
 
     si%z = x(1:4)
@@ -1389,8 +1433,15 @@ recursive subroutine orbit_timestep_sympl_rk_gauss(si, f, s, ierr)
     end if
 
     if (x(1) < 0.0) then
-      print *, 'r<0, z = ', x(1), si%z(2), si%z(3), x(2)
-      x(1) = 0.01
+      ! Axis crossing on the final iterate: continue on the opposite ray
+      ! (see newton1); x(2) is the corresponding theta.
+      x(1) = -x(1)
+      x(2) = x(2) + pi
+      call count_event(EVT_R_NEGATIVE)
+      if (x(1) > 1.0) then
+        ierr = 1
+        return
+      end if
     end if
 
     call coeff_rk_gauss(s, a, b, c)  ! TODO: move this to preprocessing

--- a/src/orbit_symplectic_quasi.f90
+++ b/src/orbit_symplectic_quasi.f90
@@ -1,5 +1,6 @@
 module orbit_symplectic_quasi
 
+use util, only: pi
 use field_can_mod, only: eval_field => evaluate, field_can_t, get_derivatives
 use orbit_symplectic_base, only: symplectic_integrator_t, multistage_integrator_t, &
   orbit_timestep_quasi_i, coeff_rk_gauss, coeff_rk_lobatto, f_rk_lobatto
@@ -217,8 +218,15 @@ subroutine timestep_midpoint_quasi(ierr)
     end if
 
     if (x(1) < 0.0) then
+      ! Axis crossing: continue on the opposite ray, (r, theta) ->
+      ! (|r|, theta + pi), instead of the former teleport to r = 0.01 (#370).
       call count_event(EVT_R_NEGATIVE)
-      x(1) = 0.01
+      x(1) = -x(1)
+      x(2) = x(2) + pi
+      if (x(1) > 1.0) then
+        ierr = 1
+        return
+      end if
     end if
 
     si%z = x(1:4)
@@ -257,8 +265,15 @@ subroutine timestep_expl_impl_euler_quasi(ierr)
     end if
 
     if (x(1) < 0.0) then
+      ! Axis crossing: continue on the opposite ray, (r, theta) ->
+      ! (|r|, theta + pi), instead of the former teleport to r = 0.01 (#370).
       call count_event(EVT_R_NEGATIVE)
-      x(1) = 0.01
+      x(1) = -x(1)
+      x(2) = x(2) + pi
+      if (x(1) > 1.0) then
+        ierr = 1
+        return
+      end if
     end if
 
     si%z(1) = x(1)
@@ -311,8 +326,15 @@ subroutine timestep_impl_expl_euler_quasi(ierr)
     end if
 
     if (x(1) < 0.0) then
+      ! Axis crossing: continue on the opposite ray, (r, theta) ->
+      ! (|r|, theta + pi), instead of the former teleport to r = 0.01 (#370).
       call count_event(EVT_R_NEGATIVE)
-      x(1) = 0.01
+      x(1) = -x(1)
+      x(2) = x(2) + pi
+      if (x(1) > 1.0) then
+        ierr = 1
+        return
+      end if
     end if
 
     si%z(1:3) = x
@@ -368,8 +390,15 @@ subroutine timestep_rk_gauss_quasi(s, ierr)
     end if
 
     if (x(1) < 0.0) then
+      ! Axis crossing: continue on the opposite ray, (r, theta) ->
+      ! (|r|, theta + pi), instead of the former teleport to r = 0.01 (#370).
       call count_event(EVT_R_NEGATIVE)
-      x(1) = 0.01
+      x(1) = -x(1)
+      x(2) = x(2) + pi
+      if (x(1) > 1.0) then
+        ierr = 1
+        return
+      end if
     end if
 
     call coeff_rk_gauss(s, a, b, c)

--- a/src/simple_gpu.f90
+++ b/src/simple_gpu.f90
@@ -9,7 +9,8 @@ module simple_gpu
     ! symplectic-Euler algebra from orbit_symplectic_euler1. Equivalence is
     ! checked against the CPU path by test_gpu_orbit_bench.
     use, intrinsic :: iso_fortran_env, only: dp => real64
-    use field_can_mod, only: field_can_t, get_derivatives2
+    use util, only: pi
+    use field_can_mod, only: field_can_t, get_derivatives, get_derivatives2
     use field_can_boozer, only: eval_field_booz
     use orbit_symplectic_base, only: symplectic_integrator_t
     use orbit_symplectic_euler1, only: sympl_euler1_newton_iter
@@ -45,6 +46,8 @@ contains
 
         do kit = 1, maxit
             if (x(1) > 1d0) return
+            ! Transient guard; converged-negative handled by the caller
+            ! (mirrors newton1 in orbit_symplectic, #370).
             if (x(1) < 0d0) x(1) = 0.01d0
 
             call eval_field_booz(f, x(1), si%z(2), si%z(3), 2)
@@ -64,6 +67,7 @@ contains
 
         real(dp) :: x(2), xlast(2)
         integer :: ktau
+        logical :: crossed
 
         ierr = 0
         ktau = 0
@@ -79,9 +83,30 @@ contains
                 ierr = 1
                 return
             end if
-            if (x(1) < 0.0d0) x(1) = 0.01d0
+            crossed = .false.
+            if (x(1) < 0.0d0) then
+                ! The converged radius lies beyond the axis: commit the
+                ! chart switch (r, theta) -> (|r|, theta + pi) (#370).
+                x(1) = -x(1)
+                si%z(2) = si%z(2) + pi
+                crossed = .true.
+                if (x(1) > 1.0d0) then
+                    ierr = 1
+                    return
+                end if
+            end if
 
-            call sympl_euler1_extrapolate_field(si, f, x, xlast)
+            si%z(1) = x(1)
+            si%z(4) = x(2)
+
+            if (crossed) then
+                ! xlast lives in the other chart; extrapolation across the
+                ! flip is invalid, evaluate the field fresh instead.
+                call eval_field_booz(f, si%z(1), si%z(2), si%z(3), 0)
+                call get_derivatives(f, si%z(4))
+            else
+                call sympl_euler1_extrapolate_field(si, f, x, xlast)
+            end if
             call sympl_euler1_advance_angles(si, f)
 
             ktau = ktau + 1

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -314,6 +314,17 @@ if (ENABLE_OPENMP)
     add_test(NAME test_sympl_testfield
         COMMAND test_sympl_testfield.x
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+    # Axis-crossing regression (issue #370): near-axis trapped orbits must
+    # never be lost at the axis and must conserve energy across crossings.
+    add_executable(test_axis_crossing.x test_axis_crossing.f90)
+    target_link_libraries(test_axis_crossing.x simple)
+    add_test(NAME test_axis_crossing
+        COMMAND test_axis_crossing.x
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    set_tests_properties(test_axis_crossing PROPERTIES
+        LABELS "integration"
+        TIMEOUT 120)
 endif()
 
 add_executable (test_coord_trans.x test_coord_trans.f90)
@@ -481,6 +492,16 @@ add_test(NAME test_array_utils COMMAND test_array_utils.x)
     # Export tool for e2e test
     add_executable(export_boozer_chartmap_tool.x export_boozer_chartmap_tool.f90)
     target_link_libraries(export_boozer_chartmap_tool.x simple)
+
+    # Axis-loss regression (issue #370): zero symplectic-only losses on
+    # identical near-axis starts, symplectic Euler vs RK Boozer reference.
+    add_test(NAME test_axis_loss_consistency
+        COMMAND ${BOOZER_CHARTMAP_PYTHON}
+            ${CMAKE_CURRENT_SOURCE_DIR}/test_axis_loss_consistency.py)
+    set_tests_properties(test_axis_loss_consistency PROPERTIES
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        LABELS "system;python"
+        TIMEOUT 1800)
 
     # E2E test: VMEC-Boozer vs chartmap confined fractions
     add_test(NAME test_e2e_boozer_chartmap

--- a/test/tests/test_axis_crossing.f90
+++ b/test/tests/test_axis_crossing.f90
@@ -1,0 +1,216 @@
+program test_axis_crossing
+    !> Axis-crossing regression test for the symplectic Euler1 integrator
+    !> (issue #370): orbits that pass the magnetic axis must continue on the
+    !> opposite ray, (r, theta) -> (|r|, theta + pi), instead of being kicked
+    !> to r = 0.01 and random-walked out of the device.
+    !>
+    !> A set of deeply trapped near-axis starts is traced on the Boozer field
+    !> of the QA test equilibrium. Assertions, for every start:
+    !>   - the orbit is never lost (the old clamp produced exactly such
+    !>     losses),
+    !>   - r stays inside [0, 1),
+    !>   - the energy drift stays bounded.
+    !> At least one start must trigger the axis-crossing branch
+    !> (EVT_R_NEGATIVE), otherwise the test would silently stop covering it.
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use util, only: twopi
+    use simple, only: tracer_t, init_sympl, init_params
+    use simple_main, only: init_field
+    use params, only: field_input, coord_input
+    use new_vmec_stuff_mod, only: rmajor
+    use orbit_symplectic, only: orbit_timestep_sympl
+    use orbit_symplectic_base, only: symplectic_integrator_t
+    use field_can_mod, only: field_can_t, eval_field => evaluate, get_val
+    use diag_counters, only: diag_counters_init, diag_counters_total, &
+                             EVT_R_NEGATIVE
+    use velo_mod, only: isw_field_type
+    use magfie_sub, only: BOOZER
+
+    implicit none
+
+    integer, parameter :: n_start = 6, nsteps = 40000, kcheck = 20
+    ! Bounded oscillation of the symplectic Euler Hamiltonian is allowed
+    ! (it grows toward the axis); secular drift is not.
+    real(dp), parameter :: h_osc_tol = 1.0e-3_dp, h_sec_tol = 1.0e-6_dp
+
+    type(tracer_t) :: norb
+    type(field_can_t) :: fcheck
+    real(dp) :: z5(5)
+    real(dp) :: r0(n_start), vpar0(n_start), th0(n_start)
+    real(dp) :: rbig, dtau, h0, hdrift, rmin, hnow, hsum1, hsum2, hsec
+    real(dp) :: osc_tol, sec_tol, dth
+    integer :: ierr, istart, kt, nh1, nh2, iphase, ksteps
+    integer(8) :: ncross0
+    integer(8) :: ncross
+    logical :: failed
+
+    ! Mix of passing potato orbits (|vpar| large, small r: the orbit circles
+    ! a drift-shifted center and sweeps through the axis) and deeply trapped
+    ! near-axis bananas.
+    r0 = [0.001_dp, 0.002_dp, 0.001_dp, 0.005_dp, 0.003_dp, 0.002_dp]
+    vpar0 = [-0.30_dp, 0.90_dp, 0.95_dp, 0.05_dp, -0.60_dp, -0.90_dp]
+    th0 = [0.0_dp, 1.0_dp, 2.0_dp, 3.0_dp, 4.0_dp, 5.0_dp]
+
+    isw_field_type = BOOZER
+    field_input = 'wout.nc'
+    coord_input = 'wout.nc'
+    call init_field(norb, 'wout.nc', 5, 5, 5, 1)
+    call init_params(norb, 2, 4, 3.5e6_dp, 256, 1, 1.0e-12_dp)
+    call diag_counters_init
+
+    rbig = rmajor*1.0e2_dp
+
+    failed = .false.
+    do iphase = 1, 2
+    ! Phase 1: fine step (512 per torus), tight tolerances; orbits graze the
+    ! axis. Phase 2: coarse step (64 per torus), where the Newton iterate
+    ! genuinely overshoots r < 0 and the chart switch must engage.
+    if (iphase == 1) then
+        dtau = twopi*rbig/512.0_dp
+        ksteps = nsteps
+        osc_tol = h_osc_tol
+        sec_tol = h_sec_tol
+    else
+        dtau = twopi*rbig/64.0_dp
+        ksteps = nsteps/8
+        osc_tol = 1.0e-2_dp
+        sec_tol = 1.0e-4_dp
+    end if
+    do istart = 1, n_start
+        z5(1) = r0(istart)
+        z5(2) = th0(istart)
+        z5(3) = 0.1_dp
+        z5(4) = 1.0_dp
+        z5(5) = vpar0(istart)
+        call init_sympl(norb%si, norb%f, z5, dtau, dtau, 1.0e-12_dp, 1)
+
+        call value_of_h(norb%si, h0)
+        hdrift = 0.0_dp
+        rmin = norb%si%z(1)
+        hsum1 = 0.0_dp
+        hsum2 = 0.0_dp
+        nh1 = 0
+        nh2 = 0
+
+        do kt = 1, ksteps
+            call orbit_timestep_sympl(norb%si, norb%f, ierr)
+            if (ierr /= 0) then
+                print *, 'FAIL: start', istart, 'lost at step', kt, &
+                    ' z = ', norb%si%z
+                failed = .true.
+                exit
+            end if
+            if (norb%si%z(1) < 0.0_dp .or. norb%si%z(1) >= 1.0_dp) then
+                print *, 'FAIL: start', istart, 'r out of range at step', kt, &
+                    ' r = ', norb%si%z(1)
+                failed = .true.
+                exit
+            end if
+            rmin = min(rmin, norb%si%z(1))
+            if (mod(kt, kcheck) == 0) then
+                call value_of_h(norb%si, hnow)
+                hdrift = max(hdrift, abs(hnow - h0)/abs(h0))
+                if (kt <= ksteps/2) then
+                    hsum1 = hsum1 + hnow
+                    nh1 = nh1 + 1
+                else
+                    hsum2 = hsum2 + hnow
+                    nh2 = nh2 + 1
+                end if
+            end if
+        end do
+
+        if (.not. failed) then
+            if (hdrift > osc_tol) then
+                print *, 'FAIL: start', istart, 'energy excursion', hdrift
+                failed = .true.
+            end if
+            hsec = abs(hsum2/max(nh2, 1) - hsum1/max(nh1, 1))/abs(h0)
+            if (hsec > sec_tol) then
+                print *, 'FAIL: start', istart, 'secular energy drift', hsec
+                failed = .true.
+            end if
+        end if
+
+        print '(a,i1,a,i2,a,es10.2,a,es10.2,a,es10.2,a,i12)', ' phase ', &
+            iphase, ' start ', istart, &
+            '  rmin = ', rmin, '  max|dH|/H = ', hdrift, '  sec = ', hsec, &
+            '  crossings so far = ', diag_counters_total(EVT_R_NEGATIVE)
+    end do
+    end do
+
+    ! Phase 3: white-box trigger. On a clean field ds/dt vanishes at the
+    ! axis, so a negative Newton iterate is rare; the spurious-loss bug fired
+    ! on corrupted near-axis field data (#370). Force the implicit solve
+    ! through the axis by biasing f%pth (the driver copies it to pthold) and
+    ! require the chart switch to engage and the orbit to survive.
+    dtau = twopi*rbig/64.0_dp
+    ncross0 = diag_counters_total(EVT_R_NEGATIVE)
+    trigger: do istart = 1, n_start
+        do kt = 1, 9
+            z5 = [2.0e-5_dp, th0(istart), 0.1_dp, 1.0_dp, vpar0(istart)]
+            call init_sympl(norb%si, norb%f, z5, dtau, dtau, 1.0e-12_dp, 1)
+            ! Bias pth by a few times the radial pth variation across the
+            ! start radius, so the implicit solve lands at a small negative
+            ! radius (a realistic crossing magnitude).
+            ! Signed: linearized solution r = r0*(1 - kt) crosses for kt >= 2.
+            norb%f%pth = norb%f%pth &
+                - real(kt, dp)*z5(1)*norb%f%dpth(1)
+            call orbit_timestep_sympl(norb%si, norb%f, ierr)
+            ! The bias is unphysical by construction, so a loss flag on the
+            ! poisoned orbit is not itself a failure; only the crossing
+            ! semantics are asserted once the event fires.
+            if (diag_counters_total(EVT_R_NEGATIVE) > ncross0) then
+                ! Discriminate the chart switch from the historic clamp:
+                ! the clamp teleported to exactly r = 0.01 with theta
+                ! unchanged; the switch keeps r near the axis (the committed
+                ! magnitude is the small overshoot) and shifts theta by pi.
+                if (norb%si%z(1) < 0.0_dp) then
+                    print *, 'FAIL: trigger left r negative, r = ', &
+                        norb%si%z(1)
+                    failed = .true.
+                end if
+                if (norb%si%z(1) >= 5.0e-3_dp) then
+                    print *, 'FAIL: trigger left the axis region, r = ', &
+                        norb%si%z(1), ' (clamp-like teleport)'
+                    failed = .true.
+                end if
+                dth = modulo(norb%si%z(2) - th0(istart), twopi)
+                if (abs(dth - 0.5_dp*twopi) > 1.0_dp) then
+                    print *, 'FAIL: trigger theta shift ', dth, &
+                        ' not close to pi (clamp-like continuation)'
+                    failed = .true.
+                end if
+                exit trigger
+            end if
+        end do
+    end do trigger
+
+    ncross = diag_counters_total(EVT_R_NEGATIVE)
+    if (ncross < 1) then
+        print *, 'FAIL: no start triggered the axis-crossing branch; ', &
+            'the test no longer covers it'
+        failed = .true.
+    end if
+
+    if (failed) then
+        print *, 'TEST FAILED'
+        error stop 1
+    end if
+    print *, 'test_axis_crossing PASSED, crossings = ', ncross
+
+contains
+
+    subroutine value_of_h(si, h)
+        !> Energy at the current integrator state, from a fresh field
+        !> evaluation (the integrator's own f may hold extrapolated values).
+        type(symplectic_integrator_t), intent(in) :: si
+        real(dp), intent(out) :: h
+
+        fcheck = norb%f
+        call eval_field(fcheck, si%z(1), si%z(2), si%z(3), 0)
+        call get_val(fcheck, si%z(4))
+        h = fcheck%H
+    end subroutine value_of_h
+
+end program test_axis_crossing

--- a/test/tests/test_axis_loss_consistency.py
+++ b/test/tests/test_axis_loss_consistency.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""System-level axis-loss regression for issue #370.
+
+Traces the same deterministic particle set near the axis with the symplectic
+Euler integrator (integmode=1) and the RK reference in Boozer coordinates
+(integmode=0) on the QA test equilibrium. The old near-axis clamp produced
+particles lost only in the symplectic run; the strict acceptance here is
+zero symplectic-only losses.
+"""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+BUILD_DIR = SCRIPT_DIR.parent.parent / "build"
+SIMPLE_X = BUILD_DIR / "simple.x"
+WOUT = SCRIPT_DIR.parent / "test_data" / "wout.nc"
+WORKDIR = BUILD_DIR / "axis_loss_consistency"
+
+SIMPLE_IN = """\
+&config
+trace_time = 1d-2
+ntimstep = 200
+ntestpart = 32
+sbeg = 0.05d0
+contr_pp = -1e10
+netcdffile = 'wout.nc'
+isw_field_type = 2
+deterministic = .True.
+startmode = {startmode}
+integmode = {integmode}
+relerr = {relerr}
+npoiper2 = 256
+facE_al = 1.0d0
+/
+"""
+
+
+def run(case: str, integmode: int, relerr: str, startmode: int,
+        start_src: Path | None) -> Path:
+    d = WORKDIR / case
+    if d.exists():
+        shutil.rmtree(d)
+    d.mkdir(parents=True)
+    (d / "wout.nc").symlink_to(WOUT)
+    (d / "simple.in").write_text(
+        SIMPLE_IN.format(integmode=integmode, relerr=relerr,
+                         startmode=startmode))
+    if start_src is not None:
+        shutil.copy2(start_src, d / "start.dat")
+    res = subprocess.run([str(SIMPLE_X)], cwd=d, capture_output=True,
+                         text=True, timeout=1200)
+    if res.returncode != 0:
+        print(res.stdout[-2000:])
+        print(res.stderr[-2000:])
+        sys.exit(f"{case}: simple.x failed")
+    return d
+
+
+def loss_times(d: Path) -> np.ndarray:
+    return np.loadtxt(d / "times_lost.dat")[:, 1]
+
+
+def main() -> None:
+    if not SIMPLE_X.exists() or not WOUT.exists():
+        sys.exit("missing simple.x or wout.nc")
+
+    # Symplectic run generates the deterministic start.dat; RK reuses it.
+    d_sympl = run("sympl", integmode=1, relerr="1d-13", startmode=1,
+                  start_src=None)
+    d_rk = run("rk", integmode=0, relerr="1d-12", startmode=2,
+               start_src=d_sympl / "start.dat")
+
+    trace_time = 1e-2
+    tl_s = loss_times(d_sympl)
+    tl_r = loss_times(d_rk)
+    lost_s = (tl_s > 0) & (tl_s < trace_time)
+    lost_r = (tl_r > 0) & (tl_r < trace_time)
+    sympl_only = lost_s & ~lost_r
+    print(f"lost sympl: {lost_s.sum()}, lost RK: {lost_r.sum()}, "
+          f"sympl-only: {sympl_only.sum()}, rk-only: {(lost_r & ~lost_s).sum()}")
+    if sympl_only.sum() != 0:
+        idx = np.nonzero(sympl_only)[0] + 1
+        sys.exit(f"FAIL: particles lost only in the symplectic run: {idx}")
+    print("test_axis_loss_consistency PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes the orbit-level part of itpplasma/benchmark-orbit-proxima#1. When the implicit symplectic solve converges to a negative radius, the orbit has passed the magnetic axis. The drivers now commit the chart switch (r, theta) -> (|r|, theta + pi) with a fresh field evaluation instead of teleporting the particle to r = 0.01 at unchanged angle. The old teleport injected spurious radial transport of trapped orbits; on a W7-X high-mirror case it fired about 600 times per 1000 particles and produced 51 losses that the RK reference does not show.

Also fixes a frozen-state bug in the GPU driver found on the way: `gpu_timestep_euler` never wrote the Newton solution back to `si%z(1)`/`si%z(4)`. With the write-back, the GPU bench agrees with the CPU path exactly on host, which removes the chaotic divergence behind the flaky loss-step criterion of itpplasma/SIMPLE#380.

## Risk tier

- [ ] T0: docs, comments, small build metadata
- [ ] T1: pure refactor, no behavior change intended
- [ ] T2: local numerical logic
- [x] T3: physics, output behavior, coordinate convention
- [ ] T4: parallelism, GPU, dependency, CI, or security-sensitive build logic

## Correctness contract

### Intended behavior change

- Symplectic drivers (Euler1, Euler2, midpoint, Gauss, the quasi variants, the GPU twin): a converged negative radius commits (r, theta) -> (|r|, theta + pi), counts an `r_negative` event, evaluates the field fresh (extrapolation across the flip is invalid), and continues the orbit. A committed |r| > 1 on the far side counts as loss.
- GPU driver writes the Newton solution back to the integrator state each substep.

### Behavior that must not change

- Orbits that never produce a negative converged radius take bit-identical paths (transient Newton floor at 0.01 unchanged, extrapolation unchanged). On W7-X high mirror, prompt losses match the old code within 5 particles of 1000 and the loss agreement with RK on the 270 genuinely lost particles is untouched.
- RK paths (`orbit_timestep_axis`) untouched.

### Coordinate / unit conventions

- r = s (toroidal flux label); the chart switch is the polar-chart continuation in (rho, theta) expressed in s. In s the Hamiltonian has sqrt(s) behavior at the axis, so intermediate Newton iterates keep the historic transient floor; only the converged solution is chart-switched. No consistent field extension to s < 0 exists for the solver itself; two earlier in-loop variants (state flip, image-point evaluation with unflipped radial-derivative signs) were tested and degraded W7-X confinement to 0.21 and 0.64 respectively, against 0.679 for the clamp.
- The Lobatto stage guard with the mismatched index pair (`x(4*ks-2-3)` guarding an assignment to `x(4*ks-3)`) is left as found; flagged here for a separate look.

### Numerical invariants

- Near-axis orbits: never lost at the axis, r stays in [0, 1), secular energy drift below 1e-6 over 40k steps including axis grazing to r ~ 1e-5 (asserted in test_axis_crossing).
- GPU vs CPU tracing: exact state agreement on host.

## Tests added

- unit: GPU bench now doubles as an exact-equivalence check (max |z_cpu - z_gpu| = 0 instead of O(1)).
- integration: `test_axis_crossing.f90`. Phase 1/2: six near-axis starts (passing potatoes and deep bananas) at fine and coarse dt; never lost, r in range, bounded energy excursion, secular drift < 1e-6 (fine) / 1e-4 (coarse). Phase 3: white-box trigger biases `f%pth` by `-kt*r0*dpth(1)` so the implicit solve lands at a small negative radius, then asserts the crossing semantics: r >= 0, r < 5e-3, theta shifted by pi; the clamp signature (r = 0.01, theta unshifted) fails both.
- system: `test_axis_loss_consistency.py`. 32 deterministic particles at sbeg = 0.05 on the QA test equilibrium, symplectic Euler vs RK Boozer on identical starts; strict zero symplectic-only losses.
- golden record: untouched.

## Golden-record impact

- [ ] unchanged
- [x] changed

Only runs whose orbits reach the axis change: each former r = 0.01 teleport becomes a continuation at the small overshoot radius on the opposite ray. Confined fractions move toward the RK reference (see Manual validation); runs without axis traffic are bit-identical.

## Failure modes considered

- Transient negative Newton iterates far from the axis: handled by the unchanged 0.01 floor; committing chart switches on transients was tested and is catastrophic (0.21 confined).
- Pathologically large negative converged radius (white-box bias, corrupted field data): |r| > 1 after the switch counts as loss instead of continuing outside the domain.
- Repeated crossings: the switch is involutive; the extrapolation skip after a crossing avoids mixing charts in the field linearization.

## Manual validation

W7-X high-mirror case of itpplasma/benchmark-orbit-proxima#1 (benchmark_orbit `run_simple/w7x_high_mirror/`, fixed 1000-particle start.dat, 0.01 s, confined fraction at 1e-4/1e-3/3e-3/1e-2 s):

| run | 1e-4 | 1e-3 | 3e-3 | 1e-2 |
|---|---|---|---|---|
| old clamp (run 100) | 0.764 | 0.708 | 0.699 | 0.679 |
| this PR (run 113) | 0.762 | 0.713 | 0.701 | 0.689 |
| RK Boozer 1e-12 (run 101) | 0.767 | 0.733 | 0.732 | 0.729 |
| sympl on booz_xform chartmap field (run 110) | 0.765 | 0.717 | 0.709 | 0.703 |

Per particle: 10 of the 51 spurious symplectic-only losses are rescued, none added (41 remain symplectic-only, 1 RK-only, unchanged). The remaining gap to RK is the near-axis quality of the internal VMEC-to-Boozer field data (see itpplasma/benchmark-orbit-proxima#1): on the clean booz_xform field the same integrator already matches RK (0.703 vs 0.710), so the field-side healing is the follow-up that closes the rest.

## Verification

test_axis_crossing on the old code (red):

```
FAIL: trigger left the axis region, r =    1.0000000000000000E-002  (clamp-like teleport)
FAIL: trigger theta shift    6.2813906799326400       not close to pi (clamp-like continuation)
TEST FAILED
```

This branch (green):

```
1/3 Test  itpplasma/SIMPLE#3: test_axis_crossing ...............   Passed    1.29 sec
2/3 Test itpplasma/SIMPLE#18: test_axis_loss_consistency .......   Passed   14.89 sec
3/3 Test itpplasma/SIMPLE#34: test_gpu_orbit_bench .............   Passed    3.16 sec
```

GPU bench before:

```
max |z_cpu - z_gpu| (final state) =   2.7562E+00
```

after:

```
max |z_cpu - z_gpu| (final state) =   0.0000E+00
loss-step mismatches = 0 / 8
```

Full fast suite: 44/45 pass; test_profiles fails identically on clean main in this environment (pre-existing, itpplasma/SIMPLE#205).

