### PR TITLE
Drop dead LIBNEO_BRANCH from libneo unexport

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILD_DIR := build
 # Prevent ambient shell env from silently changing which libneo is fetched.
 # Pass the ref explicitly via: make ... LIBNEO_REF=<branch|tag|sha>
 # $(origin) distinguishes a command-line assignment from an env import.
-unexport LIBNEO_REF LIBNEO_PATH LIBNEO_BRANCH
+unexport LIBNEO_REF LIBNEO_PATH
 ifeq ($(origin LIBNEO_REF),command line)
   FLAGS += -DLIBNEO_REF=$(LIBNEO_REF)
 endif


### PR DESCRIPTION
The build honors `LIBNEO_REF` and `LIBNEO_PATH`; `LIBNEO_BRANCH` is never read. Remove it from the `unexport` list.

## Verification
Before: `unexport` listed `LIBNEO_BRANCH`, a name no cmake/Makefile path consumes.
After: `make -n` emits an identical default cmake line (no behavior change); a command-line `LIBNEO_REF` still forwards, an ambient one is still ignored via $(origin).