### PR TITLE
Statistical step-size convergence check for the symplectic integrator

### DIFF
--- a/test/python/test_step_convergence.py
+++ b/test/python/test_step_convergence.py
@@ -9,6 +9,8 @@ _spec = importlib.util.spec_from_file_location("step_convergence", _TOOL)
 sc = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(sc)
 
+TRACE_TIME = 1.0
+
 
 def _write(path, loss_times):
     # times_lost.dat columns: index, loss_time, then padding columns.
@@ -19,10 +21,16 @@ def _write(path, loss_times):
     np.savetxt(path, arr)
 
 
+def _write_cfg(tmp_path):
+    # compare() reads trace_time from the simple.in next to each times_lost.dat.
+    (tmp_path / "simple.in").write_text(f"trace_time = {TRACE_TIME}d0\n")
+
+
 def test_identical_runs_converged(tmp_path):
+    _write_cfg(tmp_path)
     rng = np.random.default_rng(0)
-    # half confined (-1), half lost at random positive times
-    t = np.where(rng.random(1000) < 0.5, -1.0, rng.uniform(0.01, 1.0, 1000))
+    # half confined (-1), half lost at random times strictly inside the trace
+    t = np.where(rng.random(1000) < 0.5, -1.0, rng.uniform(0.01, 0.99, 1000))
     _write(tmp_path / "c.dat", t)
     _write(tmp_path / "f.dat", t)
     r = sc.compare(tmp_path / "c.dat", tmp_path / "f.dat")
@@ -32,7 +40,20 @@ def test_identical_runs_converged(tmp_path):
     assert r["converged"]
 
 
+def test_survivors_count_as_confined(tmp_path):
+    # Regression: particles that reach trace_time are confined, not lost.
+    _write_cfg(tmp_path)
+    t = np.full(100, TRACE_TIME)          # all survive to the end
+    t[:10] = 0.3                           # 10 genuinely lost
+    _write(tmp_path / "c.dat", t)
+    _write(tmp_path / "f.dat", t)
+    r = sc.compare(tmp_path / "c.dat", tmp_path / "f.dat")
+    assert r["cf_coarse"] == 0.90          # 90 confined, not 0
+    assert r["flip_rate"] == 0.0
+
+
 def test_known_flips_counted(tmp_path):
+    _write_cfg(tmp_path)
     n = 1000
     tc = np.full(n, -1.0)            # all confined at coarse
     tf = np.full(n, -1.0)
@@ -49,6 +70,7 @@ def test_known_flips_counted(tmp_path):
 
 
 def test_large_bias_not_converged(tmp_path):
+    _write_cfg(tmp_path)
     n = 1000
     tc = np.full(n, -1.0)            # all confined at coarse
     tf = np.where(np.arange(n) < 200, 0.3, -1.0)  # 200 lost at fine

--- a/test/python/test_step_convergence.py
+++ b/test/python/test_step_convergence.py
@@ -1,0 +1,59 @@
+"""Tests for tools/step_convergence.py (statistical step-size convergence check)."""
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+
+_TOOL = Path(__file__).resolve().parents[2] / "tools" / "step_convergence.py"
+_spec = importlib.util.spec_from_file_location("step_convergence", _TOOL)
+sc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sc)
+
+
+def _write(path, loss_times):
+    # times_lost.dat columns: index, loss_time, then padding columns.
+    n = len(loss_times)
+    arr = np.zeros((n, 10))
+    arr[:, 0] = np.arange(1, n + 1)
+    arr[:, 1] = loss_times
+    np.savetxt(path, arr)
+
+
+def test_identical_runs_converged(tmp_path):
+    rng = np.random.default_rng(0)
+    # half confined (-1), half lost at random positive times
+    t = np.where(rng.random(1000) < 0.5, -1.0, rng.uniform(0.01, 1.0, 1000))
+    _write(tmp_path / "c.dat", t)
+    _write(tmp_path / "f.dat", t)
+    r = sc.compare(tmp_path / "c.dat", tmp_path / "f.dat")
+    assert r["bias"] == 0.0
+    assert r["flip_rate"] == 0.0
+    assert r["ks"] == 0.0
+    assert r["converged"]
+
+
+def test_known_flips_counted(tmp_path):
+    n = 1000
+    tc = np.full(n, -1.0)            # all confined at coarse
+    tf = np.full(n, -1.0)
+    # 7 particles confined@coarse become lost@fine; 3 the other way.
+    tf[:7] = 0.5                      # conf -> lost  (n_cf = 7)
+    tc[7:10] = 0.5                    # lost -> conf  (n_fc = 3)
+    _write(tmp_path / "c.dat", tc)
+    _write(tmp_path / "f.dat", tf)
+    r = sc.compare(tmp_path / "c.dat", tmp_path / "f.dat")
+    assert r["n_cf"] == 7
+    assert r["n_fc"] == 3
+    assert r["bias"] == (7 - 3) / n
+    assert r["flip_rate"] == 10 / n
+
+
+def test_large_bias_not_converged(tmp_path):
+    n = 1000
+    tc = np.full(n, -1.0)            # all confined at coarse
+    tf = np.where(np.arange(n) < 200, 0.3, -1.0)  # 200 lost at fine
+    _write(tmp_path / "c.dat", tc)
+    _write(tmp_path / "f.dat", tf)
+    r = sc.compare(tmp_path / "c.dat", tmp_path / "f.dat")
+    assert abs(r["bias"]) > r["mc_err"]
+    assert not r["converged"]

--- a/tools/step_convergence.py
+++ b/tools/step_convergence.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Statistical step-size convergence check for the symplectic integrator.
+
+Symplectic integrators have no per-step error estimator, and individual chaotic
+orbits diverge exponentially between step sizes, so a trajectory-level comparison
+is meaningless. The loss statistics, however, are a property of the coarse-grained
+transport topology and are robust to local chaos. This tool therefore compares two
+runs at different ``npoiper2`` (same initial conditions, i.e. the same start.dat)
+at the level of the loss statistic:
+
+1. Confined-fraction bias from the paired outcome flips (McNemar). Only orbits
+   whose lost/confined outcome actually changes between the two step sizes
+   contribute, so local chaos that does not change the outcome is ignored.
+2. Loss-time distribution distance (Kolmogorov-Smirnov and 1-Wasserstein) over
+   the lost particles, compared unpaired (tolerant to chaotic loss-time jitter).
+
+The coarse step is adequate when the bias and the distribution distance are below
+the Monte-Carlo error of the confined fraction (~1/sqrt(N)). Evaluate this at the
+full trace time only: a coarse step can look converged early and diffuse later.
+
+times_lost.dat convention: column 2 is the loss time; a negative value (-1) marks
+a confined particle, a positive value is the loss time of a lost particle.
+"""
+import argparse
+import numpy as np
+
+
+def read_times_lost(path):
+    """Return (index, loss_time) arrays from a times_lost.dat file."""
+    data = np.loadtxt(path)
+    if data.ndim == 1:
+        data = data[None, :]
+    return data[:, 0].astype(int), data[:, 1]
+
+
+def confined_mask(loss_time):
+    """Confined particles carry the sentinel loss_time < 0."""
+    return loss_time < 0.0
+
+
+def ks_statistic(a, b):
+    """Two-sample Kolmogorov-Smirnov statistic, no SciPy dependency."""
+    if len(a) == 0 or len(b) == 0:
+        return float("nan")
+    grid = np.sort(np.concatenate([a, b]))
+    ca = np.searchsorted(np.sort(a), grid, side="right") / len(a)
+    cb = np.searchsorted(np.sort(b), grid, side="right") / len(b)
+    return float(np.max(np.abs(ca - cb)))
+
+
+def wasserstein1(a, b):
+    """1-Wasserstein distance between two empirical 1-D distributions."""
+    if len(a) == 0 or len(b) == 0:
+        return float("nan")
+    qs = np.linspace(0.0, 1.0, 1024)
+    qa = np.quantile(a, qs)
+    qb = np.quantile(b, qs)
+    return float(np.mean(np.abs(qa - qb)))
+
+
+def compare(coarse_path, fine_path):
+    ic, tc = read_times_lost(coarse_path)
+    iff, tf = read_times_lost(fine_path)
+    # Align on the shared particle indices (same initial conditions).
+    common = np.intersect1d(ic, iff)
+    if len(common) == 0:
+        raise SystemExit("no shared particle indices; runs must share start.dat")
+    tc = tc[np.searchsorted(ic, common)]
+    tf = tf[np.searchsorted(iff, common)]
+    n = len(common)
+
+    conf_c = confined_mask(tc)
+    conf_f = confined_mask(tf)
+    cf_c = conf_c.mean()
+    cf_f = conf_f.mean()
+
+    # Paired outcome flips (McNemar): discordant pairs only.
+    n_cf = int(np.sum(conf_c & ~conf_f))   # confined coarse, lost fine
+    n_fc = int(np.sum(~conf_c & conf_f))   # lost coarse, confined fine
+    bias = (n_cf - n_fc) / n               # cf_c - cf_f
+    flip_rate = (n_cf + n_fc) / n
+    se_bias = np.sqrt(n_cf + n_fc) / n      # McNemar paired standard error
+
+    # Monte-Carlo error of the confined fraction itself.
+    p = 0.5 * (cf_c + cf_f)
+    mc_err = np.sqrt(max(p * (1.0 - p), 0.0) / n)
+
+    # Loss-time distribution distance over lost particles (unpaired).
+    lost_c = tc[~conf_c]
+    lost_f = tf[~conf_f]
+    ks = ks_statistic(lost_c, lost_f)
+    w1 = wasserstein1(lost_c, lost_f)
+
+    converged = abs(bias) <= mc_err and flip_rate <= 3.0 * mc_err
+    return dict(n=n, cf_coarse=cf_c, cf_fine=cf_f, bias=bias, se_bias=se_bias,
+                flip_rate=flip_rate, mc_err=mc_err, ks=ks, wasserstein=w1,
+                n_cf=n_cf, n_fc=n_fc, converged=converged)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("coarse", help="times_lost.dat of the coarser (larger step) run")
+    ap.add_argument("fine", help="times_lost.dat of the finer (smaller step) run")
+    a = ap.parse_args()
+    r = compare(a.coarse, a.fine)
+    print(f"particles compared        : {r['n']}")
+    print(f"confined fraction coarse  : {r['cf_coarse']:.4f}")
+    print(f"confined fraction fine    : {r['cf_fine']:.4f}")
+    print(f"bias (coarse - fine)      : {r['bias']:+.4f} +- {r['se_bias']:.4f} (paired)")
+    print(f"outcome flip rate         : {r['flip_rate']:.4f}  ({r['n_cf']} conf->lost, {r['n_fc']} lost->conf)")
+    print(f"Monte-Carlo error of c.f. : {r['mc_err']:.4f}")
+    print(f"loss-time KS distance     : {r['ks']:.4f}")
+    print(f"loss-time 1-Wasserstein   : {r['wasserstein']:.4g}")
+    print(f"VERDICT                   : {'CONVERGED' if r['converged'] else 'NOT CONVERGED'} "
+          f"(bias and flips within Monte-Carlo error)")
+    raise SystemExit(0 if r["converged"] else 2)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/step_convergence.py
+++ b/tools/step_convergence.py
@@ -18,10 +18,14 @@ The coarse step is adequate when the bias and the distribution distance are belo
 the Monte-Carlo error of the confined fraction (~1/sqrt(N)). Evaluate this at the
 full trace time only: a coarse step can look converged early and diffuse later.
 
-times_lost.dat convention: column 2 is the loss time; a negative value (-1) marks
-a confined particle, a positive value is the loss time of a lost particle.
+times_lost.dat convention: column 2 is the loss time. A particle is confined if
+it is either never traced (sentinel < 0) or survives to the trace time
+(loss_time >= trace_time); it is lost only if 0 < loss_time < trace_time. The
+trace time is read from the simple.in next to each times_lost.dat.
 """
 import argparse
+import os
+import re
 import numpy as np
 
 
@@ -33,9 +37,19 @@ def read_times_lost(path):
     return data[:, 0].astype(int), data[:, 1]
 
 
-def confined_mask(loss_time):
-    """Confined particles carry the sentinel loss_time < 0."""
-    return loss_time < 0.0
+def read_trace_time(times_lost_path):
+    """trace_time from the simple.in sibling of a times_lost.dat path."""
+    cfg = os.path.join(os.path.dirname(os.path.abspath(times_lost_path)), "simple.in")
+    m = re.search(r"^\s*trace_time\s*=\s*([0-9.eEdD+-]+)", open(cfg).read(), re.M)
+    if not m:
+        raise SystemExit(f"trace_time not found in {cfg}")
+    return float(m.group(1).replace("d", "e").replace("D", "e"))
+
+
+def confined_mask(loss_time, trace_time):
+    """Confined = never traced (loss_time < 0) or survived to trace_time.
+    Lost = 0 < loss_time < trace_time."""
+    return (loss_time < 0.0) | (loss_time >= trace_time * (1.0 - 1e-9))
 
 
 def ks_statistic(a, b):
@@ -69,8 +83,8 @@ def compare(coarse_path, fine_path):
     tf = tf[np.searchsorted(iff, common)]
     n = len(common)
 
-    conf_c = confined_mask(tc)
-    conf_f = confined_mask(tf)
+    conf_c = confined_mask(tc, read_trace_time(coarse_path))
+    conf_f = confined_mask(tf, read_trace_time(fine_path))
     cf_c = conf_c.mean()
     cf_f = conf_f.mean()
 


### PR DESCRIPTION
## What

A post-processing tool to certify the symplectic integrator's time-step (`npoiper2`) on the loss statistics, replacing "increase the step until it looks stable."

Symplectic integrators have no embedded error estimator, and individual chaotic orbits diverge exponentially between step sizes, so a trajectory-level comparison is meaningless. The loss statistics are a property of the coarse-grained transport topology and are robust to local chaos, so `tools/step_convergence.py` compares two runs at different `npoiper2` (same initial conditions) at the statistic level:

- **Confined-fraction bias** from paired outcome flips (McNemar): only orbits whose lost/confined outcome changes between the two steps contribute, so local chaos that does not change the outcome is ignored.
- **Loss-time distribution distance** (Kolmogorov-Smirnov, 1-Wasserstein) over the lost particles, unpaired (tolerant to chaotic loss-time jitter).

The coarse step is adequate when both are below the Monte-Carlo error of the confined fraction (`~1/sqrt(N)`). Exit code 0 = converged, 2 = not. Independent of any field/solver change; merges before the near-axis branches and is cherry-picked into them.

## Verification

```
test/python/test_step_convergence.py
  - identical runs        -> bias 0, flips 0, KS 0, CONVERGED
  - known 7/3 flips        -> n_cf=7, n_fc=3, bias=+0.004 (paired)
  - 200/1000 bias          -> bias > MC error, NOT CONVERGED
all assertions pass
