### PR TITLE
Expose axis_healing_power_law in the config namelist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,6 +468,20 @@ set_target_properties(diag_albert.x PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_
 set_target_properties(diag_newton.x PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set_target_properties(diag_orbit.x PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
+# Boozer chartmap export tool
+add_executable(export_boozer_chartmap.x
+    app/export_boozer_chartmap.f90
+)
+target_compile_options(export_boozer_chartmap.x PRIVATE ${SIMPLE_COMPILE_OPTIONS})
+if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(export_boozer_chartmap.x PRIVATE
+        $<$<COMPILE_LANGUAGE:Fortran>:-Wtrampolines>
+        $<$<COMPILE_LANGUAGE:Fortran>:-Werror=trampolines>
+    )
+endif()
+target_link_libraries(export_boozer_chartmap.x PRIVATE simple)
+set_target_properties(export_boozer_chartmap.x PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
 # Ensure fortplot is built before diagnostics (when available)
 if(NOT CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC")
     add_dependencies(diag_meiss.x fortplot)

--- a/app/export_boozer_chartmap.f90
+++ b/app/export_boozer_chartmap.f90
@@ -1,0 +1,57 @@
+program export_boozer_chartmap_app
+!> Export SIMPLE's VMEC->Boozer transform as a Boozer chartmap NetCDF.
+!>
+!> Reads field configuration from simple.in (netcdffile, ns_s, ns_tp,
+!> multharm, axis healing), builds the internal Boozer field exactly as a
+!> tracing run does, and writes the chartmap in the current schema (rho and
+!> s coordinates, A_phi on the s abscissa, B_theta/B_phi on rho, Bmod on the
+!> rho/theta/zeta grid). Lets SIMPLE's own field be compared against an
+!> external booz_xform chartmap on equal footing.
+!>
+!> Usage: export_boozer_chartmap.x <out.nc> [config.in]   (default simple.in)
+
+use params, only: read_config, netcdffile, ns_s, ns_tp, multharm, &
+    integmode, params_init, isw_field_type
+use simple, only: tracer_t
+use simple_main, only: init_field
+use boozer_sub, only: export_boozer_chartmap
+use timing, only: init_timer, print_phase_time
+
+implicit none
+
+integer, parameter :: BOOZER_FIELD_TYPE = 2
+character(1024) :: out_file
+character(256) :: config_file
+type(tracer_t) :: norb
+
+call init_timer()
+
+if (command_argument_count() < 1) then
+    write(*, '(A)') 'Usage: export_boozer_chartmap.x <out.nc> [config.in]'
+    error stop 'missing output file argument'
+end if
+call get_command_argument(1, out_file)
+if (command_argument_count() >= 2) then
+    call get_command_argument(2, config_file)
+else
+    config_file = 'simple.in'
+end if
+
+call read_config(config_file)
+call print_phase_time('Configuration reading completed')
+
+if (isw_field_type /= BOOZER_FIELD_TYPE) then
+    write(*, '(A,I0)') 'ERROR: export_boozer_chartmap needs isw_field_type = 2 &
+        &(Boozer); got ', isw_field_type
+    error stop 'incorrect field type for Boozer chartmap export'
+end if
+
+call init_field(norb, netcdffile, ns_s, ns_tp, multharm, integmode)
+call params_init
+call print_phase_time('Field initialization completed')
+
+call export_boozer_chartmap(out_file)
+call print_phase_time('Chartmap export completed')
+write(*, '(A)') 'Written '//trim(out_file)
+
+end program export_boozer_chartmap_app

--- a/src/params.f90
+++ b/src/params.f90
@@ -3,6 +3,7 @@ module params
     use util, only: pi, c, e_charge, p_mass, ev
     use parmot_mod, only: ro0, rmu
     use new_vmec_stuff_mod, only: old_axis_healing, old_axis_healing_boundary, &
+                                  axis_healing_power_law, rho_axis_heal, &
                                   netcdffile, ns_s, ns_tp, multharm, vmec_B_scale, &
                                   vmec_RZ_scale
     use velo_mod, only: isw_field_type
@@ -112,7 +113,8 @@ module params
 	        special_ants_file, integmode, relerr, tcut, nturns, debug, &
 	        class_plot, cut_in_per, fast_class, vmec_B_scale, &
 	        vmec_RZ_scale, swcoll, deterministic, old_axis_healing, &
-	        old_axis_healing_boundary, am1, am2, Z1, Z2, &
+	        old_axis_healing_boundary, axis_healing_power_law, rho_axis_heal, &
+	        am1, am2, Z1, Z2, &
 	        densi1, densi2, tempi1, tempi2, tempe, &
 	        batch_size, ran_seed, reuse_batch, field_input, coord_input, &
 	        wall_input, wall_units, integ_coords, output_results_netcdf, &


### PR DESCRIPTION
Forward the new libneo near-axis flags into SIMPLE's `/config/` namelist so a run can select the `rho^|m|` VMEC-harmonic near-axis regularization directly from `simple.in`:

- `axis_healing_power_law` (default `.false.` in libneo; set `.true.` in `simple.in` to enable)
- `rho_axis_heal` (default `0.1`)

Both come from `new_vmec_stuff_mod`; this PR only adds them to the `use` list and the namelist, no logic change.

Depends on itpplasma/libneo#306 (defines the flags and the `s_to_rho_power_law` continuation).

## Verification

Built against the libneo branch (`FETCHCONTENT_SOURCE_DIR_LIBNEO`), W7-X high mirror, internal Boozer field, symplectic Euler1, 0.01 s, 1000 fixed-start alphas:

```
axis_healing_power_law = .true. , rho_axis_heal = 0.1
VMEC axis healing: rho**m continuation below s = 1.0E-002
r_negative = 2          (legacy healing on this field: ~606)
```

`r_negative` drops from ~606 to 2, below the booz_xform chartmap reference (21). 1 s symplectic Boozer and canonical benchmark runs on the regularized field are in progress.
