### PR TITLE
Select near-axis healing by enum

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,6 +468,20 @@ set_target_properties(diag_albert.x PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_
 set_target_properties(diag_newton.x PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set_target_properties(diag_orbit.x PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
+# Boozer chartmap export tool
+add_executable(export_boozer_chartmap.x
+    app/export_boozer_chartmap.f90
+)
+target_compile_options(export_boozer_chartmap.x PRIVATE ${SIMPLE_COMPILE_OPTIONS})
+if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(export_boozer_chartmap.x PRIVATE
+        $<$<COMPILE_LANGUAGE:Fortran>:-Wtrampolines>
+        $<$<COMPILE_LANGUAGE:Fortran>:-Werror=trampolines>
+    )
+endif()
+target_link_libraries(export_boozer_chartmap.x PRIVATE simple)
+set_target_properties(export_boozer_chartmap.x PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
 # Ensure fortplot is built before diagnostics (when available)
 if(NOT CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC")
     add_dependencies(diag_meiss.x fortplot)

--- a/DOC/coordinates-and-fields.md
+++ b/DOC/coordinates-and-fields.md
@@ -786,21 +786,19 @@ magnetic axis. `axis_healing` selects how the harmonics are continued to the axi
 | `axis_healing` | continuation |
 |---|---|
 | `'legacy'` | Discard the innermost surfaces and extrapolate the rescaled amplitude `c/rho^|m|`. Default. |
-| `'powerlaw'` | `rho^|m|` continuation below `rho_axis_heal`. Analytic, but splining `c/rho^|m|` amplifies near-axis noise (rough, ringing at the anchor). Superseded by `polyfit`. |
-| `'polyfit'` | `rho^|m|` times a least-squares polynomial in `s` (a Zernike radial polynomial) fitted to the reliable surfaces below `rho_axis_heal`. Same regularity, smooth, no anchor noise. Recommended. |
+| `'legacy_adaptive'` | Legacy extrapolation with an automatically detected reliability boundary. Diagnostic mode. |
+| `'powerlaw'` | `rho^|m|` continuation below `s_axis_heal`. Analytic, but splining `c/rho^|m|` amplifies near-axis noise. Superseded by `polyfit`. |
+| `'polyfit'` | `rho^|m|` times a least-squares polynomial in `s` fitted to the reliable surfaces below `s_axis_heal`. Same regularity, smooth, no anchor noise. Recommended. |
 
 Related parameters:
 
-- `axis_healing_boundary = 'fixed' | 'adaptive'` (legacy only): the reliability
-  boundary. `'fixed'` discards the innermost `min(|m|,4)` surfaces; `'adaptive'`
-  detects the noisy surface automatically.
-- `rho_axis_heal` (default 0.1): anchor radius below which `powerlaw`/`polyfit`
-  continue the harmonics.
+- `s_axis_heal` (default `1.0d-2`): anchor flux below which
+  `powerlaw`/`polyfit` continue the harmonics.
 - `axis_healing_polyfit_degree` (default 3): polynomial degree for `polyfit`.
 
 ```
 axis_healing = 'polyfit'   ! recommended near-axis field
-rho_axis_heal = 0.1
+s_axis_heal = 1.0d-2
 ```
 
 The polyfit field removes the near-axis non-convergence of the symplectic Euler1
@@ -809,9 +807,11 @@ level and energy is conserved across axis crossings.
 
 **Deprecated switches.** The booleans `old_axis_healing`,
 `old_axis_healing_boundary`, `axis_healing_power_law`, and `axis_healing_polyfit`
-still work but are mapped to `axis_healing` with a deprecation warning. A future
-release removes them and defaults `axis_healing` to `'polyfit'`; set it
-explicitly now to choose your field.
+still work but are mapped to `axis_healing` with a deprecation warning.
+`rho_axis_heal` still works and is converted to `s_axis_heal = rho_axis_heal^2`.
+A future release removes these compatibility switches and defaults
+`axis_healing` to `'polyfit'`; set `axis_healing` and `s_axis_heal` explicitly
+now to choose your field.
 
 ---
 

--- a/DOC/coordinates-and-fields.md
+++ b/DOC/coordinates-and-fields.md
@@ -777,6 +777,42 @@ field_input = 'coils.simple'
 netcdffile = 'wout.nc'  ! Reference VMEC
 ```
 
+### 8.3 Near-Axis Healing (`axis_healing`)
+
+VMEC Fourier harmonics are unreliable on the innermost flux surfaces, and the
+poloidal harmonics must scale as `rho^|m|` (`rho = sqrt(s)`) to be analytic at the
+magnetic axis. `axis_healing` selects how the harmonics are continued to the axis:
+
+| `axis_healing` | continuation |
+|---|---|
+| `'legacy'` | Discard the innermost surfaces and extrapolate the rescaled amplitude `c/rho^|m|`. Default. |
+| `'powerlaw'` | `rho^|m|` continuation below `rho_axis_heal`. Analytic, but splining `c/rho^|m|` amplifies near-axis noise (rough, ringing at the anchor). Superseded by `polyfit`. |
+| `'polyfit'` | `rho^|m|` times a least-squares polynomial in `s` (a Zernike radial polynomial) fitted to the reliable surfaces below `rho_axis_heal`. Same regularity, smooth, no anchor noise. Recommended. |
+
+Related parameters:
+
+- `axis_healing_boundary = 'fixed' | 'adaptive'` (legacy only): the reliability
+  boundary. `'fixed'` discards the innermost `min(|m|,4)` surfaces; `'adaptive'`
+  detects the noisy surface automatically.
+- `rho_axis_heal` (default 0.1): anchor radius below which `powerlaw`/`polyfit`
+  continue the harmonics.
+- `axis_healing_polyfit_degree` (default 3): polynomial degree for `polyfit`.
+
+```
+axis_healing = 'polyfit'   ! recommended near-axis field
+rho_axis_heal = 0.1
+```
+
+The polyfit field removes the near-axis non-convergence of the symplectic Euler1
+solver at its source: with it `newton1_maxit` drops to a machine-residual-floor
+level and energy is conserved across axis crossings.
+
+**Deprecated switches.** The booleans `old_axis_healing`,
+`old_axis_healing_boundary`, `axis_healing_power_law`, and `axis_healing_polyfit`
+still work but are mapped to `axis_healing` with a deprecation warning. A future
+release removes them and defaults `axis_healing` to `'polyfit'`; set it
+explicitly now to choose your field.
+
 ---
 
 ## 9. Coordinate Transformation Workflows

--- a/app/export_boozer_chartmap.f90
+++ b/app/export_boozer_chartmap.f90
@@ -1,0 +1,57 @@
+program export_boozer_chartmap_app
+!> Export SIMPLE's VMEC->Boozer transform as a Boozer chartmap NetCDF.
+!>
+!> Reads field configuration from simple.in (netcdffile, ns_s, ns_tp,
+!> multharm, axis healing), builds the internal Boozer field exactly as a
+!> tracing run does, and writes the chartmap in the current schema (rho and
+!> s coordinates, A_phi on the s abscissa, B_theta/B_phi on rho, Bmod on the
+!> rho/theta/zeta grid). Lets SIMPLE's own field be compared against an
+!> external booz_xform chartmap on equal footing.
+!>
+!> Usage: export_boozer_chartmap.x <out.nc> [config.in]   (default simple.in)
+
+use params, only: read_config, netcdffile, ns_s, ns_tp, multharm, &
+    integmode, params_init, isw_field_type
+use simple, only: tracer_t
+use simple_main, only: init_field
+use boozer_sub, only: export_boozer_chartmap
+use timing, only: init_timer, print_phase_time
+
+implicit none
+
+integer, parameter :: BOOZER_FIELD_TYPE = 2
+character(1024) :: out_file
+character(256) :: config_file
+type(tracer_t) :: norb
+
+call init_timer()
+
+if (command_argument_count() < 1) then
+    write(*, '(A)') 'Usage: export_boozer_chartmap.x <out.nc> [config.in]'
+    error stop 'missing output file argument'
+end if
+call get_command_argument(1, out_file)
+if (command_argument_count() >= 2) then
+    call get_command_argument(2, config_file)
+else
+    config_file = 'simple.in'
+end if
+
+call read_config(config_file)
+call print_phase_time('Configuration reading completed')
+
+if (isw_field_type /= BOOZER_FIELD_TYPE) then
+    write(*, '(A,I0)') 'ERROR: export_boozer_chartmap needs isw_field_type = 2 &
+        &(Boozer); got ', isw_field_type
+    error stop 'incorrect field type for Boozer chartmap export'
+end if
+
+call init_field(norb, netcdffile, ns_s, ns_tp, multharm, integmode)
+call params_init
+call print_phase_time('Field initialization completed')
+
+call export_boozer_chartmap(out_file)
+call print_phase_time('Chartmap export completed')
+write(*, '(A)') 'Written '//trim(out_file)
+
+end program export_boozer_chartmap_app

--- a/examples/orbit_output_test/simple.in
+++ b/examples/orbit_output_test/simple.in
@@ -43,7 +43,8 @@ tempi1 = 1.0d4
 tempi2 = 1.0d4
 tempe = 1.0d4
 deterministic = .True.
-axis_healing = 'legacy'   ! 'legacy' | 'powerlaw' | 'polyfit' (recommended, future default); legacy boundary via axis_healing_boundary = 'fixed' | 'adaptive'
+axis_healing = 'legacy'   ! 'legacy' | 'legacy_adaptive' | 'powerlaw' | 'polyfit' (recommended, future default)
+s_axis_heal = 1.0d-2      ! anchor flux for powerlaw/polyfit
 batch_size = 1000
 ran_seed = 12345
 reuse_batch = .False.

--- a/examples/orbit_output_test/simple.in
+++ b/examples/orbit_output_test/simple.in
@@ -43,8 +43,7 @@ tempi1 = 1.0d4
 tempi2 = 1.0d4
 tempe = 1.0d4
 deterministic = .True.
-old_axis_healing = .True.
-old_axis_healing_boundary = .True.
+axis_healing = 'legacy'   ! 'legacy' | 'powerlaw' | 'polyfit' (recommended, future default); legacy boundary via axis_healing_boundary = 'fixed' | 'adaptive'
 batch_size = 1000
 ran_seed = 12345
 reuse_batch = .False.

--- a/examples/simple_full.in
+++ b/examples/simple_full.in
@@ -52,8 +52,7 @@ tempi1 = 1.0d4,          ! temperature of the first background species for colli
 tempi2 = 1.0d4,          ! temperature of the second background species for collisions (eV)
 tempe = 1.0d4            ! electron temperature for collisions (eV)
 deterministic = .True.  ! if .True. put seed for the same random walk
-old_axis_healing = .True.  ! How to heal VMEC axis. Leave .True. until new version is fully tested.
-old_axis_healing_boundary = .True.  ! How to heal VMEC axis. Leave .True. until new version is fully tested.
+axis_healing = 'legacy'   ! 'legacy' | 'powerlaw' | 'polyfit' (recommended, future default); legacy boundary via axis_healing_boundary = 'fixed' | 'adaptive'
 batch_size = 1000 ! Use only a portion of all particles. Ignored if larger than ntestpart.
 ran_seed = 12345   ! Random seed to get batch_size amounts of random indices from ntestpart.
 reuse_batch = .False. ! Reuse batch from last run. Previous indices are stored in batch.dat, new batch generated if batch.dat not found.

--- a/examples/simple_full.in
+++ b/examples/simple_full.in
@@ -52,7 +52,8 @@ tempi1 = 1.0d4,          ! temperature of the first background species for colli
 tempi2 = 1.0d4,          ! temperature of the second background species for collisions (eV)
 tempe = 1.0d4            ! electron temperature for collisions (eV)
 deterministic = .True.  ! if .True. put seed for the same random walk
-axis_healing = 'legacy'   ! 'legacy' | 'powerlaw' | 'polyfit' (recommended, future default); legacy boundary via axis_healing_boundary = 'fixed' | 'adaptive'
+axis_healing = 'legacy'   ! 'legacy' | 'legacy_adaptive' | 'powerlaw' | 'polyfit' (recommended, future default)
+s_axis_heal = 1.0d-2      ! anchor flux for powerlaw/polyfit
 batch_size = 1000 ! Use only a portion of all particles. Ignored if larger than ntestpart.
 ran_seed = 12345   ! Random seed to get batch_size amounts of random indices from ntestpart.
 reuse_batch = .False. ! Reuse batch from last run. Previous indices are stored in batch.dat, new batch generated if batch.dat not found.

--- a/simple.in
+++ b/simple.in
@@ -52,8 +52,7 @@ tempi1 = 1.0d4,          ! temperature of the first background species for colli
 tempi2 = 1.0d4,          ! temperature of the second background species for collisions (eV)
 tempe = 1.0d4            ! electron temperature for collisions (eV)
 deterministic = .True.  ! if .True. put seed for the same random walk
-old_axis_healing = .True.  ! How to heal VMEC axis. Leave .True. until new version is fully tested.
-old_axis_healing_boundary = .True.  ! How to heal VMEC axis. Leave .True. until new version is fully tested.
+axis_healing = 'legacy'   ! 'legacy' | 'powerlaw' | 'polyfit' (recommended, future default); legacy boundary via axis_healing_boundary = 'fixed' | 'adaptive'
 batch_size = 1000 ! Use only a portion of all particles. Ignored if larger than ntestpart.
 ran_seed = 12345   ! Random seed to get batch_size amounts of random indices from ntestpart.
 reuse_batch = .False. ! Reuse batch from last run. Previous indices are stored in batch.dat, new batch generated if batch.dat not found.

--- a/simple.in
+++ b/simple.in
@@ -52,7 +52,8 @@ tempi1 = 1.0d4,          ! temperature of the first background species for colli
 tempi2 = 1.0d4,          ! temperature of the second background species for collisions (eV)
 tempe = 1.0d4            ! electron temperature for collisions (eV)
 deterministic = .True.  ! if .True. put seed for the same random walk
-axis_healing = 'legacy'   ! 'legacy' | 'powerlaw' | 'polyfit' (recommended, future default); legacy boundary via axis_healing_boundary = 'fixed' | 'adaptive'
+axis_healing = 'legacy'   ! 'legacy' | 'legacy_adaptive' | 'powerlaw' | 'polyfit' (recommended, future default)
+s_axis_heal = 1.0d-2      ! anchor flux for powerlaw/polyfit
 batch_size = 1000 ! Use only a portion of all particles. Ignored if larger than ntestpart.
 ran_seed = 12345   ! Random seed to get batch_size amounts of random indices from ntestpart.
 reuse_batch = .False. ! Reuse batch from last run. Previous indices are stored in batch.dat, new batch generated if batch.dat not found.

--- a/src/boozer_converter.F90
+++ b/src/boozer_converter.F90
@@ -1,12 +1,12 @@
 module boozer_sub
     use spl_three_to_five_sub
     use interpolate, only: BatchSplineData1D, BatchSplineData3D, &
-                           construct_batch_splines_1d, construct_batch_splines_3d, &
-                           evaluate_batch_splines_1d_der2, &
-                           evaluate_batch_splines_1d_der3, &
-                           evaluate_batch_splines_3d_der, &
-                           evaluate_batch_splines_3d_der2, &
-                           destroy_batch_splines_1d, destroy_batch_splines_3d
+        construct_batch_splines_1d, construct_batch_splines_3d, &
+        evaluate_batch_splines_1d_der2, &
+        evaluate_batch_splines_1d_der3, &
+        evaluate_batch_splines_3d_der, &
+        evaluate_batch_splines_3d_der2, &
+        destroy_batch_splines_1d, destroy_batch_splines_3d
     use field, only: magnetic_field_t, field_clone
     use, intrinsic :: iso_fortran_env, only: dp => real64
 
@@ -27,7 +27,7 @@ module boozer_sub
 
     ! Field storage for nested subroutine calls
     class(magnetic_field_t), allocatable :: current_field
-!$omp threadprivate(current_field)
+    !$omp threadprivate(current_field)
 
     ! Batch spline data for Bmod and B_r interpolation
     type(BatchSplineData3D), allocatable :: bmod_br_batch_spline
@@ -114,7 +114,7 @@ contains
         use vector_potentail_mod, only: ns, hs
         use new_vmec_stuff_mod, only: n_theta, n_phi, h_theta, h_phi, ns_s, ns_tp
         use boozer_coordinates_mod, only: ns_s_B, ns_tp_B, ns_B, n_theta_B, n_phi_B, &
-                                          hs_B, h_theta_B, h_phi_B
+            hs_B, h_theta_B, h_phi_B
 
         implicit none
 
@@ -138,12 +138,12 @@ contains
     end subroutine get_boozer_coordinates_impl
 
     subroutine splint_boozer_coord(r, vartheta_B, varphi_B, mode_secders, &
-                                   A_theta, A_phi, dA_theta_dr, dA_phi_dr, &
-                                   d2A_phi_dr2, d3A_phi_dr3, &
-                                   B_vartheta_B, dB_vartheta_B, d2B_vartheta_B, &
-                                   B_varphi_B, dB_varphi_B, d2B_varphi_B, &
-                                   Bmod_B, dBmod_B, d2Bmod_B, &
-                                   B_r, dB_r, d2B_r)
+            A_theta, A_phi, dA_theta_dr, dA_phi_dr, &
+            d2A_phi_dr2, d3A_phi_dr3, &
+            B_vartheta_B, dB_vartheta_B, d2B_vartheta_B, &
+            B_varphi_B, dB_varphi_B, d2B_varphi_B, &
+            Bmod_B, dBmod_B, d2Bmod_B, &
+            B_r, dB_r, d2B_r)
 
         implicit none
         !$acc routine seq
@@ -162,7 +162,7 @@ contains
         real(dp) :: r_eval, rho_tor, drhods, drhods2, d2rhods2m
         real(dp) :: qua, dqua_dr, dqua_dt, dqua_dp
         real(dp) :: d2qua_dr2, d2qua_drdt, d2qua_drdp, d2qua_dt2, &
-                    d2qua_dtdp, d2qua_dp2
+            d2qua_dtdp, d2qua_dp2
         real(dp) :: x_eval(3), y_eval(2), dy_eval(3, 2), d2y_eval(6, 2)
         real(dp) :: theta_wrapped, phi_wrapped
         real(dp) :: y1d(2), dy1d(2), d2y1d(2)
@@ -180,12 +180,12 @@ contains
 
         if (mode_secders > 0) then
             call evaluate_batch_splines_1d_der3(aphi_batch_spline, r_eval, &
-                                                y1d(1:1), dy1d(1:1), &
-                                                d2y1d(1:1), d3y1d)
+                y1d(1:1), dy1d(1:1), &
+                d2y1d(1:1), d3y1d)
             d3A_phi_dr3 = d3y1d(1)
         else
             call evaluate_batch_splines_1d_der2(aphi_batch_spline, r_eval, &
-                                                y1d(1:1), dy1d(1:1), d2y1d(1:1))
+                y1d(1:1), dy1d(1:1), d2y1d(1:1))
             d3A_phi_dr3 = 0.0_dp
         end if
         A_phi = y1d(1)
@@ -204,13 +204,13 @@ contains
         ! Chain rule coefficients for rho -> s conversion
         drhods = 0.5_dp/rho_tor
         drhods2 = drhods**2
-        d2rhods2m = drhods2/rho_tor  ! -d2rho/ds2 (negative of second derivative)
+        d2rhods2m = drhods2/rho_tor ! -d2rho/ds2 (negative of second derivative)
 
         if (mode_secders == 2) then
             call evaluate_batch_splines_3d_der2(bmod_br_batch_spline, x_eval, &
-                                                y_eval(1:boozer_state%bmod_br_num_quantities), &
-                                                dy_eval(:, 1:boozer_state%bmod_br_num_quantities), &
-                                                d2y_eval(:, 1:boozer_state%bmod_br_num_quantities))
+                y_eval(1:boozer_state%bmod_br_num_quantities), &
+                dy_eval(:, 1:boozer_state%bmod_br_num_quantities), &
+                d2y_eval(:, 1:boozer_state%bmod_br_num_quantities))
 
             ! Extract Bmod (quantity 1)
             qua = y_eval(1)
@@ -269,7 +269,7 @@ contains
                 dB_r(3) = dqua_dp*drhods
 
                 d2B_r(1) = d2qua_dr2*drhods - 2.0_dp*dqua_dr*d2rhods2m + &
-                           qua*drhods*(3.0_dp/4.0_dp)/r_eval**2
+                    qua*drhods*(3.0_dp/4.0_dp)/r_eval**2
                 d2B_r(2) = d2qua_drdt*drhods - dqua_dt*d2rhods2m
                 d2B_r(3) = d2qua_drdp*drhods - dqua_dp*d2rhods2m
                 d2B_r(4) = d2qua_dt2*drhods
@@ -282,8 +282,8 @@ contains
             end if
         else
             call evaluate_batch_splines_3d_der(bmod_br_batch_spline, x_eval, &
-                                               y_eval(1:boozer_state%bmod_br_num_quantities), &
-                                               dy_eval(:, 1:boozer_state%bmod_br_num_quantities))
+                y_eval(1:boozer_state%bmod_br_num_quantities), &
+                dy_eval(:, 1:boozer_state%bmod_br_num_quantities))
 
             Bmod_B = y_eval(1)
             dBmod_B(1) = dy_eval(1, 1)*drhods
@@ -294,11 +294,11 @@ contains
 
             if (mode_secders == 1) then
                 call evaluate_batch_splines_3d_der2(bmod_br_batch_spline, x_eval, &
-                                                    y_eval(1:boozer_state%bmod_br_num_quantities), &
-                                                    dy_eval(:, &
-                                                            1:boozer_state%bmod_br_num_quantities), &
-                                                    d2y_eval(:, &
-                                                             1:boozer_state%bmod_br_num_quantities))
+                    y_eval(1:boozer_state%bmod_br_num_quantities), &
+                    dy_eval(:, &
+                    1:boozer_state%bmod_br_num_quantities), &
+                    d2y_eval(:, &
+                    1:boozer_state%bmod_br_num_quantities))
                 d2Bmod_B(1) = d2y_eval(1, 1)*drhods2 - dy_eval(1, 1)*d2rhods2m
             end if
 
@@ -319,7 +319,7 @@ contains
                 if (mode_secders == 1) then
                     d2qua_dr2 = d2y_eval(1, 2)*drhods2 - dy_eval(1, 2)*d2rhods2m
                     d2B_r(1) = d2qua_dr2*drhods - 2.0_dp*dqua_dr*d2rhods2m + &
-                               qua*drhods*(3.0_dp/4.0_dp)/r_eval**2
+                        qua*drhods*(3.0_dp/4.0_dp)/r_eval**2
                 end if
             else
                 B_r = 0.0_dp
@@ -330,7 +330,7 @@ contains
 
         ! Interpolation of B_\vartheta and B_\varphi (flux functions)
         call evaluate_batch_splines_1d_der2(bcovar_tp_batch_spline, rho_tor, y1d, &
-                                            dy1d, d2y1d)
+            dy1d, d2y1d)
         B_vartheta_B = y1d(1)
         dB_vartheta_B = dy1d(1)
         B_varphi_B = y1d(2)
@@ -347,12 +347,12 @@ contains
 
     end subroutine splint_boozer_coord
 
-!> Computes delta_vartheta = vartheta_B - theta_V and delta_varphi = varphi_B - varphi_V
+    !> Computes delta_vartheta = vartheta_B - theta_V and delta_varphi = varphi_B - varphi_V
     !> and their first derivatives over angles.
     !> isw=0: given as functions of VMEC coordinates (r, vartheta, varphi)
     !> isw=1: given as functions of Boozer coordinates (r, vartheta, varphi)
     subroutine delthe_delphi_BV(isw, r, vartheta, varphi, deltheta_BV, delphi_BV, &
-                                ddeltheta_BV, ddelphi_BV)
+            ddeltheta_BV, ddelphi_BV)
         use boozer_coordinates_mod, only: use_del_tp_B
         use chamb_mod, only: rnegflag
 
@@ -380,7 +380,7 @@ contains
                 error stop "delthe_delphi_BV: V batch spline not initialized"
             end if
             call evaluate_batch_splines_3d_der(delt_delp_V_batch_spline, x_eval, &
-                                               y_eval, dy_eval)
+                y_eval, dy_eval)
         elseif (isw .eq. 1) then
             if (.not. use_del_tp_B) then
                 print *, 'delthe_delphi_BV : Boozer data is not loaded'
@@ -390,7 +390,7 @@ contains
                 error stop "delthe_delphi_BV: B batch spline not initialized"
             end if
             call evaluate_batch_splines_3d_der(delt_delp_B_batch_spline, x_eval, &
-                                               y_eval, dy_eval)
+                y_eval, dy_eval)
         else
             print *, 'delthe_delphi_BV : unknown value of switch isw'
             return
@@ -407,8 +407,8 @@ contains
 
     end subroutine delthe_delphi_BV
 
-!> Convert VMEC coordinates (r, theta, varphi) to Boozer coordinates (vartheta_B,
-!> varphi_B)
+    !> Convert VMEC coordinates (r, theta, varphi) to Boozer coordinates (vartheta_B,
+    !> varphi_B)
     subroutine vmec_to_boozer(r, theta, varphi, vartheta_B, varphi_B)
         use new_vmec_stuff_mod, only: nper
 
@@ -418,15 +418,15 @@ contains
         real(dp), dimension(2) :: ddeltheta_BV, ddelphi_BV
 
         call delthe_delphi_BV(0, r, theta, varphi, deltheta_BV, delphi_BV, &
-                              ddeltheta_BV, ddelphi_BV)
+            ddeltheta_BV, ddelphi_BV)
 
         vartheta_B = modulo(theta + deltheta_BV, TWOPI)
         varphi_B = modulo(varphi + delphi_BV, TWOPI/real(nper, dp))
 
     end subroutine vmec_to_boozer
 
-!> Convert Boozer coordinates (r, vartheta_B, varphi_B) to VMEC coordinates (theta,
-!> varphi)
+    !> Convert Boozer coordinates (r, vartheta_B, varphi_B) to VMEC coordinates (theta,
+    !> varphi)
     subroutine boozer_to_vmec(r, vartheta_B, varphi_B, theta, varphi)
         use boozer_coordinates_mod, only: use_del_tp_B
 
@@ -444,7 +444,7 @@ contains
         if (use_del_tp_B) then
 
             call delthe_delphi_BV(1, r, vartheta_B, varphi_B, deltheta_BV, delphi_BV, &
-                                  ddeltheta_BV, ddelphi_BV)
+                ddeltheta_BV, ddelphi_BV)
 
             theta = vartheta_B - deltheta_BV
             varphi = varphi_B - delphi_BV
@@ -453,12 +453,12 @@ contains
             varphi = varphi_B
         end if
 
-! Newton method:
+        ! Newton method:
 
         do iter = 1, niter
 
             call delthe_delphi_BV(0, r, theta, varphi, deltheta_BV, delphi_BV, &
-                                  ddeltheta_BV, ddelphi_BV)
+                ddeltheta_BV, ddelphi_BV)
 
             f1 = theta + deltheta_BV - vartheta_B
             f2 = varphi + delphi_BV - varphi_B
@@ -476,17 +476,17 @@ contains
             if (abs(delthe) + abs(delphi) .lt. epserr) exit
         end do
 
-!  theta=modulo(theta,TWOPI)
-!  varphi=modulo(varphi,TWOPI/real(nper, dp))
+        !  theta=modulo(theta,TWOPI)
+        !  varphi=modulo(varphi,TWOPI/real(nper, dp))
 
     end subroutine boozer_to_vmec
 
     subroutine compute_boozer_data
         ! Computes Boozer coordinate transformations and magnetic field data
         use boozer_coordinates_mod, only: ns_s_B, ns_tp_B, ns_B, n_theta_B, n_phi_B, &
-                                          hs_B, h_theta_B, h_phi_B, &
-                                          s_Bcovar_tp_B, &
-                                          use_B_r, use_del_tp_B
+            hs_B, h_theta_B, h_phi_B, &
+            s_Bcovar_tp_B, &
+            use_B_r, use_del_tp_B
         use binsrc_sub, only: binsrc
         use plag_coeff_sub, only: plag_coeff
         use spline_vmec_sub
@@ -564,7 +564,7 @@ contains
         allocate (splcoe_t(0:ns_tp_B, n_theta_B))
         allocate (splcoe_p(0:ns_tp_B, n_phi_B))
 
-! allocate data arrays for Boozer data:
+        ! allocate data arrays for Boozer data:
         if (.not. allocated(s_Bcovar_tp_B)) &
             allocate (s_Bcovar_tp_B(2, ns_s_B + 1, ns_B))
 
@@ -573,7 +573,7 @@ contains
         if (use_B_r) call ensure_grid_3d(br_grid, ns_B, n_theta_B, n_phi_B)
         call ensure_grid_4d(delt_delp_V_grid, ns_B, n_theta_B, n_phi_B, 2)
         if (use_del_tp_B) call ensure_grid_4d(delt_delp_B_grid, ns_B, n_theta_B, &
-                                              n_phi_B, 2)
+            n_phi_B, 2)
 
         do i = 0, ns_tp_B
             wint_t(i) = h_theta_B**(i + 1)/real(i + 1, dp)
@@ -607,34 +607,34 @@ contains
 
                     if (allocated(current_field)) then
                         call vmec_field_evaluate_with_field(current_field, &
-                                                            s, theta, varphi, &
-                                                            A_theta, &
-                                                            A_phi, &
-                                                            dA_theta_ds, &
-                                                            dA_phi_ds, &
-                                                            aiota, &
-                                                            sqg, alam, dl_ds, &
-                                                            dl_dt, dl_dp, &
-                                                            Bctrvr_vartheta, &
-                                                            Bctrvr_varphi, &
-                                                            Bcovar_r, Bcovar_vartheta, &
-                                                            Bcovar_varphi)
+                            s, theta, varphi, &
+                            A_theta, &
+                            A_phi, &
+                            dA_theta_ds, &
+                            dA_phi_ds, &
+                            aiota, &
+                            sqg, alam, dl_ds, &
+                            dl_dt, dl_dp, &
+                            Bctrvr_vartheta, &
+                            Bctrvr_varphi, &
+                            Bcovar_r, Bcovar_vartheta, &
+                            Bcovar_varphi)
                     else
                         call vmec_field_evaluate(s, theta, varphi, &
-                                                 A_theta, A_phi, dA_theta_ds, &
-                                                 dA_phi_ds, aiota, &
-                                                 sqg, alam, dl_ds, &
-                                                 dl_dt, dl_dp, &
-                                                 Bctrvr_vartheta, &
-                                                 Bctrvr_varphi, &
-                                                 Bcovar_r, Bcovar_vartheta, &
-                                                 Bcovar_varphi)
+                            A_theta, A_phi, dA_theta_ds, &
+                            dA_phi_ds, aiota, &
+                            sqg, alam, dl_ds, &
+                            dl_dt, dl_dp, &
+                            Bctrvr_vartheta, &
+                            Bctrvr_varphi, &
+                            Bcovar_r, Bcovar_vartheta, &
+                            Bcovar_varphi)
                     end if
 
                     alam_2D(i_theta, i_phi) = alam
                     bmod_Vg(i_theta, i_phi) = &
                         sqrt(Bctrvr_vartheta*Bcovar_vartheta &
-                             + Bctrvr_varphi*Bcovar_varphi)
+                        + Bctrvr_varphi*Bcovar_varphi)
                     Bcovar_theta_V(i_theta, i_phi) = Bcovar_vartheta*(1.0_dp + dl_dt)
                     Bcovar_varphi_V(i_theta, i_phi) = &
                         Bcovar_varphi + Bcovar_vartheta*dl_dp
@@ -644,7 +644,7 @@ contains
                 end do
             end do
 
-! covariant components $B_\vartheta$ and $B_\varphi$ of Boozer coordinates:
+            ! covariant components $B_\vartheta$ and $B_\varphi$ of Boozer coordinates:
             Bcovar_vartheta_B = sum(Bcovar_theta_V(2:n_theta_B, 2:n_phi_B))/gridcellnum
             Bcovar_varphi_B = sum(Bcovar_varphi_V(2:n_theta_B, 2:n_phi_B))/gridcellnum
             s_Bcovar_tp_B(1, 1, i_rho) = Bcovar_vartheta_B
@@ -664,7 +664,7 @@ contains
             end do
             ! Remove linear increasing component from delphi_BV_Vg
             aper = (delphi_BV_Vg(n_theta_B, 1) &
-                    - delphi_BV_Vg(1, 1))/real(n_theta_B - 1, dp)
+                - delphi_BV_Vg(1, 1))/real(n_theta_B - 1, dp)
             do i_theta = 2, n_theta_B
                 delphi_BV_Vg(i_theta, 1) = &
                     delphi_BV_Vg(i_theta, 1) - aper*real(i_theta - 1, dp)
@@ -681,7 +681,7 @@ contains
                         + sum(wint_p*splcoe_p(:, i_phi))
                 end do
                 aper = (delphi_BV_Vg(i_theta, n_phi_B) &
-                        - delphi_BV_Vg(i_theta, 1))/real(n_phi_B - 1, dp)
+                    - delphi_BV_Vg(i_theta, 1))/real(n_phi_B - 1, dp)
                 do i_phi = 2, n_phi_B
                     delphi_BV_Vg(i_theta, i_phi) = &
                         delphi_BV_Vg(i_theta, i_phi) &
@@ -689,20 +689,20 @@ contains
                 end do
             end do
 
-! difference between Boozer and VMEC toroidal angle,
-! $\Delta \varphi_{BV}=\varphi_B-\varphi=G$:
+            ! difference between Boozer and VMEC toroidal angle,
+            ! $\Delta \varphi_{BV}=\varphi_B-\varphi=G$:
             delphi_BV_Vg = denomjac*delphi_BV_Vg + Gbeg
-! difference between Boozer and VMEC poloidal angle,
-! $\Delta \vartheta_{BV}=\vartheta_B-\theta$:
+            ! difference between Boozer and VMEC poloidal angle,
+            ! $\Delta \vartheta_{BV}=\vartheta_B-\theta$:
             deltheta_BV_Vg = aiota*delphi_BV_Vg + alam_2D
 
             delt_delp_V_grid(i_rho, :, :, 1) = deltheta_BV_Vg
             delt_delp_V_grid(i_rho, :, :, 2) = delphi_BV_Vg
 
-! At this point, all quantities are specified on
-! equidistant grid in VMEC angles $(\theta,\varphi)$
+            ! At this point, all quantities are specified on
+            ! equidistant grid in VMEC angles $(\theta,\varphi)$
 
-! Re-interpolate to equidistant grid in $(\vartheta_B,\varphi)$:
+            ! Re-interpolate to equidistant grid in $(\vartheta_B,\varphi)$:
 
             do i_phi = 1, n_phi_B
                 perqua_t(1, 1:n_theta_B) = deltheta_BV_Vg(:, i_phi)
@@ -716,22 +716,22 @@ contains
                 do i_theta = 1, n_theta_B
 
                     call binsrc(theta_B, 2 - n_theta_B, 2*n_theta_B - 1, &
-                                theta_V(i_theta), i)
+                        theta_V(i_theta), i)
 
                     ibeg = i - nshift
                     iend = ibeg + ns_tp_B
 
                     call plag_coeff(npoilag, nder, theta_V(i_theta), &
-                                    theta_B(ibeg:iend), coef)
+                        theta_B(ibeg:iend), coef)
 
                     perqua_2D(:, i_theta, i_phi) = matmul(perqua_t(:, ibeg:iend), &
-                                                          coef(0, :))
+                        coef(0, :))
                 end do
             end do
 
-! End re-interpolate to equidistant grid in $(\vartheta_B,\varphi)$
+            ! End re-interpolate to equidistant grid in $(\vartheta_B,\varphi)$
 
-! Re-interpolate to equidistant grid in $(\vartheta_B,\varphi_B)$:
+            ! Re-interpolate to equidistant grid in $(\vartheta_B,\varphi_B)$:
 
             do i_theta = 1, n_theta_B
                 perqua_p(:, 1:n_phi_B) = perqua_2D(:, i_theta, :)
@@ -749,7 +749,7 @@ contains
                     call plag_coeff(npoilag, nder, phi_V(i_phi), phi_B(ibeg:iend), coef)
 
                     perqua_2D(:, i_theta, i_phi) = matmul(perqua_p(:, ibeg:iend), &
-                                                          coef(0, :))
+                        coef(0, :))
                 end do
             end do
 
@@ -759,13 +759,13 @@ contains
             end if
             bmod_grid(i_rho, :, :) = perqua_2D(3, :, :)
 
-! End re-interpolate to equidistant grid in $(\vartheta_B,\varphi_B)$
+            ! End re-interpolate to equidistant grid in $(\vartheta_B,\varphi_B)$
 
             if (use_B_r) then
                 aiota_arr(i_rho) = aiota
                 Gfunc(i_rho, :, :) = perqua_2D(2, :, :)
-! covariant components $B_k$ in symmetry flux coordinates on equidistant grid of
-! Boozer coordinates:
+                ! covariant components $B_k$ in symmetry flux coordinates on equidistant grid of
+                ! Boozer coordinates:
                 Bcovar_symfl(:, i_rho, :, :) = perqua_2D(4:6, :, :)
             end if
 
@@ -777,9 +777,9 @@ contains
         end if
 
         deallocate (Bcovar_theta_V, Bcovar_varphi_V, bmod_Vg, alam_2D, &
-                    deltheta_BV_Vg, delphi_BV_Vg, &
-                    wint_t, wint_p, coef, theta_V, theta_B, phi_V, phi_B, &
-                    perqua_t, perqua_p, perqua_2D)
+            deltheta_BV_Vg, delphi_BV_Vg, &
+            wint_t, wint_p, coef, theta_V, theta_B, phi_V, phi_B, &
+            perqua_t, perqua_p, perqua_2D)
 
         print *, 'done'
 
@@ -821,7 +821,7 @@ contains
                 br_grid(i_rho, :, i_phi) = &
                     2.0_dp*rho_tor(i_rho)*Bcovar_symfl(1, i_rho, :, i_phi) &
                     - matmul(coef(1, :)*aiota_arr(ibeg:iend), Gfunc(ibeg:iend, &
-                                                                    :, i_phi)) &
+                    :, i_phi)) &
                     *Bcovar_symfl(2, i_rho, :, i_phi) &
                     - matmul(coef(1, :), Gfunc(ibeg:iend, :, i_phi)) &
                     *Bcovar_symfl(3, i_rho, :, i_phi)
@@ -899,10 +899,10 @@ contains
         !> NetCDF file, bypassing the VMEC-based compute_boozer_data path.
         use vector_potentail_mod, only: torflux, ns, hs
         use new_vmec_stuff_mod, only: nper, rmajor, ns_A, ns_s, ns_tp, &
-                                      vmec_B_scale, vmec_RZ_scale
+            vmec_B_scale, vmec_RZ_scale
         use boozer_coordinates_mod, only: ns_s_B, ns_tp_B, ns_B, n_theta_B, &
-                                          n_phi_B, hs_B, h_theta_B, h_phi_B, &
-                                          use_B_r, use_del_tp_B
+            n_phi_B, hs_B, h_theta_B, h_phi_B, &
+            use_B_r, use_del_tp_B
         use boozer_chartmap_io, only: boozer_chartmap_data_t, read_boozer_chartmap
 
         character(len=*), intent(in) :: filename
@@ -961,7 +961,7 @@ contains
         allocate (y_aphi(ns, 1))
         y_aphi(:, 1) = d%A_phi
         call construct_batch_splines_1d(s_min, s_max, y_aphi, spline_order, .false., &
-                                        aphi_batch_spline)
+            aphi_batch_spline)
         aphi_batch_spline_ready = .true.
         deallocate (y_aphi)
 
@@ -971,7 +971,7 @@ contains
         y_bcovar(:, 1) = d%B_theta
         y_bcovar(:, 2) = d%B_phi
         call construct_batch_splines_1d(d%rho(1), d%rho(d%n_rho), y_bcovar, spline_order, &
-                                        .false., bcovar_tp_batch_spline)
+            .false., bcovar_tp_batch_spline)
         bcovar_tp_batch_spline_ready = .true.
         deallocate (y_bcovar)
 
@@ -981,19 +981,19 @@ contains
         periodic_3d = [.false., .true., .true.]
         x_min_3d = [d%rho(1), 0.0_dp, 0.0_dp]
         x_max_3d = [d%rho(d%n_rho), h_theta_B * real(d%n_theta - 1, dp), &
-                     h_phi_B * real(d%n_phi - 1, dp)]
+            h_phi_B * real(d%n_phi - 1, dp)]
 
         allocate (y_bmod(d%n_rho, d%n_theta, d%n_phi, 1))
         y_bmod(:, :, :, 1) = d%Bmod
         call construct_batch_splines_3d(x_min_3d, x_max_3d, y_bmod, order_3d, &
-                                        periodic_3d, bmod_br_batch_spline)
+            periodic_3d, bmod_br_batch_spline)
         bmod_br_batch_spline_ready = .true.
         boozer_state%bmod_br_num_quantities = 1
         deallocate (y_bmod)
 
         print *, 'Loaded Boozer splines from chartmap: ', trim(filename)
         print *, '  nfp=', d%nfp, ' ns=', d%n_rho, ' ntheta_spline=', &
-                 d%n_theta, ' nphi_spline=', d%n_phi
+            d%n_theta, ' nphi_spline=', d%n_phi
         print *, '  torflux=', torflux
 
         ! The chartmap loader builds the batch splines inline (not via
@@ -1012,8 +1012,8 @@ contains
         use vector_potentail_mod, only: torflux
         use new_vmec_stuff_mod, only: nper
         use boozer_coordinates_mod, only: ns_B, n_theta_B, n_phi_B, &
-                                          hs_B, h_theta_B, h_phi_B, &
-                                          s_Bcovar_tp_B
+            hs_B, h_theta_B, h_phi_B, &
+            s_Bcovar_tp_B
         use spline_vmec_sub, only: splint_vmec_data
         use netcdf
 
@@ -1057,9 +1057,9 @@ contains
         ! Radial grid
         do i_rho = 1, ns_B
             rho_arr(i_rho) = rho_min + (1.0_dp - rho_min) &
-                             * real(i_rho - 1, dp)/real(ns_B - 1, dp)
+                * real(i_rho - 1, dp)/real(ns_B - 1, dp)
             s_arr(i_rho) = rho_min**2 + (1.0_dp - rho_min**2) &
-                           * real(i_rho - 1, dp)/real(ns_B - 1, dp)
+                * real(i_rho - 1, dp)/real(ns_B - 1, dp)
         end do
         ! Angular grids (endpoint excluded, for chartmap geometry)
         do i_theta = 1, n_theta_out
@@ -1072,19 +1072,19 @@ contains
         ! A_phi is a flux profile on s. B_theta/B_phi stay on rho for now.
         do i_rho = 1, ns_B
             call splint_boozer_coord(s_arr(i_rho), 0.0_dp, 0.0_dp, 0, &
-                                     A_theta_dum, A_phi_arr(i_rho), dA_theta_ds, &
-                                     dA_phi_ds, d2A_phi_ds2, d3A_phi_ds3, &
-                                     B_theta_val, dB_theta, d2B_theta, &
-                                     B_phi_val, dB_phi, d2B_phi, &
-                                     Bmod_val, dBmod, d2Bmod, B_r_val, dB_r, d2B_r)
+                A_theta_dum, A_phi_arr(i_rho), dA_theta_ds, &
+                dA_phi_ds, d2A_phi_ds2, d3A_phi_ds3, &
+                B_theta_val, dB_theta, d2B_theta, &
+                B_phi_val, dB_phi, d2B_phi, &
+                Bmod_val, dBmod, d2Bmod, B_r_val, dB_r, d2B_r)
 
             s = rho_arr(i_rho)**2
             call splint_boozer_coord(s, 0.0_dp, 0.0_dp, 0, &
-                                     A_theta_dum, A_phi_dum, dA_theta_ds, &
-                                     dA_phi_ds, d2A_phi_ds2, d3A_phi_ds3, &
-                                     B_theta_arr(i_rho), dB_theta, d2B_theta, &
-                                     B_phi_arr(i_rho), dB_phi, d2B_phi, &
-                                     Bmod_val, dBmod, d2Bmod, B_r_val, dB_r, d2B_r)
+                A_theta_dum, A_phi_dum, dA_theta_ds, &
+                dA_phi_ds, d2A_phi_ds2, d3A_phi_ds3, &
+                B_theta_arr(i_rho), dB_theta, d2B_theta, &
+                B_phi_arr(i_rho), dB_phi, d2B_phi, &
+                Bmod_val, dBmod, d2Bmod, B_r_val, dB_r, d2B_r)
         end do
 
         ! Compute X, Y, Z geometry on the Boozer grid (endpoint-excluded)
@@ -1119,12 +1119,12 @@ contains
                 do i_rho = 1, ns_B
                     s = rho_arr(i_rho)**2
                     call splint_boozer_coord(s, theta_B, phi_B, 0, &
-                                             A_theta_dum, A_phi_dum, dA_theta_ds, &
-                                             dA_phi_ds, d2A_phi_ds2, d3A_phi_ds3, &
-                                             B_theta_val, dB_theta, d2B_theta, &
-                                             B_phi_val, dB_phi, d2B_phi, &
-                                             bmod_arr(i_rho, i_theta, i_phi), &
-                                             dBmod, d2Bmod, B_r_val, dB_r, d2B_r)
+                        A_theta_dum, A_phi_dum, dA_theta_ds, &
+                        dA_phi_ds, d2A_phi_ds2, d3A_phi_ds3, &
+                        B_theta_val, dB_theta, d2B_theta, &
+                        B_phi_val, dB_phi, d2B_phi, &
+                        bmod_arr(i_rho, i_theta, i_phi), &
+                        dBmod, d2Bmod, B_r_val, dB_r, d2B_r)
                 end do
             end do
         end do
@@ -1137,57 +1137,57 @@ contains
         call nc_assert(nf90_def_dim(ncid, "rho", ns_B, dim_rho), "def_dim rho")
         call nc_assert(nf90_def_dim(ncid, "s", ns_B, dim_s), "def_dim s")
         call nc_assert(nf90_def_dim(ncid, "theta", n_theta_out, dim_theta), &
-                        "def_dim theta")
+            "def_dim theta")
         call nc_assert(nf90_def_dim(ncid, "zeta", n_phi_out, dim_zeta), &
-                        "def_dim zeta")
+            "def_dim zeta")
 
         ! Coordinate variables
         call nc_assert(nf90_def_var(ncid, "rho", nf90_double, [dim_rho], var_rho), &
-                        "def_var rho")
+            "def_var rho")
         call nc_assert(nf90_def_var(ncid, "s", nf90_double, [dim_s], var_s), &
-                        "def_var s")
+            "def_var s")
         call nc_assert(nf90_def_var(ncid, "theta", nf90_double, [dim_theta], &
-                        var_theta), "def_var theta")
+            var_theta), "def_var theta")
         call nc_assert(nf90_def_var(ncid, "zeta", nf90_double, [dim_zeta], &
-                        var_zeta), "def_var zeta")
+            var_zeta), "def_var zeta")
 
         ! Geometry (NF90 reverses dims: Fortran (rho,theta,zeta) -> NetCDF (zeta,theta,rho))
         call nc_assert(nf90_def_var(ncid, "x", nf90_double, &
-                        [dim_rho, dim_theta, dim_zeta], var_x), "def_var x")
+            [dim_rho, dim_theta, dim_zeta], var_x), "def_var x")
         call nc_assert(nf90_put_att(ncid, var_x, "units", "cm"), "att x units")
         call nc_assert(nf90_def_var(ncid, "y", nf90_double, &
-                        [dim_rho, dim_theta, dim_zeta], var_y), "def_var y")
+            [dim_rho, dim_theta, dim_zeta], var_y), "def_var y")
         call nc_assert(nf90_put_att(ncid, var_y, "units", "cm"), "att y units")
         call nc_assert(nf90_def_var(ncid, "z", nf90_double, &
-                        [dim_rho, dim_theta, dim_zeta], var_z), "def_var z")
+            [dim_rho, dim_theta, dim_zeta], var_z), "def_var z")
         call nc_assert(nf90_put_att(ncid, var_z, "units", "cm"), "att z units")
 
         ! Boozer field data
         call nc_assert(nf90_def_var(ncid, "A_phi", nf90_double, [dim_s], &
-                        var_aphi), "def_var A_phi")
+            var_aphi), "def_var A_phi")
         call nc_assert(nf90_put_att(ncid, var_aphi, "radial_abscissa", "s"), &
-                        "att A_phi radial_abscissa")
+            "att A_phi radial_abscissa")
         call nc_assert(nf90_def_var(ncid, "B_theta", nf90_double, [dim_rho], &
-                        var_btheta), "def_var B_theta")
+            var_btheta), "def_var B_theta")
         call nc_assert(nf90_def_var(ncid, "B_phi", nf90_double, [dim_rho], &
-                        var_bphi), "def_var B_phi")
+            var_bphi), "def_var B_phi")
         call nc_assert(nf90_def_var(ncid, "Bmod", nf90_double, &
-                        [dim_rho, dim_theta, dim_zeta], var_bmod), &
-                        "def_var Bmod")
+            [dim_rho, dim_theta, dim_zeta], var_bmod), &
+            "def_var Bmod")
         call nc_assert(nf90_def_var(ncid, "num_field_periods", nf90_int, var_nfp), &
-                        "def_var nfp")
+            "def_var nfp")
 
         ! Global attributes
         call nc_assert(nf90_put_att(ncid, nf90_global, "rho_convention", "rho_tor"), &
-                        "att rho_convention")
+            "att rho_convention")
         call nc_assert(nf90_put_att(ncid, nf90_global, "zeta_convention", "boozer"), &
-                        "att zeta_convention")
+            "att zeta_convention")
         call nc_assert(nf90_put_att(ncid, nf90_global, "rho_lcfs", rho_arr(ns_B)), &
-                        "att rho_lcfs")
+            "att rho_lcfs")
         call nc_assert(nf90_put_att(ncid, nf90_global, "boozer_field", 1), &
-                        "att boozer_field")
+            "att boozer_field")
         call nc_assert(nf90_put_att(ncid, nf90_global, "torflux", torflux), &
-                        "att torflux")
+            "att torflux")
         ! No rmajor attribute: the chartmap reader derives the major radius
         ! from the innermost-surface geometry (see boozer_chartmap_io).
 
@@ -1211,7 +1211,7 @@ contains
 
         print *, 'Exported Boozer chartmap to ', trim(filename)
         print *, '  nfp=', nper, ' ns=', ns_B, ' ntheta=', n_theta_out, &
-                 ' nphi=', n_phi_out
+            ' nphi=', n_phi_out
         print *, '  torflux=', torflux
 
     contains
@@ -1221,7 +1221,7 @@ contains
             character(len=*), intent(in) :: loc
             if (stat /= nf90_noerr) then
                 print *, "export_boozer_chartmap: NetCDF error at ", trim(loc), &
-                         ": ", trim(nf90_strerror(stat))
+                    ": ", trim(nf90_strerror(stat))
                 error stop
             end if
         end subroutine nc_assert
@@ -1282,7 +1282,7 @@ contains
         y_batch(:, 2) = s_Bcovar_tp_B(2, 1, :)
 
         call construct_batch_splines_1d(x_min, x_max, y_batch, order, .false., &
-                                        bcovar_tp_batch_spline)
+            bcovar_tp_batch_spline)
         bcovar_tp_batch_spline_ready = .true.
         deallocate (y_batch)
     end subroutine build_boozer_bcovar_tp_batch_spline
@@ -1290,7 +1290,7 @@ contains
     subroutine build_boozer_bmod_br_batch_spline
         ! Combined Bmod + Br batch spline (1 or 2 quantities depending on use_B_r)
         use boozer_coordinates_mod, only: ns_s_B, ns_tp_B, ns_B, n_theta_B, n_phi_B, &
-                                          hs_B, h_theta_B, h_phi_B, use_B_r
+            hs_B, h_theta_B, h_phi_B, use_B_r
 
         real(dp) :: x_min(3), x_max(3)
         real(dp), allocatable :: y_batch(:, :, :, :)
@@ -1336,7 +1336,7 @@ contains
         end if
 
         call construct_batch_splines_3d(x_min, x_max, y_batch, order, periodic, &
-                                        bmod_br_batch_spline)
+            bmod_br_batch_spline)
         bmod_br_batch_spline_ready = .true.
         boozer_state%bmod_br_num_quantities = nq
         deallocate (y_batch)
@@ -1350,7 +1350,7 @@ contains
     subroutine build_boozer_delt_delp_batch_splines
         ! Use the simple 4D grids populated in compute_boozer_data
         use boozer_coordinates_mod, only: ns_s_B, ns_tp_B, ns_B, n_theta_B, n_phi_B, &
-                                          hs_B, h_theta_B, h_phi_B, use_del_tp_B
+            hs_B, h_theta_B, h_phi_B, use_del_tp_B
 
         integer :: order(3)
         real(dp) :: x_min(3), x_max(3)
@@ -1385,12 +1385,12 @@ contains
         y_batch(:, :, :, 2) = delt_delp_V_grid(:, :, :, 2)
 
         call construct_batch_splines_3d(x_min, x_max, y_batch, order, periodic, &
-                                        delt_delp_V_batch_spline)
+            delt_delp_V_batch_spline)
         delt_delp_V_batch_spline_ready = .true.
 
         if (use_del_tp_B) then
             if (.not. allocated(delt_delp_B_grid)) then
-       error stop "build_boozer_delt_delp_batch_splines: delt_delp_B_grid not allocated"
+                error stop "build_boozer_delt_delp_batch_splines: delt_delp_B_grid not allocated"
             end if
 
             if (delt_delp_B_batch_spline_ready) then
@@ -1402,7 +1402,7 @@ contains
             y_batch(:, :, :, 2) = delt_delp_B_grid(:, :, :, 2)
 
             call construct_batch_splines_3d(x_min, x_max, y_batch, order, periodic, &
-                                            delt_delp_B_batch_spline)
+                delt_delp_B_batch_spline)
             delt_delp_B_batch_spline_ready = .true.
         end if
 

--- a/src/field.F90
+++ b/src/field.F90
@@ -1,16 +1,15 @@
 module field
     !> Field module aggregating all field types and factory functions.
 
-    use, intrinsic :: iso_fortran_env, only: dp => real64
     use libneo_coordinates, only: detect_refcoords_file_type, refcoords_file_chartmap, &
-                                  refcoords_file_vmec_wout, refcoords_file_unknown
+        refcoords_file_vmec_wout, refcoords_file_unknown
     use field_base, only: magnetic_field_t
     use field_vmec, only: vmec_field_t, create_vmec_field
     use field_coils, only: coils_field_t, create_coils_field
     use field_splined, only: splined_field_t, create_splined_field
     use field_boozer_chartmap, only: boozer_chartmap_field_t, &
-                                     create_boozer_chartmap_field, &
-                                     is_boozer_chartmap
+        create_boozer_chartmap_field, &
+        is_boozer_chartmap
 
     implicit none
 
@@ -21,34 +20,34 @@ contains
         class(magnetic_field_t), allocatable, intent(out) :: dest
 
         select type (source)
-        type is (vmec_field_t)
+            type is (vmec_field_t)
             allocate (vmec_field_t :: dest)
             select type (dest)
-            type is (vmec_field_t)
+                type is (vmec_field_t)
                 dest = source
             class default
                 error stop 'field_clone: Allocation failure (vmec)'
             end select
-        type is (coils_field_t)
+            type is (coils_field_t)
             allocate (coils_field_t :: dest)
             select type (dest)
-            type is (coils_field_t)
+                type is (coils_field_t)
                 dest = source
             class default
                 error stop 'field_clone: Allocation failure (coils)'
             end select
-        type is (splined_field_t)
+            type is (splined_field_t)
             allocate (splined_field_t :: dest)
             select type (dest)
-            type is (splined_field_t)
+                type is (splined_field_t)
                 dest = source
             class default
                 error stop 'field_clone: Allocation failure (splined)'
             end select
-        type is (boozer_chartmap_field_t)
+            type is (boozer_chartmap_field_t)
             allocate (boozer_chartmap_field_t :: dest)
             select type (dest)
-            type is (boozer_chartmap_field_t)
+                type is (boozer_chartmap_field_t)
                 dest = source
             class default
                 error stop 'field_clone: Allocation failure (boozer_chartmap)'
@@ -112,7 +111,7 @@ contains
                 end select
             end if
         else if (startswidth(stripped_name, 'coils') .or. &
-                 endswith(filename, '.coils')) then
+                endswith(filename, '.coils')) then
             call create_coils_field(filename, raw_coils)
             allocate (splined_coils)
             call create_splined_field(raw_coils, ref_coords, splined_coils)

--- a/src/field/field_newton.F90
+++ b/src/field/field_newton.F90
@@ -1,92 +1,92 @@
 module field_newton
-  !> Module for field-agnostic Newton iterations
-  !> Provides Newton solvers for coordinate transformations
-  
-  use, intrinsic :: iso_fortran_env, only : dp => real64
-  use field_base, only : magnetic_field_t
-  
-  implicit none
-  private
-  
-  public :: newton_theta_from_canonical
-  
-contains
-  
-  !> Newton iteration to find field-specific theta from canonical theta
-  !> Solves: theta + Lambda(s, theta, phi) = vartheta_canonical
-  !> where Lambda is the stream function that depends on the field type
-  subroutine newton_theta_from_canonical(field, s, vartheta_canonical, varphi, &
-                                          theta, converged, iter_count)
-    class(magnetic_field_t), intent(in) :: field
-    real(dp), intent(in) :: s              ! Normalized flux coordinate
-    real(dp), intent(in) :: vartheta_canonical  ! Canonical poloidal angle
-    real(dp), intent(in) :: varphi         ! Toroidal angle
-    real(dp), intent(inout) :: theta       ! Field-specific theta (initial guess on input)
-    logical, intent(out) :: converged      ! Convergence flag
-    integer, intent(out), optional :: iter_count  ! Number of iterations
-    
-    ! Local variables
-    real(dp), parameter :: epserr = 1.0e-12_dp  ! Convergence tolerance
-    integer, parameter :: max_iter = 100
-    real(dp) :: alam, dl_dt, deltheta
-    integer :: iter
-    
-    ! Initialize
-    converged = .false.
-    
-    ! Newton iteration loop
-    do iter = 1, max_iter
-      ! Get stream function and its theta derivative for current field
-      call get_stream_function(field, s, theta, varphi, alam, dl_dt)
-      
-      ! Newton update: solve vartheta = theta + Lambda
-      ! f(theta) = theta + Lambda(theta) - vartheta = 0
-      ! f'(theta) = 1 + dLambda/dtheta
-      deltheta = (vartheta_canonical - theta - alam) / (1.0_dp + dl_dt)
-      theta = theta + deltheta
-      
-      ! Check convergence
-      if (abs(deltheta) < epserr) then
-        converged = .true.
-        exit
-      end if
-    end do
-    
-    if (present(iter_count)) iter_count = iter
-    
-    ! Warn if not converged
-    if (.not. converged) then
-      print *, 'WARNING: Newton iteration for theta did not converge'
-      print *, '  s =', s, ', vartheta =', vartheta_canonical, ', varphi =', varphi
-      print *, '  Final theta =', theta, ', deltheta =', deltheta
-    end if
-    
-  end subroutine newton_theta_from_canonical
-  
-  
-  !> Get stream function Lambda and its derivative for a given field
-  !> This abstracts the field-specific stream function evaluation
-  subroutine get_stream_function(mag_field, s, theta, varphi, alam, dl_dt)
-    use field, only: vmec_field_t
-    use vmec_field_eval, only: vmec_lambda_interpolate_with_field
-    
-    class(magnetic_field_t), intent(in) :: mag_field
-    real(dp), intent(in) :: s, theta, varphi
-    real(dp), intent(out) :: alam   ! Stream function Lambda
-    real(dp), intent(out) :: dl_dt  ! dLambda/dtheta
-    
-    ! Dispatch based on field type
-    select type (mag_field)
-    type is (vmec_field_t)
-      ! For VMEC, use the existing lambda interpolation
-      call vmec_lambda_interpolate_with_field(mag_field, s, theta, varphi, alam, dl_dt)
+    !> Module for field-agnostic Newton iterations
+    !> Provides Newton solvers for coordinate transformations
 
-    class default
-      ! For other fields, stream function may not be defined
-      alam = 0.0_dp
-      dl_dt = 0.0_dp
-    end select
-    
-  end subroutine get_stream_function
-  
+    use, intrinsic :: iso_fortran_env, only : dp => real64
+    use field_base, only : magnetic_field_t
+
+    implicit none
+    private
+
+    public :: newton_theta_from_canonical
+
+contains
+
+    !> Newton iteration to find field-specific theta from canonical theta
+    !> Solves: theta + Lambda(s, theta, phi) = vartheta_canonical
+    !> where Lambda is the stream function that depends on the field type
+    subroutine newton_theta_from_canonical(field, s, vartheta_canonical, varphi, &
+            theta, converged, iter_count)
+        class(magnetic_field_t), intent(in) :: field
+        real(dp), intent(in) :: s ! Normalized flux coordinate
+        real(dp), intent(in) :: vartheta_canonical ! Canonical poloidal angle
+        real(dp), intent(in) :: varphi ! Toroidal angle
+        real(dp), intent(inout) :: theta ! Field-specific theta (initial guess on input)
+        logical, intent(out) :: converged ! Convergence flag
+        integer, intent(out), optional :: iter_count ! Number of iterations
+
+        ! Local variables
+        real(dp), parameter :: epserr = 1.0e-12_dp ! Convergence tolerance
+        integer, parameter :: max_iter = 100
+        real(dp) :: alam, dl_dt, deltheta
+        integer :: iter
+
+        ! Initialize
+        converged = .false.
+
+        ! Newton iteration loop
+        do iter = 1, max_iter
+            ! Get stream function and its theta derivative for current field
+            call get_stream_function(field, s, theta, varphi, alam, dl_dt)
+
+            ! Newton update: solve vartheta = theta + Lambda
+            ! f(theta) = theta + Lambda(theta) - vartheta = 0
+            ! f'(theta) = 1 + dLambda/dtheta
+            deltheta = (vartheta_canonical - theta - alam) / (1.0_dp + dl_dt)
+            theta = theta + deltheta
+
+            ! Check convergence
+            if (abs(deltheta) < epserr) then
+                converged = .true.
+                exit
+            end if
+        end do
+
+        if (present(iter_count)) iter_count = iter
+
+        ! Warn if not converged
+        if (.not. converged) then
+            print *, 'WARNING: Newton iteration for theta did not converge'
+            print *, '  s =', s, ', vartheta =', vartheta_canonical, ', varphi =', varphi
+            print *, '  Final theta =', theta, ', deltheta =', deltheta
+        end if
+
+    end subroutine newton_theta_from_canonical
+
+
+    !> Get stream function Lambda and its derivative for a given field
+    !> This abstracts the field-specific stream function evaluation
+    subroutine get_stream_function(mag_field, s, theta, varphi, alam, dl_dt)
+        use field, only: vmec_field_t
+        use vmec_field_eval, only: vmec_lambda_interpolate_with_field
+
+        class(magnetic_field_t), intent(in) :: mag_field
+        real(dp), intent(in) :: s, theta, varphi
+        real(dp), intent(out) :: alam ! Stream function Lambda
+        real(dp), intent(out) :: dl_dt ! dLambda/dtheta
+
+        ! Dispatch based on field type
+        select type (mag_field)
+            type is (vmec_field_t)
+            ! For VMEC, use the existing lambda interpolation
+            call vmec_lambda_interpolate_with_field(mag_field, s, theta, varphi, alam, dl_dt)
+
+        class default
+            ! For other fields, stream function may not be defined
+            alam = 0.0_dp
+            dl_dt = 0.0_dp
+        end select
+
+    end subroutine get_stream_function
+
 end module field_newton

--- a/src/get_canonical_coordinates.F90
+++ b/src/get_canonical_coordinates.F90
@@ -1,943 +1,943 @@
 module exchange_get_cancoord_mod
-   use, intrinsic :: iso_fortran_env, only: dp => real64
+    use, intrinsic :: iso_fortran_env, only: dp => real64
 
-   implicit none
-   private
+    implicit none
+    private
 
-   logical, public :: onlytheta
-   real(dp), public :: vartheta_c, varphi_c, sqg, aiota, Bcovar_vartheta, &
-                       Bcovar_varphi, A_theta, A_phi, theta, Bctrvr_vartheta, &
-                       Bctrvr_varphi
+    logical, public :: onlytheta
+    real(dp), public :: vartheta_c, varphi_c, sqg, aiota, Bcovar_vartheta, &
+        Bcovar_varphi, A_theta, A_phi, theta, Bctrvr_vartheta, &
+        Bctrvr_varphi
 
-!$omp threadprivate(onlytheta, vartheta_c, varphi_c, sqg, aiota)
-!$omp threadprivate(Bcovar_vartheta, Bcovar_varphi, A_theta, A_phi)
-!$omp threadprivate(theta, Bctrvr_vartheta, Bctrvr_varphi)
+    !$omp threadprivate(onlytheta, vartheta_c, varphi_c, sqg, aiota)
+    !$omp threadprivate(Bcovar_vartheta, Bcovar_varphi, A_theta, A_phi)
+    !$omp threadprivate(theta, Bctrvr_vartheta, Bctrvr_varphi)
 
 end module exchange_get_cancoord_mod
 
 module get_can_sub
-   use, intrinsic :: iso_fortran_env, only: dp => real64
-   use spl_three_to_five_sub
-   use stencil_utils
-   use field, only: magnetic_field_t, vmec_field_t, create_vmec_field, field_clone
-   use field_newton, only: newton_theta_from_canonical
-   use interpolate, only: BatchSplineData1D, BatchSplineData3D, &
-                          construct_batch_splines_1d, construct_batch_splines_3d, &
-                          evaluate_batch_splines_1d_der2, &
-                          evaluate_batch_splines_3d_der, &
-                          evaluate_batch_splines_3d_der2, &
-                          evaluate_batch_splines_3d_der2_rmix, &
-                          destroy_batch_splines_1d, destroy_batch_splines_3d
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use spl_three_to_five_sub
+    use stencil_utils
+    use field, only: magnetic_field_t, vmec_field_t, create_vmec_field, field_clone
+    use field_newton, only: newton_theta_from_canonical
+    use interpolate, only: BatchSplineData1D, BatchSplineData3D, &
+        construct_batch_splines_1d, construct_batch_splines_3d, &
+        evaluate_batch_splines_1d_der2, &
+        evaluate_batch_splines_3d_der, &
+        evaluate_batch_splines_3d_der2, &
+        evaluate_batch_splines_3d_der2_rmix, &
+        destroy_batch_splines_1d, destroy_batch_splines_3d
 
-   implicit none
-   private
+    implicit none
+    private
 
-   public :: get_canonical_coordinates, get_canonical_coordinates_with_field
-   public :: splint_can_coord
-   public :: can_to_vmec, vmec_to_can, vmec_to_cyl
-   public :: deallocate_can_coord
-   public :: reset_canflux_batch_splines
+    public :: get_canonical_coordinates, get_canonical_coordinates_with_field
+    public :: splint_can_coord
+    public :: can_to_vmec, vmec_to_can, vmec_to_cyl
+    public :: deallocate_can_coord
+    public :: reset_canflux_batch_splines
 
-   ! Constants
-   real(dp), parameter :: TWOPI = 2.0_dp*3.14159265358979_dp
+    ! Constants
+    real(dp), parameter :: TWOPI = 2.0_dp*3.14159265358979_dp
 
-   ! Module variable to store the field for use in subroutines
-   class(magnetic_field_t), allocatable :: current_field
-!$omp threadprivate(current_field)
+    ! Module variable to store the field for use in subroutines
+    class(magnetic_field_t), allocatable :: current_field
+    !$omp threadprivate(current_field)
 
-   ! Batch spline for A_phi (vector potential)
-   type(BatchSplineData1D), save :: aphi_batch_spline
-   logical, save :: aphi_batch_spline_ready = .false.
+    ! Batch spline for A_phi (vector potential)
+    type(BatchSplineData1D), save :: aphi_batch_spline
+    logical, save :: aphi_batch_spline_ready = .false.
 
-   ! Batch spline for G_c (generating function)
-   type(BatchSplineData3D), save :: G_batch_spline
-   logical, save :: G_batch_spline_ready = .false.
+    ! Batch spline for G_c (generating function)
+    type(BatchSplineData3D), save :: G_batch_spline
+    logical, save :: G_batch_spline_ready = .false.
 
-   ! Batch splines for sqg_c, B_vartheta_c, B_varphi_c (separate NQ=1 splines)
-   type(BatchSplineData3D), save :: sqg_batch_spline
-   type(BatchSplineData3D), save :: Bt_batch_spline
-   type(BatchSplineData3D), save :: Bp_batch_spline
-   logical, save :: sqg_batch_spline_ready = .false.
-   logical, save :: Bt_batch_spline_ready = .false.
-   logical, save :: Bp_batch_spline_ready = .false.
+    ! Batch splines for sqg_c, B_vartheta_c, B_varphi_c (separate NQ=1 splines)
+    type(BatchSplineData3D), save :: sqg_batch_spline
+    type(BatchSplineData3D), save :: Bt_batch_spline
+    type(BatchSplineData3D), save :: Bp_batch_spline
+    logical, save :: sqg_batch_spline_ready = .false.
+    logical, save :: Bt_batch_spline_ready = .false.
+    logical, save :: Bp_batch_spline_ready = .false.
 
 contains
 
-   subroutine get_canonical_coordinates_with_field(field)
-      implicit none
+    subroutine get_canonical_coordinates_with_field(field)
+        implicit none
 
-      class(magnetic_field_t), intent(in) :: field
+        class(magnetic_field_t), intent(in) :: field
 
-      ! Store field in module variable for use in nested subroutines
-      call field_clone(field, current_field)
+        ! Store field in module variable for use in nested subroutines
+        call field_clone(field, current_field)
 
-      call reset_canflux_batch_splines
+        call reset_canflux_batch_splines
 
-      ! Call the actual implementation
-      call get_canonical_coordinates_impl
+        ! Call the actual implementation
+        call get_canonical_coordinates_impl
 
-   end subroutine get_canonical_coordinates_with_field
+    end subroutine get_canonical_coordinates_with_field
 
-   subroutine get_canonical_coordinates
-      ! Backward compatibility wrapper - uses VMEC field by default
-      type(vmec_field_t) :: vmec_field
+    subroutine get_canonical_coordinates
+        ! Backward compatibility wrapper - uses VMEC field by default
+        type(vmec_field_t) :: vmec_field
 
-      call create_vmec_field(vmec_field)
-      call get_canonical_coordinates_with_field(vmec_field)
-   end subroutine get_canonical_coordinates
+        call create_vmec_field(vmec_field)
+        call get_canonical_coordinates_with_field(vmec_field)
+    end subroutine get_canonical_coordinates
 
-   subroutine reset_canflux_batch_splines
-      if (aphi_batch_spline_ready) then
-         call destroy_batch_splines_1d(aphi_batch_spline)
-         aphi_batch_spline_ready = .false.
-      end if
-      if (G_batch_spline_ready) then
-         call destroy_batch_splines_3d(G_batch_spline)
-         G_batch_spline_ready = .false.
-      end if
-      if (sqg_batch_spline_ready) then
-         call destroy_batch_splines_3d(sqg_batch_spline)
-         sqg_batch_spline_ready = .false.
-      end if
-      if (Bt_batch_spline_ready) then
-         call destroy_batch_splines_3d(Bt_batch_spline)
-         Bt_batch_spline_ready = .false.
-      end if
-      if (Bp_batch_spline_ready) then
-         call destroy_batch_splines_3d(Bp_batch_spline)
-         Bp_batch_spline_ready = .false.
-      end if
-   end subroutine reset_canflux_batch_splines
+    subroutine reset_canflux_batch_splines
+        if (aphi_batch_spline_ready) then
+            call destroy_batch_splines_1d(aphi_batch_spline)
+            aphi_batch_spline_ready = .false.
+        end if
+        if (G_batch_spline_ready) then
+            call destroy_batch_splines_3d(G_batch_spline)
+            G_batch_spline_ready = .false.
+        end if
+        if (sqg_batch_spline_ready) then
+            call destroy_batch_splines_3d(sqg_batch_spline)
+            sqg_batch_spline_ready = .false.
+        end if
+        if (Bt_batch_spline_ready) then
+            call destroy_batch_splines_3d(Bt_batch_spline)
+            Bt_batch_spline_ready = .false.
+        end if
+        if (Bp_batch_spline_ready) then
+            call destroy_batch_splines_3d(Bp_batch_spline)
+            Bp_batch_spline_ready = .false.
+        end if
+    end subroutine reset_canflux_batch_splines
 
-   subroutine get_canonical_coordinates_impl
-      use canonical_coordinates_mod, only: ns_c, n_theta_c, n_phi_c, &
-                                           hs_c, h_theta_c, h_phi_c, &
-                                           ns_s_c, ns_tp_c, &
-                                           nh_stencil, G_c, sqg_c, &
-                                           B_vartheta_c, B_varphi_c
-      use vector_potentail_mod, only: ns, hs
-      use exchange_get_cancoord_mod, only: vartheta_c, varphi_c, sqg, aiota, &
-                                           Bcovar_vartheta, Bcovar_varphi, &
-                                           onlytheta
-      use new_vmec_stuff_mod, only: n_theta, n_phi, h_theta, h_phi, ns_s, ns_tp
-      use odeint_allroutines_sub, only: odeint_allroutines
+    subroutine get_canonical_coordinates_impl
+        use canonical_coordinates_mod, only: ns_c, n_theta_c, n_phi_c, &
+            hs_c, h_theta_c, h_phi_c, &
+            ns_s_c, ns_tp_c, &
+            nh_stencil, G_c, sqg_c, &
+            B_vartheta_c, B_varphi_c
+        use vector_potentail_mod, only: ns, hs
+        use exchange_get_cancoord_mod, only: vartheta_c, varphi_c, sqg, aiota, &
+            Bcovar_vartheta, Bcovar_varphi, &
+            onlytheta
+        use new_vmec_stuff_mod, only: n_theta, n_phi, h_theta, h_phi, ns_s, ns_tp
+        use odeint_allroutines_sub, only: odeint_allroutines
 
-      implicit none
+        implicit none
 
-      real(dp), parameter :: relerr = 1.0e-10_dp
-      integer :: i_theta, i_phi, i_sten, ndim, is_beg
-      integer, dimension(:), allocatable :: ipoi_t, ipoi_p
-      real(dp), dimension(:), allocatable :: y, dy
-      real(dp) :: dstencil_theta(-nh_stencil:nh_stencil), &
-                  dstencil_phi(-nh_stencil:nh_stencil)
+        real(dp), parameter :: relerr = 1.0e-10_dp
+        integer :: i_theta, i_phi, i_sten, ndim, is_beg
+        integer, dimension(:), allocatable :: ipoi_t, ipoi_p
+        real(dp), dimension(:), allocatable :: y, dy
+        real(dp) :: dstencil_theta(-nh_stencil:nh_stencil), &
+            dstencil_phi(-nh_stencil:nh_stencil)
 
-      real(dp) :: r, r1, r2, G_beg, dG_c_dt, dG_c_dp
-      integer :: is
-      integer :: i_ctr
+        real(dp) :: r, r1, r2, G_beg, dG_c_dt, dG_c_dp
+        integer :: is
+        integer :: i_ctr
 
-      ns_c = ns
-      n_theta_c = n_theta
-      n_phi_c = n_phi
-      h_theta_c = h_theta
-      h_phi_c = h_phi
-      hs_c = hs
+        ns_c = ns
+        n_theta_c = n_theta
+        n_phi_c = n_phi
+        h_theta_c = h_theta
+        h_phi_c = h_phi
+        hs_c = hs
 
-      ! Initialize derivative stencils using stencil_utils module
-      call init_derivative_stencil(nh_stencil, h_theta_c, dstencil_theta)
-      call init_derivative_stencil(nh_stencil, h_phi_c, dstencil_phi)
+        ! Initialize derivative stencils using stencil_utils module
+        call init_derivative_stencil(nh_stencil, h_theta_c, dstencil_theta)
+        call init_derivative_stencil(nh_stencil, h_phi_c, dstencil_phi)
 
-      allocate (ipoi_t(1 - nh_stencil:n_theta_c + nh_stencil))
-      allocate (ipoi_p(1 - nh_stencil:n_phi_c + nh_stencil))
+        allocate (ipoi_t(1 - nh_stencil:n_theta_c + nh_stencil))
+        allocate (ipoi_p(1 - nh_stencil:n_phi_c + nh_stencil))
 
-      do i_theta = 1, n_theta_c
-         ipoi_t(i_theta) = i_theta
-      end do
+        do i_theta = 1, n_theta_c
+            ipoi_t(i_theta) = i_theta
+        end do
 
-      do i_phi = 1, n_phi_c
-         ipoi_p(i_phi) = i_phi
-      end do
+        do i_phi = 1, n_phi_c
+            ipoi_p(i_phi) = i_phi
+        end do
 
-      do i_sten = 1, nh_stencil
-         ipoi_t(1 - i_sten) = ipoi_t(n_theta - i_sten)
-         ipoi_t(n_theta_c + i_sten) = ipoi_t(1 + i_sten)
-         ipoi_p(1 - i_sten) = ipoi_p(n_phi_c - i_sten)
-         ipoi_p(n_phi_c + i_sten) = ipoi_p(1 + i_sten)
-      end do
+        do i_sten = 1, nh_stencil
+            ipoi_t(1 - i_sten) = ipoi_t(n_theta - i_sten)
+            ipoi_t(n_theta_c + i_sten) = ipoi_t(1 + i_sten)
+            ipoi_p(1 - i_sten) = ipoi_p(n_phi_c - i_sten)
+            ipoi_p(n_phi_c + i_sten) = ipoi_p(1 + i_sten)
+        end do
 
-      allocate (G_c(ns_c, n_theta_c, n_phi_c))
-      allocate (sqg_c(ns_c, n_theta_c, n_phi_c))
-      allocate (B_vartheta_c(ns_c, n_theta_c, n_phi_c))
-      allocate (B_varphi_c(ns_c, n_theta_c, n_phi_c))
+        allocate (G_c(ns_c, n_theta_c, n_phi_c))
+        allocate (sqg_c(ns_c, n_theta_c, n_phi_c))
+        allocate (B_vartheta_c(ns_c, n_theta_c, n_phi_c))
+        allocate (B_varphi_c(ns_c, n_theta_c, n_phi_c))
 
-      onlytheta = .false.
-      ndim = 1
-      is_beg = 1
-      G_beg = 1.0e-8_dp
+        onlytheta = .false.
+        ndim = 1
+        is_beg = 1
+        G_beg = 1.0e-8_dp
 
-      i_ctr = 0
-!$omp parallel private(y, dy, i_theta, i_phi, is, r1, r2, r, dG_c_dt, dG_c_dp)
-!$omp critical
-      allocate (y(ndim), dy(ndim))
-!$omp end critical
+        i_ctr = 0
+        !$omp parallel private(y, dy, i_theta, i_phi, is, r1, r2, r, dG_c_dt, dG_c_dp)
+        !$omp critical
+        allocate (y(ndim), dy(ndim))
+        !$omp end critical
 
-!$omp do
-      do i_theta = 1, n_theta_c
+        !$omp do
+        do i_theta = 1, n_theta_c
 #ifdef SIMPLE_ENABLE_DEBUG_OUTPUT
-!$omp critical
-         i_ctr = i_ctr + 1
-         call print_progress('integrate ODE: ', i_ctr, n_theta_c)
-!$omp end critical
+            !$omp critical
+            i_ctr = i_ctr + 1
+            call print_progress('integrate ODE: ', i_ctr, n_theta_c)
+            !$omp end critical
 #endif
-         vartheta_c = h_theta_c*real(i_theta - 1, dp)
-         do i_phi = 1, n_phi_c
-            varphi_c = h_phi_c*real(i_phi - 1, dp)
+            vartheta_c = h_theta_c*real(i_theta - 1, dp)
+            do i_phi = 1, n_phi_c
+                varphi_c = h_phi_c*real(i_phi - 1, dp)
 
-            G_c(is_beg, i_theta, i_phi) = G_beg
-            y(1) = G_beg
+                G_c(is_beg, i_theta, i_phi) = G_beg
+                y(1) = G_beg
 
-            do is = is_beg - 1, 2, -1
-               r1 = hs_c*real(is, dp)
-               r2 = hs_c*real(is - 1, dp)
+                do is = is_beg - 1, 2, -1
+                    r1 = hs_c*real(is, dp)
+                    r2 = hs_c*real(is - 1, dp)
 
-               call odeint_allroutines(y, ndim, r1, r2, relerr, rhs_cancoord)
+                    call odeint_allroutines(y, ndim, r1, r2, relerr, rhs_cancoord)
 
-               G_c(is, i_theta, i_phi) = y(1)
+                    G_c(is, i_theta, i_phi) = y(1)
+                end do
+
+                y(1) = G_beg
+
+                do is = is_beg + 1, ns_c
+                    r1 = hs_c*real(is - 2, dp)
+                    r2 = hs_c*real(is - 1, dp)
+                    if (is == 2) r1 = 1.0e-8_dp
+
+                    call odeint_allroutines(y, ndim, r1, r2, relerr, rhs_cancoord)
+
+                    G_c(is, i_theta, i_phi) = y(1)
+                end do
             end do
+        end do
+        !$omp end do
 
-            y(1) = G_beg
-
-            do is = is_beg + 1, ns_c
-               r1 = hs_c*real(is - 2, dp)
-               r2 = hs_c*real(is - 1, dp)
-               if (is == 2) r1 = 1.0e-8_dp
-
-               call odeint_allroutines(y, ndim, r1, r2, relerr, rhs_cancoord)
-
-               G_c(is, i_theta, i_phi) = y(1)
-            end do
-         end do
-      end do
-!$omp end do
-
-      i_ctr = 0
-!$omp barrier
-!$omp do
-      do i_theta = 1, n_theta_c
+        i_ctr = 0
+        !$omp barrier
+        !$omp do
+        do i_theta = 1, n_theta_c
 #ifdef SIMPLE_ENABLE_DEBUG_OUTPUT
-!$omp critical
-         i_ctr = i_ctr + 1
-         call print_progress('compute components: ', i_ctr, n_theta_c)
-!$omp end critical
+            !$omp critical
+            i_ctr = i_ctr + 1
+            call print_progress('compute components: ', i_ctr, n_theta_c)
+            !$omp end critical
 #endif
-         vartheta_c = h_theta_c*real(i_theta - 1, dp)
-         do i_phi = 1, n_phi_c
-            varphi_c = h_phi_c*real(i_phi - 1, dp)
+            vartheta_c = h_theta_c*real(i_theta - 1, dp)
+            do i_phi = 1, n_phi_c
+                varphi_c = h_phi_c*real(i_phi - 1, dp)
 
-            do is = 2, ns_c
-               r = hs_c*real(is - 1, dp)
-               y(1) = G_c(is, i_theta, i_phi)
+                do is = 2, ns_c
+                    r = hs_c*real(is - 1, dp)
+                    y(1) = G_c(is, i_theta, i_phi)
 
-               call rhs_cancoord(r, y, dy)
+                    call rhs_cancoord(r, y, dy)
 
-               dG_c_dt = sum(dstencil_theta*G_c(is, &
-                                                ipoi_t(i_theta - &
-                                                       nh_stencil:i_theta + &
-                                                       nh_stencil), i_phi))
-               dG_c_dp = sum(dstencil_phi*G_c(is, i_theta, &
-                                              ipoi_p(i_phi - nh_stencil:i_phi + &
-                                                     nh_stencil)))
-               sqg_c(is, i_theta, i_phi) = sqg*(1.0_dp + aiota*dG_c_dt + dG_c_dp)
-               B_vartheta_c(is, i_theta, i_phi) = Bcovar_vartheta + &
-                                                  (aiota*Bcovar_vartheta + &
-                                                   Bcovar_varphi)*dG_c_dt
-               B_varphi_c(is, i_theta, i_phi) = Bcovar_varphi + &
-                                                (aiota*Bcovar_vartheta + &
-                                                 Bcovar_varphi)*dG_c_dp
+                    dG_c_dt = sum(dstencil_theta*G_c(is, &
+                        ipoi_t(i_theta - &
+                        nh_stencil:i_theta + &
+                        nh_stencil), i_phi))
+                    dG_c_dp = sum(dstencil_phi*G_c(is, i_theta, &
+                        ipoi_p(i_phi - nh_stencil:i_phi + &
+                        nh_stencil)))
+                    sqg_c(is, i_theta, i_phi) = sqg*(1.0_dp + aiota*dG_c_dt + dG_c_dp)
+                    B_vartheta_c(is, i_theta, i_phi) = Bcovar_vartheta + &
+                        (aiota*Bcovar_vartheta + &
+                        Bcovar_varphi)*dG_c_dt
+                    B_varphi_c(is, i_theta, i_phi) = Bcovar_varphi + &
+                        (aiota*Bcovar_vartheta + &
+                        Bcovar_varphi)*dG_c_dp
+                end do
+                ! Extrapolate on-axis point (is=1) with parabola
+                sqg_c(1, i_theta, i_phi) = 3.0_dp*(sqg_c(2, i_theta, i_phi) &
+                    - sqg_c(3, i_theta, i_phi)) + &
+                    sqg_c(4, i_theta, i_phi)
+                B_vartheta_c(1, i_theta, i_phi) = 0.0_dp
+                B_varphi_c(1, i_theta, i_phi) = 3.0_dp*(B_varphi_c(2, i_theta, i_phi) &
+                    - B_varphi_c(3, i_theta, &
+                    i_phi)) + B_varphi_c(4, &
+                    i_theta, i_phi)
             end do
-            ! Extrapolate on-axis point (is=1) with parabola
-            sqg_c(1, i_theta, i_phi) = 3.0_dp*(sqg_c(2, i_theta, i_phi) &
-                                               - sqg_c(3, i_theta, i_phi)) + &
-                                       sqg_c(4, i_theta, i_phi)
-            B_vartheta_c(1, i_theta, i_phi) = 0.0_dp
-            B_varphi_c(1, i_theta, i_phi) = 3.0_dp*(B_varphi_c(2, i_theta, i_phi) &
-                                                    - B_varphi_c(3, i_theta, &
-                                                                 i_phi)) + B_varphi_c(4, &
-                                                                                      i_theta, i_phi)
-         end do
-      end do
-!$omp end do
+        end do
+        !$omp end do
 
-!$omp critical
-      deallocate (y, dy)
-!$omp end critical
-!$omp end parallel
+        !$omp critical
+        deallocate (y, dy)
+        !$omp end critical
+        !$omp end parallel
 
-      ns_s_c = ns_s
-      ns_tp_c = ns_tp
+        ns_s_c = ns_s
+        ns_tp_c = ns_tp
 
-      onlytheta = .true.
+        onlytheta = .true.
 
-      ! Build batch splines from computed grids
-      call build_canflux_aphi_batch_spline
-      call build_canflux_G_batch_spline
-      call build_canflux_sqg_Bt_Bp_batch_spline
+        ! Build batch splines from computed grids
+        call build_canflux_aphi_batch_spline
+        call build_canflux_G_batch_spline
+        call build_canflux_sqg_Bt_Bp_batch_spline
 
-      deallocate (ipoi_t, ipoi_p, sqg_c, B_vartheta_c, B_varphi_c, G_c)
+        deallocate (ipoi_t, ipoi_p, sqg_c, B_vartheta_c, B_varphi_c, G_c)
 
-   end subroutine get_canonical_coordinates_impl
+    end subroutine get_canonical_coordinates_impl
 
-   subroutine build_canflux_aphi_batch_spline
-      use vector_potentail_mod, only: ns, hs, sA_phi
-      use new_vmec_stuff_mod, only: ns_A
+    subroutine build_canflux_aphi_batch_spline
+        use vector_potentail_mod, only: ns, hs, sA_phi
+        use new_vmec_stuff_mod, only: ns_A
 
-      integer :: order
+        integer :: order
 
-      if (aphi_batch_spline_ready) then
-         call destroy_batch_splines_1d(aphi_batch_spline)
-         aphi_batch_spline_ready = .false.
-      end if
+        if (aphi_batch_spline_ready) then
+            call destroy_batch_splines_1d(aphi_batch_spline)
+            aphi_batch_spline_ready = .false.
+        end if
 
-      order = ns_A
-      if (order < 3 .or. order > 5) then
-         error stop "build_canflux_aphi_batch_spline: spline order must be 3..5"
-      end if
+        order = ns_A
+        if (order < 3 .or. order > 5) then
+            error stop "build_canflux_aphi_batch_spline: spline order must be 3..5"
+        end if
 
-      aphi_batch_spline%order = order
-      aphi_batch_spline%num_points = ns
-      aphi_batch_spline%periodic = .false.
-      aphi_batch_spline%x_min = 0.0_dp
-      aphi_batch_spline%h_step = hs
-      aphi_batch_spline%num_quantities = 1
+        aphi_batch_spline%order = order
+        aphi_batch_spline%num_points = ns
+        aphi_batch_spline%periodic = .false.
+        aphi_batch_spline%x_min = 0.0_dp
+        aphi_batch_spline%h_step = hs
+        aphi_batch_spline%num_quantities = 1
 
-      allocate (aphi_batch_spline%coeff(1, 0:order, ns))
-      aphi_batch_spline%coeff(1, 0:order, :) = sA_phi(1:order + 1, :)
+        allocate (aphi_batch_spline%coeff(1, 0:order, ns))
+        aphi_batch_spline%coeff(1, 0:order, :) = sA_phi(1:order + 1, :)
 
-      aphi_batch_spline_ready = .true.
-   end subroutine build_canflux_aphi_batch_spline
+        aphi_batch_spline_ready = .true.
+    end subroutine build_canflux_aphi_batch_spline
 
-   subroutine build_canflux_G_batch_spline
-      use canonical_coordinates_mod, only: ns_c, n_theta_c, n_phi_c, &
-                                           hs_c, h_theta_c, h_phi_c, &
-                                           ns_s_c, ns_tp_c, G_c
+    subroutine build_canflux_G_batch_spline
+        use canonical_coordinates_mod, only: ns_c, n_theta_c, n_phi_c, &
+            hs_c, h_theta_c, h_phi_c, &
+            ns_s_c, ns_tp_c, G_c
 
-      integer :: order(3)
-      real(dp) :: x_min(3), x_max(3)
-      logical :: periodic(3)
-      real(dp), allocatable :: y_batch(:, :, :, :)
+        integer :: order(3)
+        real(dp) :: x_min(3), x_max(3)
+        logical :: periodic(3)
+        real(dp), allocatable :: y_batch(:, :, :, :)
 
-      if (G_batch_spline_ready) then
-         call destroy_batch_splines_3d(G_batch_spline)
-         G_batch_spline_ready = .false.
-      end if
+        if (G_batch_spline_ready) then
+            call destroy_batch_splines_3d(G_batch_spline)
+            G_batch_spline_ready = .false.
+        end if
 
-      order = [ns_s_c, ns_tp_c, ns_tp_c]
-      if (any(order < 3) .or. any(order > 5)) then
-         error stop "build_canflux_G_batch_spline: spline order must be 3..5"
-      end if
+        order = [ns_s_c, ns_tp_c, ns_tp_c]
+        if (any(order < 3) .or. any(order > 5)) then
+            error stop "build_canflux_G_batch_spline: spline order must be 3..5"
+        end if
 
-      x_min = [0.0_dp, 0.0_dp, 0.0_dp]
-      x_max(1) = hs_c*real(ns_c - 1, dp)
-      x_max(2) = h_theta_c*real(n_theta_c - 1, dp)
-      x_max(3) = h_phi_c*real(n_phi_c - 1, dp)
+        x_min = [0.0_dp, 0.0_dp, 0.0_dp]
+        x_max(1) = hs_c*real(ns_c - 1, dp)
+        x_max(2) = h_theta_c*real(n_theta_c - 1, dp)
+        x_max(3) = h_phi_c*real(n_phi_c - 1, dp)
 
-      periodic = [.false., .true., .true.]
+        periodic = [.false., .true., .true.]
 
-      allocate (y_batch(ns_c, n_theta_c, n_phi_c, 1))
-      y_batch(:, :, :, 1) = G_c
+        allocate (y_batch(ns_c, n_theta_c, n_phi_c, 1))
+        y_batch(:, :, :, 1) = G_c
 
-      call construct_batch_splines_3d(x_min, x_max, y_batch, order, periodic, &
-                                      G_batch_spline)
-      G_batch_spline_ready = .true.
-      deallocate (y_batch)
-   end subroutine build_canflux_G_batch_spline
+        call construct_batch_splines_3d(x_min, x_max, y_batch, order, periodic, &
+            G_batch_spline)
+        G_batch_spline_ready = .true.
+        deallocate (y_batch)
+    end subroutine build_canflux_G_batch_spline
 
-   subroutine build_canflux_sqg_Bt_Bp_batch_spline
-      use canonical_coordinates_mod, only: ns_c, n_theta_c, n_phi_c, &
-                                           hs_c, h_theta_c, h_phi_c, &
-                                           ns_s_c, ns_tp_c, &
-                                           sqg_c, B_vartheta_c, B_varphi_c
+    subroutine build_canflux_sqg_Bt_Bp_batch_spline
+        use canonical_coordinates_mod, only: ns_c, n_theta_c, n_phi_c, &
+            hs_c, h_theta_c, h_phi_c, &
+            ns_s_c, ns_tp_c, &
+            sqg_c, B_vartheta_c, B_varphi_c
 
-      integer :: order(3)
-      real(dp) :: x_min(3), x_max(3)
-      logical :: periodic(3)
-      real(dp), allocatable :: y_batch(:, :, :, :)
+        integer :: order(3)
+        real(dp) :: x_min(3), x_max(3)
+        logical :: periodic(3)
+        real(dp), allocatable :: y_batch(:, :, :, :)
 
-      if (sqg_batch_spline_ready) then
-         call destroy_batch_splines_3d(sqg_batch_spline)
-         sqg_batch_spline_ready = .false.
-      end if
-      if (Bt_batch_spline_ready) then
-         call destroy_batch_splines_3d(Bt_batch_spline)
-         Bt_batch_spline_ready = .false.
-      end if
-      if (Bp_batch_spline_ready) then
-         call destroy_batch_splines_3d(Bp_batch_spline)
-         Bp_batch_spline_ready = .false.
-      end if
+        if (sqg_batch_spline_ready) then
+            call destroy_batch_splines_3d(sqg_batch_spline)
+            sqg_batch_spline_ready = .false.
+        end if
+        if (Bt_batch_spline_ready) then
+            call destroy_batch_splines_3d(Bt_batch_spline)
+            Bt_batch_spline_ready = .false.
+        end if
+        if (Bp_batch_spline_ready) then
+            call destroy_batch_splines_3d(Bp_batch_spline)
+            Bp_batch_spline_ready = .false.
+        end if
 
-      order = [ns_s_c, ns_tp_c, ns_tp_c]
-      if (any(order < 3) .or. any(order > 5)) then
-         error stop "build_canflux_sqg_Bt_Bp_batch_spline: spline order must be 3..5"
-      end if
+        order = [ns_s_c, ns_tp_c, ns_tp_c]
+        if (any(order < 3) .or. any(order > 5)) then
+            error stop "build_canflux_sqg_Bt_Bp_batch_spline: spline order must be 3..5"
+        end if
 
-      x_min = [0.0_dp, 0.0_dp, 0.0_dp]
-      x_max(1) = hs_c*real(ns_c - 1, dp)
-      x_max(2) = h_theta_c*real(n_theta_c - 1, dp)
-      x_max(3) = h_phi_c*real(n_phi_c - 1, dp)
+        x_min = [0.0_dp, 0.0_dp, 0.0_dp]
+        x_max(1) = hs_c*real(ns_c - 1, dp)
+        x_max(2) = h_theta_c*real(n_theta_c - 1, dp)
+        x_max(3) = h_phi_c*real(n_phi_c - 1, dp)
 
-      periodic = [.false., .true., .true.]
+        periodic = [.false., .true., .true.]
 
-      allocate (y_batch(ns_c, n_theta_c, n_phi_c, 1))
+        allocate (y_batch(ns_c, n_theta_c, n_phi_c, 1))
 
-      y_batch(:, :, :, 1) = sqg_c
-      call construct_batch_splines_3d(x_min, x_max, y_batch, order, periodic, &
-                                      sqg_batch_spline)
-      sqg_batch_spline_ready = .true.
+        y_batch(:, :, :, 1) = sqg_c
+        call construct_batch_splines_3d(x_min, x_max, y_batch, order, periodic, &
+            sqg_batch_spline)
+        sqg_batch_spline_ready = .true.
 
-      y_batch(:, :, :, 1) = B_vartheta_c
-      call construct_batch_splines_3d(x_min, x_max, y_batch, order, periodic, &
-                                      Bt_batch_spline)
-      Bt_batch_spline_ready = .true.
+        y_batch(:, :, :, 1) = B_vartheta_c
+        call construct_batch_splines_3d(x_min, x_max, y_batch, order, periodic, &
+            Bt_batch_spline)
+        Bt_batch_spline_ready = .true.
 
-      y_batch(:, :, :, 1) = B_varphi_c
-      call construct_batch_splines_3d(x_min, x_max, y_batch, order, periodic, &
-                                      Bp_batch_spline)
-      Bp_batch_spline_ready = .true.
+        y_batch(:, :, :, 1) = B_varphi_c
+        call construct_batch_splines_3d(x_min, x_max, y_batch, order, periodic, &
+            Bp_batch_spline)
+        Bp_batch_spline_ready = .true.
 
-      deallocate (y_batch)
-   end subroutine build_canflux_sqg_Bt_Bp_batch_spline
+        deallocate (y_batch)
+    end subroutine build_canflux_sqg_Bt_Bp_batch_spline
 
-   subroutine rhs_cancoord(r, y, dy)
-      use exchange_get_cancoord_mod, only: vartheta_c, varphi_c, sqg, aiota, &
-                                           Bcovar_vartheta, Bcovar_varphi, &
-                                           theta, onlytheta
-      use spline_vmec_sub
-      use vmec_field_eval
+    subroutine rhs_cancoord(r, y, dy)
+        use exchange_get_cancoord_mod, only: vartheta_c, varphi_c, sqg, aiota, &
+            Bcovar_vartheta, Bcovar_varphi, &
+            theta, onlytheta
+        use spline_vmec_sub
+        use vmec_field_eval
 
-      implicit none
+        implicit none
 
-      real(dp), intent(in) :: r
-      real(dp), intent(in) :: y(:)
-      real(dp), intent(out) :: dy(:)
+        real(dp), intent(in) :: r
+        real(dp), intent(in) :: y(:)
+        real(dp), intent(out) :: dy(:)
 
-      real(dp), parameter :: epserr = 1.0e-14_dp
-      integer :: iter
-      real(dp) :: s, varphi, A_theta, A_phi, dA_theta_ds, dA_phi_ds, &
-                  alam, dl_ds, dl_dt, dl_dp, Bctrvr_vartheta, Bctrvr_varphi, Bcovar_r
-      logical :: converged
+        real(dp), parameter :: epserr = 1.0e-14_dp
+        integer :: iter
+        real(dp) :: s, varphi, A_theta, A_phi, dA_theta_ds, dA_phi_ds, &
+            alam, dl_ds, dl_dt, dl_dp, Bctrvr_vartheta, Bctrvr_varphi, Bcovar_r
+        logical :: converged
 
-      real(dp) :: vartheta, daiota_ds, deltheta
+        real(dp) :: vartheta, daiota_ds, deltheta
 
-      s = r**2
+        s = r**2
 
-      if (allocated(current_field)) then
-         call vmec_iota_interpolate_with_field(current_field, s, aiota, daiota_ds)
-      else
-         call vmec_iota_interpolate(s, aiota, daiota_ds)
-      end if
+        if (allocated(current_field)) then
+            call vmec_iota_interpolate_with_field(current_field, s, aiota, daiota_ds)
+        else
+            call vmec_iota_interpolate(s, aiota, daiota_ds)
+        end if
 
-      vartheta = vartheta_c + aiota*y(1)
-      varphi = varphi_c + y(1)
+        vartheta = vartheta_c + aiota*y(1)
+        varphi = varphi_c + y(1)
 
-      ! Newton iteration to find field-specific theta from canonical theta
-      if (allocated(current_field)) then
-         theta = vartheta
-         call newton_theta_from_canonical(current_field, s, vartheta, varphi, &
-                                          theta, converged)
-         if (.not. converged) then
-            print *, 'WARNING: Newton iteration failed in rhs_cancoord'
-         end if
-      else
-         theta = vartheta
-         do iter = 1, 100
-            call vmec_lambda_interpolate(s, theta, varphi, alam, dl_dt)
-            deltheta = (vartheta - theta - alam)/(1.0_dp + dl_dt)
-            theta = theta + deltheta
-            if (abs(deltheta) < epserr) exit
-         end do
-      end if
+        ! Newton iteration to find field-specific theta from canonical theta
+        if (allocated(current_field)) then
+            theta = vartheta
+            call newton_theta_from_canonical(current_field, s, vartheta, varphi, &
+                theta, converged)
+            if (.not. converged) then
+                print *, 'WARNING: Newton iteration failed in rhs_cancoord'
+            end if
+        else
+            theta = vartheta
+            do iter = 1, 100
+                call vmec_lambda_interpolate(s, theta, varphi, alam, dl_dt)
+                deltheta = (vartheta - theta - alam)/(1.0_dp + dl_dt)
+                theta = theta + deltheta
+                if (abs(deltheta) < epserr) exit
+            end do
+        end if
 
-      if (onlytheta) return
+        if (onlytheta) return
 
-      if (allocated(current_field)) then
-         call vmec_field_evaluate_with_field(current_field, s, theta, varphi, &
-                                             A_theta, A_phi, dA_theta_ds, &
-                                             dA_phi_ds, aiota, &
-                                             sqg, alam, dl_ds, dl_dt, dl_dp, &
-                                             Bctrvr_vartheta, Bctrvr_varphi, &
-                                             Bcovar_r, Bcovar_vartheta, &
-                                             Bcovar_varphi)
-      else
-         call vmec_field_evaluate(s, theta, varphi, A_theta, A_phi, &
-                                  dA_theta_ds, dA_phi_ds, aiota, &
-                                  sqg, alam, dl_ds, dl_dt, dl_dp, Bctrvr_vartheta, &
-                                  Bctrvr_varphi, &
-                                  Bcovar_r, Bcovar_vartheta, Bcovar_varphi)
-      end if
+        if (allocated(current_field)) then
+            call vmec_field_evaluate_with_field(current_field, s, theta, varphi, &
+                A_theta, A_phi, dA_theta_ds, &
+                dA_phi_ds, aiota, &
+                sqg, alam, dl_ds, dl_dt, dl_dp, &
+                Bctrvr_vartheta, Bctrvr_varphi, &
+                Bcovar_r, Bcovar_vartheta, &
+                Bcovar_varphi)
+        else
+            call vmec_field_evaluate(s, theta, varphi, A_theta, A_phi, &
+                dA_theta_ds, dA_phi_ds, aiota, &
+                sqg, alam, dl_ds, dl_dt, dl_dp, Bctrvr_vartheta, &
+                Bctrvr_varphi, &
+                Bcovar_r, Bcovar_vartheta, Bcovar_varphi)
+        end if
 
-      dy(1) = -(Bcovar_r + daiota_ds*Bcovar_vartheta*y(1))/ &
-              (aiota*Bcovar_vartheta + Bcovar_varphi)
-      dy(1) = 2.0_dp*r*dy(1)
+        dy(1) = -(Bcovar_r + daiota_ds*Bcovar_vartheta*y(1))/ &
+            (aiota*Bcovar_vartheta + Bcovar_varphi)
+        dy(1) = 2.0_dp*r*dy(1)
 
-   end subroutine rhs_cancoord
+    end subroutine rhs_cancoord
 
-   subroutine print_progress(message, progress, total)
-      character(*), intent(in) :: message
-      integer, intent(in) :: progress, total
+    subroutine print_progress(message, progress, total)
+        character(*), intent(in) :: message
+        integer, intent(in) :: progress, total
 
 #ifndef SIMPLE_ENABLE_DEBUG_OUTPUT
-      return
+        return
 #endif
 
-      write (*, '(A, I4, A, I4)', advance='no') message, progress, ' of ', total
+        write (*, '(A, I4, A, I4)', advance='no') message, progress, ' of ', total
 
-      if (progress < total) then
-         write (*, '(A)', advance="no") char(13)
-      else
-         write (*, *)
-      end if
-   end subroutine print_progress
+        if (progress < total) then
+            write (*, '(A)', advance="no") char(13)
+        else
+            write (*, *)
+        end if
+    end subroutine print_progress
 
-   subroutine splint_can_coord(fullset, mode_secders, r, vartheta_c, varphi_c, &
-                               A_theta, A_phi, dA_theta_dr, dA_phi_dr, &
-                               d2A_phi_dr2, d3A_phi_dr3, &
-                               sqg_c, dsqg_c_dr, dsqg_c_dt, dsqg_c_dp, &
-                               B_vartheta_c, dB_vartheta_c_dr, &
-                               dB_vartheta_c_dt, dB_vartheta_c_dp, &
-                               B_varphi_c, dB_varphi_c_dr, &
-                               dB_varphi_c_dt, dB_varphi_c_dp, &
-                               d2sqg_rr, d2sqg_rt, d2sqg_rp, &
-                               d2sqg_tt, d2sqg_tp, d2sqg_pp, &
-                               d2bth_rr, d2bth_rt, d2bth_rp, &
-                               d2bth_tt, d2bth_tp, d2bth_pp, &
-                               d2bph_rr, d2bph_rt, d2bph_rp, &
-                               d2bph_tt, d2bph_tp, d2bph_pp, G_c)
+    subroutine splint_can_coord(fullset, mode_secders, r, vartheta_c, varphi_c, &
+            A_theta, A_phi, dA_theta_dr, dA_phi_dr, &
+            d2A_phi_dr2, d3A_phi_dr3, &
+            sqg_c, dsqg_c_dr, dsqg_c_dt, dsqg_c_dp, &
+            B_vartheta_c, dB_vartheta_c_dr, &
+            dB_vartheta_c_dt, dB_vartheta_c_dp, &
+            B_varphi_c, dB_varphi_c_dr, &
+            dB_varphi_c_dt, dB_varphi_c_dp, &
+            d2sqg_rr, d2sqg_rt, d2sqg_rp, &
+            d2sqg_tt, d2sqg_tp, d2sqg_pp, &
+            d2bth_rr, d2bth_rt, d2bth_rp, &
+            d2bth_tt, d2bth_tp, d2bth_pp, &
+            d2bph_rr, d2bph_rt, d2bph_rp, &
+            d2bph_tt, d2bph_tp, d2bph_pp, G_c)
 
-      use vector_potentail_mod, only: torflux
-      use new_vmec_stuff_mod, only: nper
-      use chamb_mod, only: rnegflag
-      use diag_mod, only: dodiag, icounter
+        use vector_potentail_mod, only: torflux
+        use new_vmec_stuff_mod, only: nper
+        use chamb_mod, only: rnegflag
+        use diag_mod, only: dodiag, icounter
 
-      implicit none
+        implicit none
 
-      logical, intent(in) :: fullset
-      integer, intent(in) :: mode_secders
-      real(dp), intent(in) :: r
-      real(dp), intent(in) :: vartheta_c, varphi_c
+        logical, intent(in) :: fullset
+        integer, intent(in) :: mode_secders
+        real(dp), intent(in) :: r
+        real(dp), intent(in) :: vartheta_c, varphi_c
 
-      real(dp), intent(out) :: A_phi, A_theta, dA_phi_dr, dA_theta_dr
-      real(dp), intent(out) :: d2A_phi_dr2, d3A_phi_dr3
-      real(dp), intent(out) :: sqg_c, dsqg_c_dr, dsqg_c_dt, dsqg_c_dp
-      real(dp), intent(out) :: B_vartheta_c, dB_vartheta_c_dr
-      real(dp), intent(out) :: dB_vartheta_c_dt, dB_vartheta_c_dp
-      real(dp), intent(out) :: B_varphi_c, dB_varphi_c_dr
-      real(dp), intent(out) :: dB_varphi_c_dt, dB_varphi_c_dp
-      real(dp), intent(out) :: d2sqg_rr, d2sqg_rt, d2sqg_rp
-      real(dp), intent(out) :: d2sqg_tt, d2sqg_tp, d2sqg_pp
-      real(dp), intent(out) :: d2bth_rr, d2bth_rt, d2bth_rp
-      real(dp), intent(out) :: d2bth_tt, d2bth_tp, d2bth_pp
-      real(dp), intent(out) :: d2bph_rr, d2bph_rt, d2bph_rp
-      real(dp), intent(out) :: d2bph_tt, d2bph_tp, d2bph_pp
-      real(dp), intent(out) :: G_c
+        real(dp), intent(out) :: A_phi, A_theta, dA_phi_dr, dA_theta_dr
+        real(dp), intent(out) :: d2A_phi_dr2, d3A_phi_dr3
+        real(dp), intent(out) :: sqg_c, dsqg_c_dr, dsqg_c_dt, dsqg_c_dp
+        real(dp), intent(out) :: B_vartheta_c, dB_vartheta_c_dr
+        real(dp), intent(out) :: dB_vartheta_c_dt, dB_vartheta_c_dp
+        real(dp), intent(out) :: B_varphi_c, dB_varphi_c_dr
+        real(dp), intent(out) :: dB_varphi_c_dt, dB_varphi_c_dp
+        real(dp), intent(out) :: d2sqg_rr, d2sqg_rt, d2sqg_rp
+        real(dp), intent(out) :: d2sqg_tt, d2sqg_tp, d2sqg_pp
+        real(dp), intent(out) :: d2bth_rr, d2bth_rt, d2bth_rp
+        real(dp), intent(out) :: d2bth_tt, d2bth_tp, d2bth_pp
+        real(dp), intent(out) :: d2bph_rr, d2bph_rt, d2bph_rp
+        real(dp), intent(out) :: d2bph_tt, d2bph_tp, d2bph_pp
+        real(dp), intent(out) :: G_c
 
-      real(dp) :: r_eval
-      real(dp) :: rho_tor, drhods, drhods2, d2rhods2m
-      real(dp) :: x_eval(3)
-      real(dp) :: yq(1), dyq(3, 1), d2yq(6, 1)
-      real(dp) :: d2yq_rmix(3, 1)
-      real(dp) :: y_G(1), dy_G(3, 1)
-      real(dp) :: y1d(1), dy1d(1), d2y1d(1)
-      real(dp) :: theta_wrapped, phi_wrapped
-      real(dp) :: qua, dqua_dr, dqua_dt, dqua_dp
-      real(dp) :: d2qua_dr2, d2qua_drdt, d2qua_drdp
-      real(dp) :: d2qua_dt2, d2qua_dtdp, d2qua_dp2
+        real(dp) :: r_eval
+        real(dp) :: rho_tor, drhods, drhods2, d2rhods2m
+        real(dp) :: x_eval(3)
+        real(dp) :: yq(1), dyq(3, 1), d2yq(6, 1)
+        real(dp) :: d2yq_rmix(3, 1)
+        real(dp) :: y_G(1), dy_G(3, 1)
+        real(dp) :: y1d(1), dy1d(1), d2y1d(1)
+        real(dp) :: theta_wrapped, phi_wrapped
+        real(dp) :: qua, dqua_dr, dqua_dt, dqua_dp
+        real(dp) :: d2qua_dr2, d2qua_drdt, d2qua_drdp
+        real(dp) :: d2qua_dt2, d2qua_dtdp, d2qua_dp2
 
-      if (dodiag) then
-!$omp atomic
-         icounter = icounter + 1
-      end if
-      r_eval = r
-      if (r_eval <= 0.0_dp) then
-         rnegflag = .true.
-         r_eval = abs(r_eval)
-      end if
+        if (dodiag) then
+            !$omp atomic
+            icounter = icounter + 1
+        end if
+        r_eval = r
+        if (r_eval <= 0.0_dp) then
+            rnegflag = .true.
+            r_eval = abs(r_eval)
+        end if
 
-      A_theta = torflux*r_eval
-      dA_theta_dr = torflux
+        A_theta = torflux*r_eval
+        dA_theta_dr = torflux
 
-      ! Interpolate A_phi using batch spline (1D)
-      if (.not. aphi_batch_spline_ready) then
-         error stop "splint_can_coord: Aphi batch spline not initialized"
-      end if
+        ! Interpolate A_phi using batch spline (1D)
+        if (.not. aphi_batch_spline_ready) then
+            error stop "splint_can_coord: Aphi batch spline not initialized"
+        end if
 
-      call evaluate_batch_splines_1d_der2(aphi_batch_spline, r_eval, &
-                                          y1d, dy1d, d2y1d)
-      d3A_phi_dr3 = 0.0_dp
-      A_phi = y1d(1)
-      dA_phi_dr = dy1d(1)
-      d2A_phi_dr2 = d2y1d(1)
+        call evaluate_batch_splines_1d_der2(aphi_batch_spline, r_eval, &
+            y1d, dy1d, d2y1d)
+        d3A_phi_dr3 = 0.0_dp
+        A_phi = y1d(1)
+        dA_phi_dr = dy1d(1)
+        d2A_phi_dr2 = d2y1d(1)
 
-      ! Prepare coordinates for 3D interpolation
-      rho_tor = sqrt(r_eval)
-      theta_wrapped = modulo(vartheta_c, TWOPI)
-      phi_wrapped = modulo(varphi_c, TWOPI/real(nper, dp))
+        ! Prepare coordinates for 3D interpolation
+        rho_tor = sqrt(r_eval)
+        theta_wrapped = modulo(vartheta_c, TWOPI)
+        phi_wrapped = modulo(varphi_c, TWOPI/real(nper, dp))
 
-      x_eval(1) = rho_tor
-      x_eval(2) = theta_wrapped
-      x_eval(3) = phi_wrapped
+        x_eval(1) = rho_tor
+        x_eval(2) = theta_wrapped
+        x_eval(3) = phi_wrapped
 
-      ! Chain rule coefficients for rho -> s conversion
-      ! rho = sqrt(s), drho/ds = 0.5/rho, d2rho/ds2 = -0.25/rho^3
-      drhods = 0.5_dp/rho_tor
-      drhods2 = drhods**2
-      d2rhods2m = drhods2/rho_tor  ! -d2rho/ds2 (negated for chain rule)
+        ! Chain rule coefficients for rho -> s conversion
+        ! rho = sqrt(s), drho/ds = 0.5/rho, d2rho/ds2 = -0.25/rho^3
+        drhods = 0.5_dp/rho_tor
+        drhods2 = drhods**2
+        d2rhods2m = drhods2/rho_tor ! -d2rho/ds2 (negated for chain rule)
 
-      ! Interpolate G if needed
-      if (fullset) then
-         if (.not. G_batch_spline_ready) then
-            error stop "splint_can_coord: G batch spline not initialized"
-         end if
-         call evaluate_batch_splines_3d_der(G_batch_spline, x_eval, y_G, dy_G)
-         G_c = y_G(1)
-      else
-         G_c = 0.0_dp
-      end if
+        ! Interpolate G if needed
+        if (fullset) then
+            if (.not. G_batch_spline_ready) then
+                error stop "splint_can_coord: G batch spline not initialized"
+            end if
+            call evaluate_batch_splines_3d_der(G_batch_spline, x_eval, y_G, dy_G)
+            G_c = y_G(1)
+        else
+            G_c = 0.0_dp
+        end if
 
-      ! Interpolate sqg, B_vartheta, B_varphi (separate NQ=1 splines)
-      if (.not. (sqg_batch_spline_ready .and. Bt_batch_spline_ready .and. &
-                 Bp_batch_spline_ready)) then
-         error stop "splint_can_coord: sqg/Bt/Bp batch splines not initialized"
-      end if
+        ! Interpolate sqg, B_vartheta, B_varphi (separate NQ=1 splines)
+        if (.not. (sqg_batch_spline_ready .and. Bt_batch_spline_ready .and. &
+            Bp_batch_spline_ready)) then
+        error stop "splint_can_coord: sqg/Bt/Bp batch splines not initialized"
+    end if
 
-      if (mode_secders == 2 .or. mode_secders == 3) then
-         if (mode_secders == 2) then
+    if (mode_secders == 2 .or. mode_secders == 3) then
+        if (mode_secders == 2) then
             call evaluate_batch_splines_3d_der2(sqg_batch_spline, x_eval, yq, &
-                                                dyq, d2yq)
-         else
+                dyq, d2yq)
+        else
             call evaluate_batch_splines_3d_der2_rmix(sqg_batch_spline, x_eval, yq, &
-                                                     dyq, d2yq_rmix)
+                dyq, d2yq_rmix)
             d2yq(1:3, 1) = d2yq_rmix(:, 1)
             d2yq(4:6, 1) = 0.0_dp
-         end if
+        end if
 
-         qua = yq(1)
-         dqua_dr = dyq(1, 1)
-         dqua_dt = dyq(2, 1)
-         dqua_dp = dyq(3, 1)
-         d2qua_dr2 = d2yq(1, 1)
-         d2qua_drdt = d2yq(2, 1)
-         d2qua_drdp = d2yq(3, 1)
-         d2qua_dt2 = d2yq(4, 1)
-         d2qua_dtdp = d2yq(5, 1)
-         d2qua_dp2 = d2yq(6, 1)
+        qua = yq(1)
+        dqua_dr = dyq(1, 1)
+        dqua_dt = dyq(2, 1)
+        dqua_dp = dyq(3, 1)
+        d2qua_dr2 = d2yq(1, 1)
+        d2qua_drdt = d2yq(2, 1)
+        d2qua_drdp = d2yq(3, 1)
+        d2qua_dt2 = d2yq(4, 1)
+        d2qua_dtdp = d2yq(5, 1)
+        d2qua_dp2 = d2yq(6, 1)
 
-         d2qua_dr2 = d2qua_dr2*drhods2 - dqua_dr*d2rhods2m
-         dqua_dr = dqua_dr*drhods
-         d2qua_drdt = d2qua_drdt*drhods
-         d2qua_drdp = d2qua_drdp*drhods
+        d2qua_dr2 = d2qua_dr2*drhods2 - dqua_dr*d2rhods2m
+        dqua_dr = dqua_dr*drhods
+        d2qua_drdt = d2qua_drdt*drhods
+        d2qua_drdp = d2qua_drdp*drhods
 
-         sqg_c = qua
-         dsqg_c_dr = dqua_dr
-         dsqg_c_dt = dqua_dt
-         dsqg_c_dp = dqua_dp
-         d2sqg_rr = d2qua_dr2
-         d2sqg_rt = d2qua_drdt
-         d2sqg_rp = d2qua_drdp
-         d2sqg_tt = d2qua_dt2
-         d2sqg_tp = d2qua_dtdp
-         d2sqg_pp = d2qua_dp2
+        sqg_c = qua
+        dsqg_c_dr = dqua_dr
+        dsqg_c_dt = dqua_dt
+        dsqg_c_dp = dqua_dp
+        d2sqg_rr = d2qua_dr2
+        d2sqg_rt = d2qua_drdt
+        d2sqg_rp = d2qua_drdp
+        d2sqg_tt = d2qua_dt2
+        d2sqg_tp = d2qua_dtdp
+        d2sqg_pp = d2qua_dp2
 
-         if (mode_secders == 2) then
+        if (mode_secders == 2) then
             call evaluate_batch_splines_3d_der2(Bt_batch_spline, x_eval, yq, &
-                                                dyq, d2yq)
-         else
+                dyq, d2yq)
+        else
             call evaluate_batch_splines_3d_der2_rmix(Bt_batch_spline, x_eval, yq, &
-                                                     dyq, d2yq_rmix)
+                dyq, d2yq_rmix)
             d2yq(1:3, 1) = d2yq_rmix(:, 1)
             d2yq(4:6, 1) = 0.0_dp
-         end if
+        end if
 
-         qua = yq(1)
-         dqua_dr = dyq(1, 1)
-         dqua_dt = dyq(2, 1)
-         dqua_dp = dyq(3, 1)
-         d2qua_dr2 = d2yq(1, 1)
-         d2qua_drdt = d2yq(2, 1)
-         d2qua_drdp = d2yq(3, 1)
-         d2qua_dt2 = d2yq(4, 1)
-         d2qua_dtdp = d2yq(5, 1)
-         d2qua_dp2 = d2yq(6, 1)
+        qua = yq(1)
+        dqua_dr = dyq(1, 1)
+        dqua_dt = dyq(2, 1)
+        dqua_dp = dyq(3, 1)
+        d2qua_dr2 = d2yq(1, 1)
+        d2qua_drdt = d2yq(2, 1)
+        d2qua_drdp = d2yq(3, 1)
+        d2qua_dt2 = d2yq(4, 1)
+        d2qua_dtdp = d2yq(5, 1)
+        d2qua_dp2 = d2yq(6, 1)
 
-         d2qua_dr2 = d2qua_dr2*drhods2 - dqua_dr*d2rhods2m
-         dqua_dr = dqua_dr*drhods
-         d2qua_drdt = d2qua_drdt*drhods
-         d2qua_drdp = d2qua_drdp*drhods
+        d2qua_dr2 = d2qua_dr2*drhods2 - dqua_dr*d2rhods2m
+        dqua_dr = dqua_dr*drhods
+        d2qua_drdt = d2qua_drdt*drhods
+        d2qua_drdp = d2qua_drdp*drhods
 
-         B_vartheta_c = qua
-         dB_vartheta_c_dr = dqua_dr
-         dB_vartheta_c_dt = dqua_dt
-         dB_vartheta_c_dp = dqua_dp
-         d2bth_rr = d2qua_dr2
-         d2bth_rt = d2qua_drdt
-         d2bth_rp = d2qua_drdp
-         d2bth_tt = d2qua_dt2
-         d2bth_tp = d2qua_dtdp
-         d2bth_pp = d2qua_dp2
+        B_vartheta_c = qua
+        dB_vartheta_c_dr = dqua_dr
+        dB_vartheta_c_dt = dqua_dt
+        dB_vartheta_c_dp = dqua_dp
+        d2bth_rr = d2qua_dr2
+        d2bth_rt = d2qua_drdt
+        d2bth_rp = d2qua_drdp
+        d2bth_tt = d2qua_dt2
+        d2bth_tp = d2qua_dtdp
+        d2bth_pp = d2qua_dp2
 
-         if (mode_secders == 2) then
+        if (mode_secders == 2) then
             call evaluate_batch_splines_3d_der2(Bp_batch_spline, x_eval, yq, &
-                                                dyq, d2yq)
-         else
+                dyq, d2yq)
+        else
             call evaluate_batch_splines_3d_der2_rmix(Bp_batch_spline, x_eval, yq, &
-                                                     dyq, d2yq_rmix)
+                dyq, d2yq_rmix)
             d2yq(1:3, 1) = d2yq_rmix(:, 1)
             d2yq(4:6, 1) = 0.0_dp
-         end if
+        end if
 
-         qua = yq(1)
-         dqua_dr = dyq(1, 1)
-         dqua_dt = dyq(2, 1)
-         dqua_dp = dyq(3, 1)
-         d2qua_dr2 = d2yq(1, 1)
-         d2qua_drdt = d2yq(2, 1)
-         d2qua_drdp = d2yq(3, 1)
-         d2qua_dt2 = d2yq(4, 1)
-         d2qua_dtdp = d2yq(5, 1)
-         d2qua_dp2 = d2yq(6, 1)
+        qua = yq(1)
+        dqua_dr = dyq(1, 1)
+        dqua_dt = dyq(2, 1)
+        dqua_dp = dyq(3, 1)
+        d2qua_dr2 = d2yq(1, 1)
+        d2qua_drdt = d2yq(2, 1)
+        d2qua_drdp = d2yq(3, 1)
+        d2qua_dt2 = d2yq(4, 1)
+        d2qua_dtdp = d2yq(5, 1)
+        d2qua_dp2 = d2yq(6, 1)
 
-         d2qua_dr2 = d2qua_dr2*drhods2 - dqua_dr*d2rhods2m
-         dqua_dr = dqua_dr*drhods
-         d2qua_drdt = d2qua_drdt*drhods
-         d2qua_drdp = d2qua_drdp*drhods
+        d2qua_dr2 = d2qua_dr2*drhods2 - dqua_dr*d2rhods2m
+        dqua_dr = dqua_dr*drhods
+        d2qua_drdt = d2qua_drdt*drhods
+        d2qua_drdp = d2qua_drdp*drhods
 
-         B_varphi_c = qua
-         dB_varphi_c_dr = dqua_dr
-         dB_varphi_c_dt = dqua_dt
-         dB_varphi_c_dp = dqua_dp
-         d2bph_rr = d2qua_dr2
-         d2bph_rt = d2qua_drdt
-         d2bph_rp = d2qua_drdp
-         d2bph_tt = d2qua_dt2
-         d2bph_tp = d2qua_dtdp
-         d2bph_pp = d2qua_dp2
+        B_varphi_c = qua
+        dB_varphi_c_dr = dqua_dr
+        dB_varphi_c_dt = dqua_dt
+        dB_varphi_c_dp = dqua_dp
+        d2bph_rr = d2qua_dr2
+        d2bph_rt = d2qua_drdt
+        d2bph_rp = d2qua_drdp
+        d2bph_tt = d2qua_dt2
+        d2bph_tp = d2qua_dtdp
+        d2bph_pp = d2qua_dp2
 
-      else
-         call evaluate_batch_splines_3d_der(sqg_batch_spline, x_eval, yq, dyq)
-         sqg_c = yq(1)
-         dsqg_c_dr = dyq(1, 1)*drhods
-         dsqg_c_dt = dyq(2, 1)
-         dsqg_c_dp = dyq(3, 1)
+    else
+        call evaluate_batch_splines_3d_der(sqg_batch_spline, x_eval, yq, dyq)
+        sqg_c = yq(1)
+        dsqg_c_dr = dyq(1, 1)*drhods
+        dsqg_c_dt = dyq(2, 1)
+        dsqg_c_dp = dyq(3, 1)
 
-         call evaluate_batch_splines_3d_der(Bt_batch_spline, x_eval, yq, dyq)
-         B_vartheta_c = yq(1)
-         dB_vartheta_c_dr = dyq(1, 1)*drhods
-         dB_vartheta_c_dt = dyq(2, 1)
-         dB_vartheta_c_dp = dyq(3, 1)
+        call evaluate_batch_splines_3d_der(Bt_batch_spline, x_eval, yq, dyq)
+        B_vartheta_c = yq(1)
+        dB_vartheta_c_dr = dyq(1, 1)*drhods
+        dB_vartheta_c_dt = dyq(2, 1)
+        dB_vartheta_c_dp = dyq(3, 1)
 
-         call evaluate_batch_splines_3d_der(Bp_batch_spline, x_eval, yq, dyq)
-         B_varphi_c = yq(1)
-         dB_varphi_c_dr = dyq(1, 1)*drhods
-         dB_varphi_c_dt = dyq(2, 1)
-         dB_varphi_c_dp = dyq(3, 1)
+        call evaluate_batch_splines_3d_der(Bp_batch_spline, x_eval, yq, dyq)
+        B_varphi_c = yq(1)
+        dB_varphi_c_dr = dyq(1, 1)*drhods
+        dB_varphi_c_dt = dyq(2, 1)
+        dB_varphi_c_dp = dyq(3, 1)
 
-         d2sqg_rr = 0.0_dp
-         d2sqg_rt = 0.0_dp
-         d2sqg_rp = 0.0_dp
-         d2sqg_tt = 0.0_dp
-         d2sqg_tp = 0.0_dp
-         d2sqg_pp = 0.0_dp
-         d2bth_rr = 0.0_dp
-         d2bth_rt = 0.0_dp
-         d2bth_rp = 0.0_dp
-         d2bth_tt = 0.0_dp
-         d2bth_tp = 0.0_dp
-         d2bth_pp = 0.0_dp
-         d2bph_rr = 0.0_dp
-         d2bph_rt = 0.0_dp
-         d2bph_rp = 0.0_dp
-         d2bph_tt = 0.0_dp
-         d2bph_tp = 0.0_dp
-         d2bph_pp = 0.0_dp
+        d2sqg_rr = 0.0_dp
+        d2sqg_rt = 0.0_dp
+        d2sqg_rp = 0.0_dp
+        d2sqg_tt = 0.0_dp
+        d2sqg_tp = 0.0_dp
+        d2sqg_pp = 0.0_dp
+        d2bth_rr = 0.0_dp
+        d2bth_rt = 0.0_dp
+        d2bth_rp = 0.0_dp
+        d2bth_tt = 0.0_dp
+        d2bth_tp = 0.0_dp
+        d2bth_pp = 0.0_dp
+        d2bph_rr = 0.0_dp
+        d2bph_rt = 0.0_dp
+        d2bph_rp = 0.0_dp
+        d2bph_tt = 0.0_dp
+        d2bph_tp = 0.0_dp
+        d2bph_pp = 0.0_dp
 
-         if (mode_secders == 1) then
+        if (mode_secders == 1) then
             call evaluate_batch_splines_3d_der2(sqg_batch_spline, x_eval, yq, dyq, &
-                                                d2yq)
+                d2yq)
             d2sqg_rr = d2yq(1, 1)*drhods2 - dyq(1, 1)*d2rhods2m
 
             call evaluate_batch_splines_3d_der2(Bt_batch_spline, x_eval, yq, dyq, &
-                                                d2yq)
+                d2yq)
             d2bth_rr = d2yq(1, 1)*drhods2 - dyq(1, 1)*d2rhods2m
 
             call evaluate_batch_splines_3d_der2(Bp_batch_spline, x_eval, yq, dyq, &
-                                                d2yq)
+                d2yq)
             d2bph_rr = d2yq(1, 1)*drhods2 - dyq(1, 1)*d2rhods2m
-         end if
-      end if
+        end if
+    end if
 
-   end subroutine splint_can_coord
+end subroutine splint_can_coord
 
-   subroutine can_to_vmec(r, vartheta_c_in, varphi_c_in, theta_vmec, varphi_vmec)
-      use exchange_get_cancoord_mod, only: vartheta_c, varphi_c, theta
+subroutine can_to_vmec(r, vartheta_c_in, varphi_c_in, theta_vmec, varphi_vmec)
+    use exchange_get_cancoord_mod, only: vartheta_c, varphi_c, theta
 
-      implicit none
+    implicit none
 
-      real(dp), intent(in) :: r, vartheta_c_in, varphi_c_in
-      real(dp), intent(out) :: theta_vmec, varphi_vmec
+    real(dp), intent(in) :: r, vartheta_c_in, varphi_c_in
+    real(dp), intent(out) :: theta_vmec, varphi_vmec
 
-      logical :: fullset
-      integer :: mode_secders
-      real(dp) :: r_local
-      real(dp) :: A_phi, A_theta, dA_phi_dr, dA_theta_dr, d2A_phi_dr2, d3A_phi_dr3
-      real(dp) :: sqg_c, dsqg_c_dr, dsqg_c_dt, dsqg_c_dp
-      real(dp) :: B_vartheta_c, dB_vartheta_c_dr, dB_vartheta_c_dt, dB_vartheta_c_dp
-      real(dp) :: B_varphi_c, dB_varphi_c_dr, dB_varphi_c_dt, dB_varphi_c_dp
-      real(dp) :: G_c
-      real(dp) :: d2sqg_rr, d2sqg_rt, d2sqg_rp, d2sqg_tt, d2sqg_tp, d2sqg_pp
-      real(dp) :: d2bth_rr, d2bth_rt, d2bth_rp, d2bth_tt, d2bth_tp, d2bth_pp
-      real(dp) :: d2bph_rr, d2bph_rt, d2bph_rp, d2bph_tt, d2bph_tp, d2bph_pp
-      real(dp), dimension(1) :: y, dy
+    logical :: fullset
+    integer :: mode_secders
+    real(dp) :: r_local
+    real(dp) :: A_phi, A_theta, dA_phi_dr, dA_theta_dr, d2A_phi_dr2, d3A_phi_dr3
+    real(dp) :: sqg_c, dsqg_c_dr, dsqg_c_dt, dsqg_c_dp
+    real(dp) :: B_vartheta_c, dB_vartheta_c_dr, dB_vartheta_c_dt, dB_vartheta_c_dp
+    real(dp) :: B_varphi_c, dB_varphi_c_dr, dB_varphi_c_dt, dB_varphi_c_dp
+    real(dp) :: G_c
+    real(dp) :: d2sqg_rr, d2sqg_rt, d2sqg_rp, d2sqg_tt, d2sqg_tp, d2sqg_pp
+    real(dp) :: d2bth_rr, d2bth_rt, d2bth_rp, d2bth_tt, d2bth_tp, d2bth_pp
+    real(dp) :: d2bph_rr, d2bph_rt, d2bph_rp, d2bph_tt, d2bph_tp, d2bph_pp
+    real(dp), dimension(1) :: y, dy
 
-      fullset = .true.
-      mode_secders = 0
-      r_local = r
+    fullset = .true.
+    mode_secders = 0
+    r_local = r
 
-      call splint_can_coord(fullset, mode_secders, r_local, vartheta_c_in, &
-                            varphi_c_in, A_theta, A_phi, dA_theta_dr, dA_phi_dr, &
-                            d2A_phi_dr2, d3A_phi_dr3, &
-                            sqg_c, dsqg_c_dr, dsqg_c_dt, dsqg_c_dp, &
-                            B_vartheta_c, dB_vartheta_c_dr, dB_vartheta_c_dt, &
-                            dB_vartheta_c_dp, &
-                            B_varphi_c, dB_varphi_c_dr, dB_varphi_c_dt, &
-                            dB_varphi_c_dp, &
-                            d2sqg_rr, d2sqg_rt, d2sqg_rp, d2sqg_tt, d2sqg_tp, &
-                            d2sqg_pp, &
-                            d2bth_rr, d2bth_rt, d2bth_rp, d2bth_tt, d2bth_tp, &
-                            d2bth_pp, &
-                            d2bph_rr, d2bph_rt, d2bph_rp, d2bph_tt, d2bph_tp, &
-                            d2bph_pp, G_c)
+    call splint_can_coord(fullset, mode_secders, r_local, vartheta_c_in, &
+        varphi_c_in, A_theta, A_phi, dA_theta_dr, dA_phi_dr, &
+        d2A_phi_dr2, d3A_phi_dr3, &
+        sqg_c, dsqg_c_dr, dsqg_c_dt, dsqg_c_dp, &
+        B_vartheta_c, dB_vartheta_c_dr, dB_vartheta_c_dt, &
+        dB_vartheta_c_dp, &
+        B_varphi_c, dB_varphi_c_dr, dB_varphi_c_dt, &
+        dB_varphi_c_dp, &
+        d2sqg_rr, d2sqg_rt, d2sqg_rp, d2sqg_tt, d2sqg_tp, &
+        d2sqg_pp, &
+        d2bth_rr, d2bth_rt, d2bth_rp, d2bth_tt, d2bth_tp, &
+        d2bth_pp, &
+        d2bph_rr, d2bph_rt, d2bph_rp, d2bph_tt, d2bph_tp, &
+        d2bph_pp, G_c)
 
-      vartheta_c = vartheta_c_in
-      varphi_c = varphi_c_in
-      y(1) = G_c
+    vartheta_c = vartheta_c_in
+    varphi_c = varphi_c_in
+    y(1) = G_c
 
-      ! Transform from r (toroidal flux) to rho_tor for ODE integration
-      call rhs_cancoord(sqrt(r_local), y, dy)
+    ! Transform from r (toroidal flux) to rho_tor for ODE integration
+    call rhs_cancoord(sqrt(r_local), y, dy)
 
-      theta_vmec = theta
-      varphi_vmec = varphi_c_in + G_c
+    theta_vmec = theta
+    varphi_vmec = varphi_c_in + G_c
 
-   end subroutine can_to_vmec
+end subroutine can_to_vmec
 
-   subroutine deallocate_can_coord
-      call reset_canflux_batch_splines
-   end subroutine deallocate_can_coord
+subroutine deallocate_can_coord
+    call reset_canflux_batch_splines
+end subroutine deallocate_can_coord
 
-   subroutine vmec_to_can(r, theta, varphi, vartheta_c, varphi_c)
-      ! Input : r,theta,varphi      - VMEC coordinates
-      ! Output: vartheta_c,varphi_c - canonical coordinates
+subroutine vmec_to_can(r, theta, varphi, vartheta_c, varphi_c)
+    ! Input : r,theta,varphi      - VMEC coordinates
+    ! Output: vartheta_c,varphi_c - canonical coordinates
 
-      use spline_vmec_sub
-      use new_vmec_stuff_mod, only: nper
-      use vector_potentail_mod, only: torflux
-      use chamb_mod, only: rnegflag
-      use vmec_field_eval
+    use spline_vmec_sub
+    use new_vmec_stuff_mod, only: nper
+    use vector_potentail_mod, only: torflux
+    use chamb_mod, only: rnegflag
+    use vmec_field_eval
 
-      implicit none
+    implicit none
 
-      real(dp), parameter :: epserr = 1.0e-14_dp
-      integer, parameter :: niter = 100
-      integer :: iter
-      real(dp), intent(in) :: r, theta, varphi
-      real(dp), intent(out) :: vartheta_c, varphi_c
-      real(dp) :: delthe, delphi, alam, dl_dt, vartheta
-      real(dp) :: rho_tor, x_eval(3), y_G(1), dy_G(3, 1)
-      real(dp) :: G_c, dG_c_dt, dG_c_dp, aiota
-      real(dp) :: ts, ps, dts_dtc, dts_dpc, dps_dtc, dps_dpc, det
-      real(dp) :: y1d(1), dy1d(1), d2y1d(1), dA_phi_dr, dA_theta_dr
-      real(dp) :: r_local
+    real(dp), parameter :: epserr = 1.0e-14_dp
+    integer, parameter :: niter = 100
+    integer :: iter
+    real(dp), intent(in) :: r, theta, varphi
+    real(dp), intent(out) :: vartheta_c, varphi_c
+    real(dp) :: delthe, delphi, alam, dl_dt, vartheta
+    real(dp) :: rho_tor, x_eval(3), y_G(1), dy_G(3, 1)
+    real(dp) :: G_c, dG_c_dt, dG_c_dp, aiota
+    real(dp) :: ts, ps, dts_dtc, dts_dpc, dps_dtc, dps_dpc, det
+    real(dp) :: y1d(1), dy1d(1), d2y1d(1), dA_phi_dr, dA_theta_dr
+    real(dp) :: r_local
 
-      r_local = r
-      if (r_local <= 0.0_dp) then
-         rnegflag = .true.
-         r_local = abs(r_local)
-      end if
+    r_local = r
+    if (r_local <= 0.0_dp) then
+        rnegflag = .true.
+        r_local = abs(r_local)
+    end if
 
-      if (allocated(current_field)) then
-         call vmec_lambda_interpolate_with_field(current_field, r_local, theta, &
-                                                 varphi, alam, dl_dt)
-      else
-         call vmec_lambda_interpolate(r_local, theta, varphi, alam, dl_dt)
-      end if
+    if (allocated(current_field)) then
+        call vmec_lambda_interpolate_with_field(current_field, r_local, theta, &
+            varphi, alam, dl_dt)
+    else
+        call vmec_lambda_interpolate(r_local, theta, varphi, alam, dl_dt)
+    end if
 
-      vartheta = theta + alam
+    vartheta = theta + alam
 
-      vartheta_c = vartheta
-      varphi_c = varphi
+    vartheta_c = vartheta
+    varphi_c = varphi
 
-      ! Get iota from A_phi interpolation
-      dA_theta_dr = torflux
-      call evaluate_batch_splines_1d_der2(aphi_batch_spline, r_local, y1d, &
-                                          dy1d, d2y1d)
-      dA_phi_dr = dy1d(1)
-      aiota = -dA_phi_dr/dA_theta_dr
+    ! Get iota from A_phi interpolation
+    dA_theta_dr = torflux
+    call evaluate_batch_splines_1d_der2(aphi_batch_spline, r_local, y1d, &
+        dy1d, d2y1d)
+    dA_phi_dr = dy1d(1)
+    aiota = -dA_phi_dr/dA_theta_dr
 
-      do iter = 1, niter
-         rho_tor = sqrt(r_local)
-         x_eval(1) = rho_tor
-         x_eval(2) = modulo(vartheta_c, TWOPI)
-         x_eval(3) = modulo(varphi_c, TWOPI/real(nper, dp))
+    do iter = 1, niter
+        rho_tor = sqrt(r_local)
+        x_eval(1) = rho_tor
+        x_eval(2) = modulo(vartheta_c, TWOPI)
+        x_eval(3) = modulo(varphi_c, TWOPI/real(nper, dp))
 
-         call evaluate_batch_splines_3d_der(G_batch_spline, x_eval, y_G, dy_G)
-         G_c = y_G(1)
-         dG_c_dt = dy_G(2, 1)
-         dG_c_dp = dy_G(3, 1)
+        call evaluate_batch_splines_3d_der(G_batch_spline, x_eval, y_G, dy_G)
+        G_c = y_G(1)
+        dG_c_dt = dy_G(2, 1)
+        dG_c_dp = dy_G(3, 1)
 
-         ts = vartheta_c + aiota*G_c - vartheta
-         ps = varphi_c + G_c - varphi
-         dts_dtc = 1.0_dp + aiota*dG_c_dt
-         dts_dpc = aiota*dG_c_dp
-         dps_dtc = dG_c_dt
-         dps_dpc = 1.0_dp + dG_c_dp
-         det = 1.0_dp + aiota*dG_c_dt + dG_c_dp
+        ts = vartheta_c + aiota*G_c - vartheta
+        ps = varphi_c + G_c - varphi
+        dts_dtc = 1.0_dp + aiota*dG_c_dt
+        dts_dpc = aiota*dG_c_dp
+        dps_dtc = dG_c_dt
+        dps_dpc = 1.0_dp + dG_c_dp
+        det = 1.0_dp + aiota*dG_c_dt + dG_c_dp
 
-         delthe = (ps*dts_dpc - ts*dps_dpc)/det
-         delphi = (ts*dps_dtc - ps*dts_dtc)/det
+        delthe = (ps*dts_dpc - ts*dps_dpc)/det
+        delphi = (ts*dps_dtc - ps*dts_dtc)/det
 
-         vartheta_c = vartheta_c + delthe
-         varphi_c = varphi_c + delphi
-         if (abs(delthe) + abs(delphi) < epserr) exit
-      end do
+        vartheta_c = vartheta_c + delthe
+        varphi_c = varphi_c + delphi
+        if (abs(delthe) + abs(delphi) < epserr) exit
+    end do
 
-   end subroutine vmec_to_can
+end subroutine vmec_to_can
 
-   subroutine vmec_to_cyl(s, theta, varphi, Rcyl, Zcyl)
-      use spline_vmec_sub
-      use vmec_field_eval
+subroutine vmec_to_cyl(s, theta, varphi, Rcyl, Zcyl)
+    use spline_vmec_sub
+    use vmec_field_eval
 
-      real(dp), intent(in) :: s, theta, varphi
-      real(dp), intent(out) :: Rcyl, Zcyl
+    real(dp), intent(in) :: s, theta, varphi
+    real(dp), intent(out) :: Rcyl, Zcyl
 
-      real(dp) :: A_phi, A_theta, dA_phi_ds, dA_theta_ds, aiota, &
-                  R, Z, alam, dR_ds, dR_dt, dR_dp, dZ_ds, dZ_dt, dZ_dp, dl_ds, &
-                  dl_dt, dl_dp
+    real(dp) :: A_phi, A_theta, dA_phi_ds, dA_theta_ds, aiota, &
+        R, Z, alam, dR_ds, dR_dt, dR_dp, dZ_ds, dZ_dt, dZ_dp, dl_ds, &
+        dl_dt, dl_dp
 
-      if (allocated(current_field)) then
-         call vmec_data_interpolate_with_field(current_field, s, theta, varphi, &
-                                               A_phi, A_theta, dA_phi_ds, &
-                                               dA_theta_ds, aiota, &
-                                               R, Z, alam, dR_ds, dR_dt, dR_dp, &
-                                               dZ_ds, dZ_dt, dZ_dp, &
-                                               dl_ds, dl_dt, dl_dp)
-      else
-         call vmec_data_interpolate(s, theta, varphi, A_phi, A_theta, &
-                                    dA_phi_ds, dA_theta_ds, aiota, &
-                                    R, Z, alam, dR_ds, dR_dt, dR_dp, dZ_ds, &
-                                    dZ_dt, dZ_dp, &
-                                    dl_ds, dl_dt, dl_dp)
-      end if
+    if (allocated(current_field)) then
+        call vmec_data_interpolate_with_field(current_field, s, theta, varphi, &
+            A_phi, A_theta, dA_phi_ds, &
+            dA_theta_ds, aiota, &
+            R, Z, alam, dR_ds, dR_dt, dR_dp, &
+            dZ_ds, dZ_dt, dZ_dp, &
+            dl_ds, dl_dt, dl_dp)
+    else
+        call vmec_data_interpolate(s, theta, varphi, A_phi, A_theta, &
+            dA_phi_ds, dA_theta_ds, aiota, &
+            R, Z, alam, dR_ds, dR_dt, dR_dp, dZ_ds, &
+            dZ_dt, dZ_dp, &
+            dl_ds, dl_dt, dl_dp)
+    end if
 
-      Rcyl = R
-      Zcyl = Z
-   end subroutine vmec_to_cyl
+    Rcyl = R
+    Zcyl = Z
+end subroutine vmec_to_cyl
 
 end module get_can_sub

--- a/src/params.f90
+++ b/src/params.f90
@@ -3,6 +3,7 @@ module params
     use util, only: pi, c, e_charge, p_mass, ev
     use parmot_mod, only: ro0, rmu
     use new_vmec_stuff_mod, only: old_axis_healing, old_axis_healing_boundary, &
+                                  axis_healing_power_law, rho_axis_heal, &
                                   netcdffile, ns_s, ns_tp, multharm, vmec_B_scale, &
                                   vmec_RZ_scale
     use velo_mod, only: isw_field_type
@@ -112,7 +113,8 @@ module params
 	        special_ants_file, integmode, relerr, tcut, nturns, debug, &
 	        class_plot, cut_in_per, fast_class, vmec_B_scale, &
 	        vmec_RZ_scale, swcoll, deterministic, old_axis_healing, &
-	        old_axis_healing_boundary, am1, am2, Z1, Z2, &
+	        old_axis_healing_boundary, axis_healing_power_law, rho_axis_heal, &
+	        am1, am2, Z1, Z2, &
 	        densi1, densi2, tempi1, tempi2, tempe, &
 	        batch_size, ran_seed, reuse_batch, field_input, coord_input, &
 	        wall_input, wall_units, integ_coords, output_results_netcdf, &

--- a/src/params.f90
+++ b/src/params.f90
@@ -2,9 +2,10 @@ module params
     use, intrinsic :: iso_fortran_env, only: int8
     use util, only: pi, c, e_charge, p_mass, ev
     use parmot_mod, only: ro0, rmu
-    use new_vmec_stuff_mod, only: old_axis_healing, old_axis_healing_boundary, &
-                                  axis_healing_power_law, rho_axis_heal, &
-                                  axis_healing_polyfit, axis_healing_polyfit_degree, &
+    use new_vmec_stuff_mod, only: axis_healing, axis_healing_boundary, &
+                                  rho_axis_heal, axis_healing_polyfit_degree, &
+                                  old_axis_healing, old_axis_healing_boundary, &
+                                  axis_healing_power_law, axis_healing_polyfit, &
                                   netcdffile, ns_s, ns_tp, multharm, vmec_B_scale, &
                                   vmec_RZ_scale
     use velo_mod, only: isw_field_type
@@ -115,7 +116,7 @@ module params
 	        class_plot, cut_in_per, fast_class, vmec_B_scale, &
 	        vmec_RZ_scale, swcoll, deterministic, old_axis_healing, &
 	        old_axis_healing_boundary, axis_healing_power_law, rho_axis_heal, &
-	        axis_healing_polyfit, axis_healing_polyfit_degree, &
+	        axis_healing_polyfit, axis_healing_polyfit_degree, axis_healing, axis_healing_boundary, &
 	        am1, am2, Z1, Z2, &
 	        densi1, densi2, tempi1, tempi2, tempe, &
 	        batch_size, ran_seed, reuse_batch, field_input, coord_input, &

--- a/src/params.f90
+++ b/src/params.f90
@@ -2,8 +2,8 @@ module params
     use, intrinsic :: iso_fortran_env, only: int8
     use util, only: pi, c, e_charge, p_mass, ev
     use parmot_mod, only: ro0, rmu
-    use new_vmec_stuff_mod, only: axis_healing, axis_healing_boundary, &
-                                  rho_axis_heal, axis_healing_polyfit_degree, &
+    use new_vmec_stuff_mod, only: axis_healing, s_axis_heal, rho_axis_heal, &
+                                  axis_healing_polyfit_degree, &
                                   old_axis_healing, old_axis_healing_boundary, &
                                   axis_healing_power_law, axis_healing_polyfit, &
                                   netcdffile, ns_s, ns_tp, multharm, vmec_B_scale, &
@@ -115,8 +115,8 @@ module params
 	        special_ants_file, integmode, relerr, tcut, nturns, debug, &
 	        class_plot, cut_in_per, fast_class, vmec_B_scale, &
 	        vmec_RZ_scale, swcoll, deterministic, old_axis_healing, &
-	        old_axis_healing_boundary, axis_healing_power_law, rho_axis_heal, &
-	        axis_healing_polyfit, axis_healing_polyfit_degree, axis_healing, axis_healing_boundary, &
+	        old_axis_healing_boundary, axis_healing_power_law, s_axis_heal, rho_axis_heal, &
+	        axis_healing_polyfit, axis_healing_polyfit_degree, axis_healing, &
 	        am1, am2, Z1, Z2, &
 	        densi1, densi2, tempi1, tempi2, tempe, &
 	        batch_size, ran_seed, reuse_batch, field_input, coord_input, &

--- a/src/params.f90
+++ b/src/params.f90
@@ -4,6 +4,7 @@ module params
     use parmot_mod, only: ro0, rmu
     use new_vmec_stuff_mod, only: old_axis_healing, old_axis_healing_boundary, &
                                   axis_healing_power_law, rho_axis_heal, &
+                                  axis_healing_polyfit, axis_healing_polyfit_degree, &
                                   netcdffile, ns_s, ns_tp, multharm, vmec_B_scale, &
                                   vmec_RZ_scale
     use velo_mod, only: isw_field_type
@@ -114,6 +115,7 @@ module params
 	        class_plot, cut_in_per, fast_class, vmec_B_scale, &
 	        vmec_RZ_scale, swcoll, deterministic, old_axis_healing, &
 	        old_axis_healing_boundary, axis_healing_power_law, rho_axis_heal, &
+	        axis_healing_polyfit, axis_healing_polyfit_degree, &
 	        am1, am2, Z1, Z2, &
 	        densi1, densi2, tempi1, tempi2, tempe, &
 	        batch_size, ran_seed, reuse_batch, field_input, coord_input, &

--- a/src/util.F90
+++ b/src/util.F90
@@ -1,48 +1,48 @@
 #ifndef _OPENMP
-  function omp_get_thread_num()
+function omp_get_thread_num()
     integer :: omp_get_thread_num
     omp_get_thread_num = 0
-  end function omp_get_thread_num
+end function omp_get_thread_num
 #endif
 
 module util
 
-implicit none
+    implicit none
 
-double precision, parameter  :: pi=3.14159265358979d0
-double precision, parameter  :: twopi=6.28318530717958d0
-double precision, parameter  :: c=2.9979d10
-double precision, parameter  :: e_charge=4.8032d-10
-double precision, parameter  :: e_mass=9.1094d-28
-double precision, parameter  :: p_mass=1.6726d-24
-double precision, parameter  :: ev=1.6022d-12
-double precision, parameter  :: sqrt2=dsqrt(2.0d0)
+    double precision, parameter  :: pi=3.14159265358979d0
+    double precision, parameter  :: twopi=6.28318530717958d0
+    double precision, parameter  :: c=2.9979d10
+    double precision, parameter  :: e_charge=4.8032d-10
+    double precision, parameter  :: e_mass=9.1094d-28
+    double precision, parameter  :: p_mass=1.6726d-24
+    double precision, parameter  :: ev=1.6022d-12
+    double precision, parameter  :: sqrt2=dsqrt(2.0d0)
 
 contains
 
-! From: http://fortranwiki.org/fortran/show/newunit
-! This is a simple function to search for an available unit.
-! LUN_MIN and LUN_MAX define the range of possible LUNs to check.
-! The UNIT value is returned by the function, and also by the optional
-! argument. This allows the function to be used directly in an OPEN
-! statement, and optionally save the result in a local variable.
-! If no units are available, -1 is returned.
-integer function newunit(unit)
-  integer, intent(out), optional :: unit
-! local
-  integer, parameter :: LUN_MIN=10, LUN_MAX=1000
-  logical :: opened
-  integer :: lun
-! begin
-  newunit=-1
-  do lun=LUN_MIN,LUN_MAX
-    inquire(unit=lun,opened=opened)
-    if (.not. opened) then
-      newunit=lun
-      exit
-    end if
-  end do
-  if (present(unit)) unit=newunit
-end function newunit
+    ! From: http://fortranwiki.org/fortran/show/newunit
+    ! This is a simple function to search for an available unit.
+    ! LUN_MIN and LUN_MAX define the range of possible LUNs to check.
+    ! The UNIT value is returned by the function, and also by the optional
+    ! argument. This allows the function to be used directly in an OPEN
+    ! statement, and optionally save the result in a local variable.
+    ! If no units are available, -1 is returned.
+    integer function newunit(unit)
+        integer, intent(out), optional :: unit
+        ! local
+        integer, parameter :: LUN_MIN=10, LUN_MAX=1000
+        logical :: opened
+        integer :: lun
+        ! begin
+        newunit=-1
+        do lun=LUN_MIN,LUN_MAX
+            inquire(unit=lun,opened=opened)
+            if (.not. opened) then
+                newunit=lun
+                exit
+            end if
+        end do
+        if (present(unit)) unit=newunit
+    end function newunit
 
 end module util

--- a/src/wall/stl_wall_intersection.F90
+++ b/src/wall/stl_wall_intersection.F90
@@ -1,6 +1,6 @@
 module stl_wall_intersection
 
-    use, intrinsic :: iso_fortran_env, only: dp => real64, int8
+    use, intrinsic :: iso_fortran_env, only: dp => real64
     use, intrinsic :: iso_c_binding, only: c_ptr, c_null_ptr, c_associated, c_int
     use, intrinsic :: iso_c_binding, only: c_double, c_char, c_null_char
     implicit none
@@ -19,7 +19,7 @@ module stl_wall_intersection
 #ifdef SIMPLE_ENABLE_CGAL
     interface
         function stl_wall_create(filename_c, scale_to_m) &
-            bind(C, name="stl_wall_create") result(h)
+                bind(C, name="stl_wall_create") result(h)
             import :: c_ptr, c_char, c_double
             character(kind=c_char), intent(in) :: filename_c(*)
             real(c_double), value, intent(in) :: scale_to_m
@@ -32,7 +32,7 @@ module stl_wall_intersection
         end subroutine stl_wall_destroy
 
         function stl_wall_first_hit_segment_c(h, p0_m, p1_m, hit_m) &
-            bind(C, name="stl_wall_first_hit_segment") result(hit)
+                bind(C, name="stl_wall_first_hit_segment") result(hit)
             import :: c_ptr, c_double, c_int
             type(c_ptr), value, intent(in) :: h
             real(c_double), intent(in) :: p0_m(3)
@@ -42,8 +42,8 @@ module stl_wall_intersection
         end function stl_wall_first_hit_segment_c
 
         function stl_wall_first_hit_segment_with_normal_c( &
-            h, p0_m, p1_m, hit_m, normal) &
-            bind(C, name="stl_wall_first_hit_segment_with_normal") result(hit)
+                h, p0_m, p1_m, hit_m, normal) &
+                bind(C, name="stl_wall_first_hit_segment_with_normal") result(hit)
             import :: c_ptr, c_double, c_int
             type(c_ptr), value, intent(in) :: h
             real(c_double), intent(in) :: p0_m(3)
@@ -116,9 +116,9 @@ contains
             error stop "stl_wall_first_hit_segment: wall not initialized"
         end if
         hit_i = stl_wall_first_hit_segment_c(wall%handle, &
-                                             real(p0_m, c_double), &
-                                             real(p1_m, c_double), &
-                                             hit_m)
+            real(p0_m, c_double), &
+            real(p1_m, c_double), &
+            hit_m)
         hit = (hit_i /= 0)
 #else
         hit = .false.
@@ -128,7 +128,7 @@ contains
     end subroutine stl_wall_first_hit_segment
 
     subroutine stl_wall_first_hit_segment_with_normal(wall, p0_m, p1_m, hit, hit_m, &
-                                                      normal)
+            normal)
         type(stl_wall_t), intent(in) :: wall
         real(dp), intent(in) :: p0_m(3)
         real(dp), intent(in) :: p1_m(3)
@@ -143,9 +143,9 @@ contains
             error stop "stl_wall_first_hit_segment_with_normal: wall not initialized"
         end if
         hit_i = stl_wall_first_hit_segment_with_normal_c(wall%handle, &
-                                                         real(p0_m, c_double), &
-                                                         real(p1_m, c_double), &
-                                                         hit_m, normal)
+            real(p0_m, c_double), &
+            real(p1_m, c_double), &
+            hit_m, normal)
         hit = (hit_i /= 0)
 #else
         hit = .false.

--- a/test/test_data/simple.multiple_fieldline.in
+++ b/test/test_data/simple.multiple_fieldline.in
@@ -35,8 +35,7 @@ vmec_B_scale = 1.0d0     ! factor to scale the B field from VMEC
 vmec_RZ_scale = 1.0d0    ! factor to scale the device size from VMEC
 swcoll = .False.         ! if .True. enables collisions. This is incompatible with classification.
 deterministic = .False.  ! if .True. put seed for the same random walk
-old_axis_healing = .True.  ! How to heal VMEC axis. Leave .True. until new version is fully tested.
-old_axis_healing_boundary = .True.  ! How to heal VMEC axis. Leave .True. until new version is fully tested.
+axis_healing = 'legacy'   ! 'legacy' | 'powerlaw' | 'polyfit' (recommended, future default); legacy boundary via axis_healing_boundary = 'fixed' | 'adaptive'
 batch_size = 1000 ! Use only a portion of all particles. Ignored if larger than ntestpart.
 ran_seed = 12345   ! Random seed to get batch_size amounts of random indices from ntestpart.
 reuse_batch = .False. ! Reuse batch from last run. Previous indices are stored in batch.dat, new batch generated if batch.dat not found.

--- a/test/test_data/simple.multiple_fieldline.in
+++ b/test/test_data/simple.multiple_fieldline.in
@@ -35,7 +35,8 @@ vmec_B_scale = 1.0d0     ! factor to scale the B field from VMEC
 vmec_RZ_scale = 1.0d0    ! factor to scale the device size from VMEC
 swcoll = .False.         ! if .True. enables collisions. This is incompatible with classification.
 deterministic = .False.  ! if .True. put seed for the same random walk
-axis_healing = 'legacy'   ! 'legacy' | 'powerlaw' | 'polyfit' (recommended, future default); legacy boundary via axis_healing_boundary = 'fixed' | 'adaptive'
+axis_healing = 'legacy'   ! 'legacy' | 'legacy_adaptive' | 'powerlaw' | 'polyfit' (recommended, future default)
+s_axis_heal = 1.0d-2      ! anchor flux for powerlaw/polyfit
 batch_size = 1000 ! Use only a portion of all particles. Ignored if larger than ntestpart.
 ran_seed = 12345   ! Random seed to get batch_size amounts of random indices from ntestpart.
 reuse_batch = .False. ! Reuse batch from last run. Previous indices are stored in batch.dat, new batch generated if batch.dat not found.

--- a/test/test_data/simple.single_fieldline.in
+++ b/test/test_data/simple.single_fieldline.in
@@ -35,8 +35,7 @@ vmec_B_scale = 1.0d0     ! factor to scale the B field from VMEC
 vmec_RZ_scale = 1.0d0    ! factor to scale the device size from VMEC
 swcoll = .False.         ! if .True. enables collisions. This is incompatible with classification.
 deterministic = .False.  ! if .True. put seed for the same random walk
-old_axis_healing = .True.  ! How to heal VMEC axis. Leave .True. until new version is fully tested.
-old_axis_healing_boundary = .True.  ! How to heal VMEC axis. Leave .True. until new version is fully tested.
+axis_healing = 'legacy'   ! 'legacy' | 'powerlaw' | 'polyfit' (recommended, future default); legacy boundary via axis_healing_boundary = 'fixed' | 'adaptive'
 batch_size = 1000 ! Use only a portion of all particles. Ignored if larger than ntestpart.
 ran_seed = 12345   ! Random seed to get batch_size amounts of random indices from ntestpart.
 reuse_batch = .False. ! Reuse batch from last run. Previous indices are stored in batch.dat, new batch generated if batch.dat not found.

--- a/test/test_data/simple.single_fieldline.in
+++ b/test/test_data/simple.single_fieldline.in
@@ -35,7 +35,8 @@ vmec_B_scale = 1.0d0     ! factor to scale the B field from VMEC
 vmec_RZ_scale = 1.0d0    ! factor to scale the device size from VMEC
 swcoll = .False.         ! if .True. enables collisions. This is incompatible with classification.
 deterministic = .False.  ! if .True. put seed for the same random walk
-axis_healing = 'legacy'   ! 'legacy' | 'powerlaw' | 'polyfit' (recommended, future default); legacy boundary via axis_healing_boundary = 'fixed' | 'adaptive'
+axis_healing = 'legacy'   ! 'legacy' | 'legacy_adaptive' | 'powerlaw' | 'polyfit' (recommended, future default)
+s_axis_heal = 1.0d-2      ! anchor flux for powerlaw/polyfit
 batch_size = 1000 ! Use only a portion of all particles. Ignored if larger than ntestpart.
 ran_seed = 12345   ! Random seed to get batch_size amounts of random indices from ntestpart.
 reuse_batch = .False. ! Reuse batch from last run. Previous indices are stored in batch.dat, new batch generated if batch.dat not found.

--- a/test/test_data/simple.volume.in
+++ b/test/test_data/simple.volume.in
@@ -35,8 +35,7 @@ vmec_B_scale = 1.0d0     ! factor to scale the B field from VMEC
 vmec_RZ_scale = 1.0d0    ! factor to scale the device size from VMEC
 swcoll = .False.         ! if .True. enables collisions. This is incompatible with classification.
 deterministic = .False.  ! if .True. put seed for the same random walk
-old_axis_healing = .True.  ! How to heal VMEC axis. Leave .True. until new version is fully tested.
-old_axis_healing_boundary = .True.  ! How to heal VMEC axis. Leave .True. until new version is fully tested.
+axis_healing = 'legacy'   ! 'legacy' | 'powerlaw' | 'polyfit' (recommended, future default); legacy boundary via axis_healing_boundary = 'fixed' | 'adaptive'
 batch_size = 1000 ! Use only a portion of all particles. Ignored if larger than ntestpart.
 ran_seed = 12345   ! Random seed to get batch_size amounts of random indices from ntestpart.
 reuse_batch = .False. ! Reuse batch from last run. Previous indices are stored in batch.dat, new batch generated if batch.dat not found.

--- a/test/test_data/simple.volume.in
+++ b/test/test_data/simple.volume.in
@@ -35,7 +35,8 @@ vmec_B_scale = 1.0d0     ! factor to scale the B field from VMEC
 vmec_RZ_scale = 1.0d0    ! factor to scale the device size from VMEC
 swcoll = .False.         ! if .True. enables collisions. This is incompatible with classification.
 deterministic = .False.  ! if .True. put seed for the same random walk
-axis_healing = 'legacy'   ! 'legacy' | 'powerlaw' | 'polyfit' (recommended, future default); legacy boundary via axis_healing_boundary = 'fixed' | 'adaptive'
+axis_healing = 'legacy'   ! 'legacy' | 'legacy_adaptive' | 'powerlaw' | 'polyfit' (recommended, future default)
+s_axis_heal = 1.0d-2      ! anchor flux for powerlaw/polyfit
 batch_size = 1000 ! Use only a portion of all particles. Ignored if larger than ntestpart.
 ran_seed = 12345   ! Random seed to get batch_size amounts of random indices from ntestpart.
 reuse_batch = .False. ! Reuse batch from last run. Previous indices are stored in batch.dat, new batch generated if batch.dat not found.


### PR DESCRIPTION
## Problem

Near-axis VMEC harmonic healing was exposed through separate boolean switches and a separate legacy boundary selector. That made `simple.in` hard to read and kept the public API tied to implementation details.

## Change

Expose one selector in the `&config` namelist:

```fortran
axis_healing = 'legacy'
axis_healing = 'legacy_adaptive'
axis_healing = 'powerlaw'
axis_healing = 'polyfit'
```

`legacy` is the historical fixed-boundary behavior. `legacy_adaptive` keeps the old adaptive boundary as an explicit diagnostic mode. `powerlaw` and `polyfit` use the public flux anchor:

```fortran
s_axis_heal = 1.0d-2
```

`rho_axis_heal` remains accepted for one compatibility window and is converted in libneo to `s_axis_heal = rho_axis_heal**2` with a warning. The old boolean switches remain accepted with warnings.

This PR also updates the shipped input files and documentation. Formatting changes are from `fo fmt`, which is now part of the full gate after the fo source filtering fix.

Depends on itpplasma/libneo#320.

## Verification

### Test fails before tooling fix

Before updating fo, the SIMPLE gate scanned generated build/dependency trees:

```text
LIBNEO_BRANCH=feat/near-axis-field-investigation fo check
fo: too many source files, max 2048
Build: OK (469 modules, 0 cached, 469 changed, 469 affected) Tests: pass (2.5s)
```

### Test passes after fix

With lazy-fortran/fo@502ba14 installed:

```text
LIBNEO_BRANCH=feat/near-axis-field-investigation fo
Static: OK (8 modules, 8 changed, 8 affected)
Build: OK
Tests: skipped, no affected tests
Lint: OK
All stages passed (1.8s)
```

Prose check:

```text
$HOME/code/prompts/scripts/check-writing-slop.py DOC/coordinates-and-fields.md simple.in examples/simple_full.in examples/orbit_output_test/simple.in test/test_data/simple.multiple_fieldline.in test/test_data/simple.single_fieldline.in test/test_data/simple.volume.in
PASS: no writing-slop candidates at threshold medium
```
