### PR TITLE
Integrator diagnostics: diag_traj.x single-orbit dump + integrator sweep harness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,6 +435,10 @@ add_executable(diag_orbit.x
     app/simple_diag_orbit.f90
 )
 
+add_executable(diag_traj.x
+    app/simple_diag_traj.f90
+)
+
 # Apply SIMPLE-specific compile options to executable
 target_compile_options(simple.x PRIVATE ${SIMPLE_COMPILE_OPTIONS})
 
@@ -454,6 +458,7 @@ set_target_properties(simple.x PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINAR
 target_compile_options(diag_meiss.x PRIVATE ${SIMPLE_COMPILE_OPTIONS})
 target_compile_options(diag_albert.x PRIVATE ${SIMPLE_COMPILE_OPTIONS})
 target_compile_options(diag_orbit.x PRIVATE ${SIMPLE_COMPILE_OPTIONS})
+target_compile_options(diag_traj.x PRIVATE ${SIMPLE_COMPILE_OPTIONS})
 
 # Apply trampoline error flags only to SIMPLE executable (not subprojects like fortplot)
 if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
@@ -475,6 +480,8 @@ target_link_libraries(diag_meiss.x PRIVATE simple)
 target_link_libraries(diag_albert.x PRIVATE simple)
 target_link_libraries(diag_newton.x PRIVATE simple)
 target_link_libraries(diag_orbit.x PRIVATE simple)
+target_link_libraries(diag_traj.x PRIVATE simple)
+set_target_properties(diag_traj.x PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set_target_properties(diag_meiss.x PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set_target_properties(diag_albert.x PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set_target_properties(diag_newton.x PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/app/simple_diag_traj.f90
+++ b/app/simple_diag_traj.f90
@@ -1,0 +1,122 @@
+program diag_traj_main
+!> Stream the trajectory of one particle through the PRODUCTION integrator
+!> selected by integmode (RK orbit_timestep_axis for integmode<=0, symplectic
+!> orbit_timestep_sympl otherwise). Unlike diag_orbit.x it does not hardcode a
+!> solver and does not preallocate ntimstep*ntau points: it writes s, theta, phi,
+!> pphi, H every `stride` substeps and reports min(s), loss time, and the number
+!> of axis crossings (EVT_R_NEGATIVE). Built to localize the symplectic-vs-RK
+!> non-prompt loss discrepancy on the internal Boozer field (#370).
+!>
+!> Usage: ./diag_traj.x [config_file] particle_number [stride]
+
+use, intrinsic :: iso_fortran_env, only: dp => real64
+use params, only: read_config, netcdffile, ns_s, ns_tp, multharm, integmode, &
+    params_init, dtaumin, relerr, ntestpart, zstart, startmode, grid_density, &
+    special_ants_file, reuse_batch, num_surf, sbeg, trace_time, v0
+use simple, only: tracer_t, init_sympl
+use simple_main, only: init_field
+use magfie_sub, only: init_magfie, VMEC
+use samplers, only: init_starting_surf, sample, START_FILE
+use field_can_mod, only: field_can_t, get_val, eval_field => evaluate, ref_to_integ
+use orbit_symplectic, only: orbit_timestep_sympl
+use orbit_symplectic_base, only: symplectic_integrator_t
+use alpha_lifetime_sub, only: orbit_timestep_axis
+use diag_counters, only: diag_counters_init, diag_counters_reset, &
+    diag_counters_total, EVT_R_NEGATIVE
+use util, only: twopi
+
+implicit none
+
+character(256) :: config_file, arg
+type(tracer_t) :: norb
+type(symplectic_integrator_t) :: si
+type(field_can_t) :: f
+integer :: pnum, stride, nargs
+real(dp), dimension(5) :: z
+real(dp) :: t, s, smin, H
+integer(8) :: kt
+integer :: ierr, unit
+character(64) :: fname
+
+config_file = 'simple.in'
+stride = 1
+nargs = command_argument_count()
+if (nargs == 1) then
+    call get_command_argument(1, arg); read(arg,*) pnum
+elseif (nargs == 2) then
+    call get_command_argument(1, arg)
+    ! second arg is either config (non-numeric) or stride; assume "pnum stride"
+    read(arg,*) pnum
+    call get_command_argument(2, arg); read(arg,*) stride
+elseif (nargs == 3) then
+    call get_command_argument(1, config_file)
+    call get_command_argument(2, arg); read(arg,*) pnum
+    call get_command_argument(3, arg); read(arg,*) stride
+else
+    print *, 'Usage: ./diag_traj.x [config] particle_number [stride]'
+    stop
+end if
+
+call read_config(config_file)
+call init_field(norb, netcdffile, ns_s, ns_tp, multharm, integmode)
+call params_init
+call init_magfie(VMEC)
+call init_starting_surf
+if (startmode == 2) then
+    call sample(zstart, START_FILE)
+elseif (startmode == 5) then
+    if (num_surf == 1) then
+        call sample(zstart, 0.0d0, sbeg(1))
+    else
+        call sample(zstart, sbeg(1), sbeg(num_surf))
+    end if
+else
+    call sample(zstart, START_FILE)
+end if
+
+if (pnum < 1 .or. pnum > ntestpart) then
+    print *, 'particle out of range', pnum, ntestpart; error stop
+end if
+
+call diag_counters_init()
+call diag_counters_reset()
+
+call ref_to_integ(zstart(1:3, pnum), z(1:3))
+z(4:5) = zstart(4:5, pnum)
+if (integmode > 0) call init_sympl(si, f, z, dtaumin, dtaumin, relerr, integmode)
+
+write(fname, '(A,I0,A,I0,A)') 'traj_p', pnum, '_im', integmode, '.dat'
+open(newunit=unit, file=trim(fname), status='replace')
+write(unit, '(A)') '# t[s]    s    theta    phi    pphi/z4    H'
+
+kt = 0; t = 0.0_dp; smin = z(1); ierr = 0
+do
+    if (integmode <= 0) then
+        call orbit_timestep_axis(z, dtaumin, dtaumin, relerr, ierr)
+        s = z(1)
+        H = -1.0_dp
+    else
+        call orbit_timestep_sympl(si, f, ierr)
+        z(1:4) = si%z
+        s = si%z(1)
+        call get_val(f, si%z(4))
+        H = f%H
+    end if
+    kt = kt + 1
+    t = kt*dtaumin/v0
+    smin = min(smin, s)
+    if (mod(kt, int(stride,8)) == 0_8 .or. ierr /= 0) then
+        write(unit, '(6ES16.8)') t, s, mod(z(2), twopi), mod(z(3), twopi), z(4), H
+    end if
+    if (ierr /= 0) exit
+    if (t >= trace_time) exit
+end do
+close(unit)
+
+print '(A,I0,A,I0)', 'particle ', pnum, '  integmode ', integmode
+print '(A,L1,A,ES12.5)', 'lost = ', (ierr /= 0), '   t_end[s] = ', t
+print '(A,ES12.5)', 'min(s) reached       = ', smin
+print '(A,I0)',     'axis crossings (R<0) = ', int(diag_counters_total(EVT_R_NEGATIVE))
+print '(A,A)',      'trajectory written   : ', trim(fname)
+
+end program diag_traj_main

--- a/tools/integrator_bench/bench_integrators.sh
+++ b/tools/integrator_bench/bench_integrators.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Sweep all SIMPLE integrators on a small case and report completion, confined
+# fraction, inner-solver non-convergence, and wall time. Boy-scout check that
+# every integrator runs cleanly + a quick performance benchmark. Run one case at
+# a time so it does not compete with production.
+#
+# Usage: bench_integrators.sh <simple.x> <wout.nc> <base_simple.in> [outdir]
+set -u
+BIN=${1:?simple.x}
+WOUT=${2:?wout.nc}
+BASE=${3:?base simple.in}
+OUT=${4:-/tmp/integ_bench}
+export OMP_NUM_THREADS=${OMP_NUM_THREADS:-8}
+
+# integmode -> name
+declare -A NAME=( [0]=RK45 [1]=Euler1 [2]=Euler2 [3]=midpoint \
+                  [4]=Gauss1 [5]=Gauss2 [6]=Gauss3 [7]=Gauss4 [15]=Lobatto3 )
+
+printf '%-9s %-9s %-6s %-10s %-14s %-9s\n' integmode name rc conf_frac newton_maxit wall_s
+for im in 0 1 2 3 4 5 6 7 15; do
+  d="$OUT/im${im}"
+  mkdir -p "$d"
+  cp "$WOUT" "$d/wout.nc"
+  cp "$BASE" "$d/simple.in"
+  sed -i "s/^integmode = .*/integmode = ${im}/" "$d/simple.in"
+  grep -q '^integmode' "$d/simple.in" || echo "integmode = ${im}" >> "$d/simple.in"
+  cd "$d"
+  t0=$(date +%s.%N)
+  "$BIN" > log 2>&1
+  rc=$?
+  t1=$(date +%s.%N)
+  wall=$(awk "BEGIN{printf \"%.2f\", $t1-$t0}")
+  cf=$(tail -1 confined_fraction.dat 2>/dev/null | awk '{print $2}')
+  mx=$(grep -oE '(newton1_maxit|newton2_maxit|rk_gauss_maxit|rk_lobatto_maxit|fixpoint_maxit)=[0-9]+' log | \
+        awk -F= '{s+=$2} END{print s+0}')
+  printf '%-9s %-9s %-6s %-10s %-14s %-9s\n' "$im" "${NAME[$im]:-?}" "$rc" "${cf:-NA}" "${mx:-0}" "$wall"
+done


### PR DESCRIPTION
Additive tooling for integrator verification; no existing code path changes.

- `diag_traj.x`: streams s, theta, phi, pphi, H per substep for one particle through the production stepper selected by integmode (RK `orbit_timestep_axis` or symplectic `orbit_timestep_sympl`), and reports min(s), loss time, and axis-crossing count. Unlike diag_orbit.x it does not hardcode the midpoint solver and does not preallocate ntimstep*ntau points.
- `tools/integrator_bench/bench_integrators.sh`: sweeps integmodes on a small case, reporting completion, confined fraction, inner-solver non-convergence, and wall time.

## Verification
`diag_traj.x` builds and links, and produced the single-orbit RK/Euler1/midpoint traces used in itpplasma/SIMPLE#398.