### PR TITLE
Correct integmode mode list in configs and docs

### DIFF
--- a/examples/simple_full.in
+++ b/examples/simple_full.in
@@ -32,7 +32,7 @@ startmode = 1            !  mode for initial conditions:
 !                         5=distribute in volume ("global")
 grid_density = 0d0       ! for startmode 1 only, between 0.0 to 0.99, when 0.0 then no grid is made.
 special_ants_file = .False. ! if .True., a different start file is read (defined in samplers.f90), .False. uses standard filename (defined in samplers.f90)
-integmode = 1            ! mode for integrator: -1 = RK VMEC, 0 = RK, 1 = Euler1, 2 = Euler2, 3 = Verlet
+integmode = 1            ! mode for integrator: -1 = RK VMEC, 0 = RK, 1 = Euler1, 2 = Euler2, 3 = Midpoint, 4-7 = Gauss1-4, 15 = Lobatto3
 relerr = 1d-13           ! tolerance for integrator. Set to 1d-13 for symplectic.
 tcut = -1d0              ! time when to do cut for classification, usually 1d-1, or -1 if no cuts desired
 debug = .False.          ! produce debugging output (.True./.False.). Use only in non-parallel mode!

--- a/src/simple.f90
+++ b/src/simple.f90
@@ -26,7 +26,7 @@ public
     real(dp) :: dtau, dtaumin, v0
     integer          :: n_e, n_d
 
-    integer :: integmode = 0 ! 0 = RK, 1 = Euler1, 2 = Euler2, 3 = Verlet
+    integer :: integmode = 0 ! 0 = RK, 1 = Euler1, 2 = Euler2, 3 = Midpoint, 4-7 = Gauss1-4, 15 = Lobatto3
     real(dp) :: relerr
 
     type(field_can_t) :: f

--- a/test/test_data/simple.multiple_fieldline.in
+++ b/test/test_data/simple.multiple_fieldline.in
@@ -24,7 +24,7 @@ ns_tp = 5                ! spline order for 3D quantities over theta and phi
 multharm = 5             ! angular grid factor (n_grid=multharm*n_harm_max where n_harm_max - maximum Fourier index
 isw_field_type = 0       ! -1: Testing, 0: Canonical, 1: VMEC, 2: Boozer
 startmode = 1            ! mode for initial conditions: 0=generate and store, 1=generate, store, and run, 2=read and run, 3=read ANTS and run, 4=read and run a batch
-integmode = 1            ! mode for integrator: -1 = RK VMEC, 0 = RK, 1 = Euler1, 2 = Euler2, 3 = Verlet
+integmode = 1            ! mode for integrator: -1 = RK VMEC, 0 = RK, 1 = Euler1, 2 = Euler2, 3 = Midpoint, 4-7 = Gauss1-4, 15 = Lobatto3
 relerr = 1d-13           ! tolerance for integrator. Set to 1d-13 for symplectic.
 tcut = -1d0              ! time when to do cut for classification, usually 1d-1, or -1 if no cuts desired
 debug = .False.          ! produce debugging output (.True./.False.). Use only in non-parallel mode!

--- a/test/test_data/simple.single_fieldline.in
+++ b/test/test_data/simple.single_fieldline.in
@@ -24,7 +24,7 @@ ns_tp = 5                ! spline order for 3D quantities over theta and phi
 multharm = 5             ! angular grid factor (n_grid=multharm*n_harm_max where n_harm_max - maximum Fourier index
 isw_field_type = 0       ! -1: Testing, 0: Canonical, 1: VMEC, 2: Boozer
 startmode = 1            ! mode for initial conditions: 0=generate and store, 1=generate, store, and run, 2=read and run, 3=read ANTS and run, 4=read and run a batch
-integmode = 1            ! mode for integrator: -1 = RK VMEC, 0 = RK, 1 = Euler1, 2 = Euler2, 3 = Verlet
+integmode = 1            ! mode for integrator: -1 = RK VMEC, 0 = RK, 1 = Euler1, 2 = Euler2, 3 = Midpoint, 4-7 = Gauss1-4, 15 = Lobatto3
 relerr = 1d-13           ! tolerance for integrator. Set to 1d-13 for symplectic.
 tcut = -1d0              ! time when to do cut for classification, usually 1d-1, or -1 if no cuts desired
 debug = .False.          ! produce debugging output (.True./.False.). Use only in non-parallel mode!

--- a/test/test_data/simple.volume.in
+++ b/test/test_data/simple.volume.in
@@ -24,7 +24,7 @@ ns_tp = 5                ! spline order for 3D quantities over theta and phi
 multharm = 5             ! angular grid factor (n_grid=multharm*n_harm_max where n_harm_max - maximum Fourier index
 isw_field_type = 0       ! -1: Testing, 0: Canonical, 1: VMEC, 2: Boozer
 startmode = 1            ! mode for initial conditions: 0=generate and store, 1=generate, store, and run, 2=read and run, 3=read ANTS and run, 4=read and run a batch
-integmode = 1            ! mode for integrator: -1 = RK VMEC, 0 = RK, 1 = Euler1, 2 = Euler2, 3 = Verlet
+integmode = 1            ! mode for integrator: -1 = RK VMEC, 0 = RK, 1 = Euler1, 2 = Euler2, 3 = Midpoint, 4-7 = Gauss1-4, 15 = Lobatto3
 relerr = 1d-13           ! tolerance for integrator. Set to 1d-13 for symplectic.
 tcut = -1d0              ! time when to do cut for classification, usually 1d-1, or -1 if no cuts desired
 debug = .False.          ! produce debugging output (.True./.False.). Use only in non-parallel mode!

--- a/test/tests/test_coord_trans.f90
+++ b/test/tests/test_coord_trans.f90
@@ -31,7 +31,7 @@ program test_coord_trans
   integer          :: startmode
 
   integer :: ntau ! number of dtaumin in dtau
-  integer :: integmode = 0 ! 0 = RK, 1 = Euler1, 2 = Euler2, 3 = Verlet
+  integer :: integmode = 0 ! 0 = RK, 1 = Euler1, 2 = Euler2, 3 = Midpoint, 4-7 = Gauss1-4, 15 = Lobatto3
 
 
   double precision :: relerr
@@ -94,7 +94,7 @@ subroutine read_config
   read (1,*) ns_tp             !spline order for 3D quantities over theta and phi
   read (1,*) multharm          !angular grid factor (n_grid=multharm*n_harm_max where n_harm_max - maximum Fourier index)
   read (1,*) startmode         !mode for initial conditions: 0=generate and store, 1=generate, store, and run, 2=read and run, 3=read ANTS and run
-  read (1,*) integmode         !mode for integrator: -1 = RK VMEC, 0 = RK CAN, 1 = Euler1, 2 = Euler2, 3 = Verlet
+  read (1,*) integmode         !mode for integrator: -1 = RK VMEC, 0 = RK CAN, 1 = Euler1, 2 = Euler2, 3 = Midpoint, 4-7 = Gauss1-4, 15 = Lobatto3
   read (1,*) relerr            !relative error for RK integrator
   read (1,*) tcut              !time when to do cut for classification, usually 1d-1, or -1 if no cuts desired
   read (1,*) debug             !produce debugging output (.True./.False.). Use only in non-parallel mode!


### PR DESCRIPTION
integmode=3 is MIDPOINT, not Verlet (orbit_symplectic_base.f90), and the list omitted Gauss1-4 (4-7) and Lobatto3 (15). Corrects the comment in the example configs, test inputs, and the integmode declarations.

Comment-only; the compiled program and namelist parsing are unaffected.

## Verification
Changes are confined to `! ...` comments in namelist inputs and Fortran declaration comments. No code, no behavior change.