### PR TITLE
Fix RK near-axis pseudo-Cartesian coordinates

### DIFF
--- a/src/sub_alpha_lifetime_can.f90
+++ b/src/sub_alpha_lifetime_can.f90
@@ -351,21 +351,35 @@ if(dodiag) write (123,*) tau2,z
   real(dp), intent(in) :: tau
   real(dp), intent(in) :: z_axis(:)
   real(dp), intent(out) :: vz_axis(:)
+  real(dp), parameter :: s_floor=1.d-8
   real(dp) :: derlogsqs
+  real(dp) :: r2,scale,x_eval,y_eval
   real(dp), dimension(5) :: z,vz
   !
-  !  z(1)=z_axis(1)**2+z_axis(2)**2
-  z(1)=sqrt(z_axis(1)**2+z_axis(2)**2)
-  z(1)=max(z(1),1.d-8)
-  z(2)=atan2(z_axis(2),z_axis(1))
+  r2=z_axis(1)**2+z_axis(2)**2
+  if(r2.lt.s_floor) then
+    if(r2.gt.0.d0) then
+      scale=sqrt(s_floor/r2)
+      x_eval=scale*z_axis(1)
+      y_eval=scale*z_axis(2)
+    else
+      x_eval=sqrt(s_floor)
+      y_eval=0.d0
+    endif
+    z(1)=s_floor
+  else
+    x_eval=z_axis(1)
+    y_eval=z_axis(2)
+    z(1)=r2
+  endif
+  z(2)=atan2(y_eval,x_eval)
   z(3:5)=z_axis(3:5)
   !
   call velo_can(tau,z,vz)
   !
-  !  derlogsqs=0.5d0*vz(1)/sqrt(z(1))
-  derlogsqs=vz(1)/z(1)
-  vz_axis(1)=derlogsqs*z_axis(1)-vz(2)*z_axis(2)
-  vz_axis(2)=derlogsqs*z_axis(2)+vz(2)*z_axis(1)
+  derlogsqs=0.5d0*vz(1)/z(1)
+  vz_axis(1)=derlogsqs*x_eval-vz(2)*y_eval
+  vz_axis(2)=derlogsqs*y_eval+vz(2)*x_eval
   vz_axis(3:5)=vz(3:5)
   !
   end subroutine velo_axis
@@ -410,9 +424,9 @@ if(dodiag) write (123,*) tau2,z
   !
       do while((dtau>0 .and. (tau2 .lt. dtau)) .or. (dtau<0 .and. (tau2 .gt. dtau)))
         if(near_axis) then
-          if(z(1)**2+z(2)**2.gt.snear_axis**2) then
+          if(z(1)**2+z(2)**2.gt.snear_axis) then
             near_axis=.false.
-            z1=sqrt(z(1)**2+z(2)**2)
+            z1=z(1)**2+z(2)**2
             z2=atan2(z(2),z(1))
             z(1)=z1
             z(2)=z2
@@ -434,8 +448,8 @@ if(dodiag) write (123,*) tau2,z
         else
           if(z(1).lt.snear_axis) then
             near_axis=.true.
-            z1=z(1)*cos(z(2))
-            z2=z(1)*sin(z(2))
+            z1=sqrt(max(z(1),0.d0))*cos(z(2))
+            z2=sqrt(max(z(1),0.d0))*sin(z(2))
             z(1)=z1
             z(2)=z2
   !
@@ -462,9 +476,9 @@ if(dodiag) write (123,*) tau2,z
       tau2=dtau
   !
       if(near_axis) then
-        if(z(1)**2+z(2)**2.gt.snear_axis**2) then
+        if(z(1)**2+z(2)**2.gt.snear_axis) then
           near_axis=.false.
-          z1=sqrt(z(1)**2+z(2)**2)
+          z1=z(1)**2+z(2)**2
           z2=atan2(z(2),z(1))
           z(1)=z1
           z(2)=z2
@@ -486,8 +500,8 @@ if(dodiag) write (123,*) tau2,z
       else
         if(z(1).lt.snear_axis) then
           near_axis=.true.
-          z1=z(1)*cos(z(2))
-          z2=z(1)*sin(z(2))
+          z1=sqrt(max(z(1),0.d0))*cos(z(2))
+          z2=sqrt(max(z(1),0.d0))*sin(z(2))
           z(1)=z1
           z(2)=z2
   !
@@ -509,7 +523,7 @@ if(dodiag) write (123,*) tau2,z
       endif
   !
       if(near_axis) then
-        z1=sqrt(z(1)**2+z(2)**2)
+        z1=z(1)**2+z(2)**2
         z2=atan2(z(2),z(1))
         z(1)=z1
         z(2)=z2


### PR DESCRIPTION
## Summary

Fix the RK near-axis pseudo-Cartesian transform used by `orbit_timestep_axis`.

The old path entered the near-axis chart as `(s cos theta, s sin theta)` but treated it as `(sqrt(s) cos theta, sqrt(s) sin theta)` when evaluating velocity and returning to flux coordinates. That made the axis an artificial sink for some mirror-trapped particles.

This PR makes the chart consistent:

- enter with `(sqrt(s) cos theta, sqrt(s) sin theta)`
- recover `s = x^2 + y^2`
- use the matching `0.5` chain-rule factor in `velo_axis`
- keep the floor only for field evaluation, not as the physical radial mapping

This is the RK-only extraction from PR #401. The symplectic near-axis experiment stays stacked there.

## Verification

`fo check`

```text
{"ok":true,"stage":"done","target":"","summary":"build and tests passed","hint":"","rerun":"","log_path":"","elapsed_s":2.401,"modules":469,"cached":0,"changed":469}
```
