### PR TITLE
Add Boris full-orbit pusher with mocked field/metric providers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,10 @@
     orbit_symplectic_quasi.f90
     orbit_symplectic_euler1.f90
     orbit_symplectic.f90
+    orbit_full_provider.f90
+    orbit_full_mock_cart.f90
+    orbit_full_mock_cyl.f90
+    orbit_full.f90
     util.F90
     samplers.f90
     cut_detector.f90

--- a/src/orbit_full.f90
+++ b/src/orbit_full.f90
@@ -1,0 +1,356 @@
+module orbit_full
+  ! Full-orbit (gyro-resolved Lorentz) pushers for SIMPLE, alongside the
+  ! existing symplectic guiding-center tracer. CGS Gaussian units throughout
+  ! (see src/util.F90): the Lorentz force carries the explicit 1/c,
+  !   m dv/dt = (q/c) v x B.
+  !
+  ! ORBIT_BORIS is the explicit gyro-resolved pusher (this module).
+  ! ORBIT_PAULI is the variational CPP scheme; the seam (state slots, provider
+  ! canonical-field method, non-fatal convergence error) is in place but the
+  ! step is not implemented here yet.
+  use, intrinsic :: iso_fortran_env, only: dp => real64
+  use orbit_full_provider, only: field_metric_provider_t, &
+      FO_OK, FO_ERR_FIELD, FO_ERR_NO_CONVERGE, FO_ERR_OUT_OF_DOMAIN
+  use orbit_full_mock_cart, only: cartesian_provider_t
+  use neo_biotsavart, only: coils_t
+  use util, only: c, p_mass, e_charge, twopi
+  implicit none
+  private
+
+  ! orbit models (0 reserved for the existing symplectic guiding-center path)
+  integer, parameter, public :: ORBIT_GC    = 0
+  integer, parameter, public :: ORBIT_PAULI = 1   ! CPP variational, big dt, implicit
+  integer, parameter, public :: ORBIT_BORIS = 2   ! gyro-resolved Lorentz, explicit
+
+  ! coordinate kinds (3..5 reserved for the libneo PR: VMEC, Boozer, chartmap)
+  integer, parameter, public :: COORD_CART = 1
+  integer, parameter, public :: COORD_CYL  = 2
+
+  ! error codes re-exported from the provider module
+  public :: FO_OK, FO_ERR_FIELD, FO_ERR_NO_CONVERGE, FO_ERR_OUT_OF_DOMAIN
+
+  ! Name kept as FullOrbitState (no _t) for API compatibility with
+  ! test_full_orbit.f90.
+  type, public :: FullOrbitState
+    integer  :: orbit_model = ORBIT_BORIS
+    integer  :: ncoord      = COORD_CART
+    ! Boris/Cartesian:   z = (x1,x2,x3, v1,v2,v3) physical position and velocity.
+    ! Boris/curvilinear: z = (u1,u2,u3, v1,v2,v3) with v contravariant.
+    ! Pauli (CPP):       z = (u1,u2,u3, vpar,0,0); z(1:4) carry state.
+    real(dp) :: z(6)   = 0.0_dp
+    real(dp) :: mu     = 0.0_dp   ! m*vperp^2/(2 B), adiabatic invariant
+    real(dp) :: dt     = 0.0_dp
+    real(dp) :: qm     = 0.0_dp   ! charge/mass (esu/g)
+    real(dp) :: mass   = 0.0_dp   ! particle mass (g)
+    real(dp) :: charge = 0.0_dp   ! particle charge (esu)
+    class(field_metric_provider_t), pointer :: prov => null()
+  end type FullOrbitState
+
+  public :: init_full_orbit_state, timestep_full_orbit, &
+            convert_full_to_gc, compute_energy
+
+  interface init_full_orbit_state
+    module procedure init_full_orbit_state_prov
+    module procedure init_full_orbit_state_coils
+  end interface init_full_orbit_state
+
+contains
+
+  subroutine init_full_orbit_state_prov(state, x0, v0, orbit_model, ncoord, &
+                                        mass, charge, dt, prov)
+    type(FullOrbitState), intent(out) :: state
+    real(dp), intent(in) :: x0(3), v0(3)
+    integer,  intent(in) :: orbit_model, ncoord
+    real(dp), intent(in) :: mass, charge, dt
+    class(field_metric_provider_t), intent(in), target :: prov
+
+    state%orbit_model = orbit_model
+    state%ncoord      = ncoord
+    state%mass        = mass
+    state%charge      = charge
+    state%qm          = charge / mass
+    state%dt          = dt
+    state%prov        => prov
+    state%z(1:3)      = x0
+    state%z(4:6)      = v0
+    call set_mu_from_state(state)
+  end subroutine init_full_orbit_state_prov
+
+  ! Convenience init matching test_full_orbit.f90: flux-like IC (s,theta,phi)
+  ! plus a coil set. Builds a Cartesian Biot-Savart provider, places the
+  ! particle on a circle of radius proportional to s, and sets the velocity
+  ! from pitch lambda=vpar/v with speed v. mass/charge are atomic units here
+  ! (e.g. 4.0 amu, 2.0 e) and converted to CGS internally.
+  subroutine init_full_orbit_state_coils(state, s, theta, phi, lambda, v, &
+                                         orbit_model, mass_amu, charge_e, dt, coils)
+    type(FullOrbitState), intent(out) :: state
+    real(dp), intent(in) :: s, theta, phi, lambda, v
+    integer,  intent(in) :: orbit_model
+    real(dp), intent(in) :: mass_amu, charge_e, dt
+    type(coils_t), intent(in), target :: coils
+    type(cartesian_provider_t), allocatable, save :: cart_prov
+    real(dp) :: mass_cgs, charge_cgs, vpar, vperp, R, x0(3), v0(3)
+    real(dp), parameter :: R_AXIS = 1200.0_dp  ! cm, reactor-scale placeholder
+
+    if (allocated(cart_prov)) deallocate(cart_prov)
+    allocate(cart_prov)
+    cart_prov%field_kind = 3                     ! FIELD_COILS
+    cart_prov%coils => coils
+
+    mass_cgs   = mass_amu * p_mass
+    charge_cgs = charge_e * e_charge
+
+    R = R_AXIS * (1.0_dp + 0.1_dp * (s - 0.5_dp))
+    x0 = [R * cos(phi), R * sin(phi), 0.0_dp]
+    vpar  = lambda * v
+    vperp = sqrt(max(v*v - vpar*vpar, 0.0_dp))
+    ! Velocity: vpar along toroidal e_phi, vperp along e_R for a generic start.
+    v0 = [ vperp * cos(phi) - vpar * sin(phi) * sin(theta), &
+           vperp * sin(phi) + vpar * cos(phi) * sin(theta), &
+           vpar  * cos(theta) ]
+
+    call init_full_orbit_state_prov(state, x0, v0, orbit_model, COORD_CART, &
+                                    mass_cgs, charge_cgs, dt, cart_prov)
+  end subroutine init_full_orbit_state_coils
+
+  subroutine set_mu_from_state(state)
+    type(FullOrbitState), intent(inout) :: state
+    real(dp) :: Bvec(3), Bmod, hcov(3), vperp2, vpar
+    integer :: ierr
+
+    call state%prov%eval_field(state%z(1:3), Bvec, Bmod, hcov, ierr)
+    if (ierr /= FO_OK .or. Bmod <= 0.0_dp) then
+      state%mu = 0.0_dp
+      return
+    end if
+    select case (state%ncoord)
+    case (COORD_CYL)
+      vperp2 = vperp_sq_cyl(state%z(1), state%z(4:6), hcov)
+    case default
+      vpar   = dot_product(state%z(4:6), hcov)
+      vperp2 = max(dot_product(state%z(4:6), state%z(4:6)) - vpar*vpar, 0.0_dp)
+    end select
+    state%mu = state%mass * vperp2 / (2.0_dp * Bmod)
+  end subroutine set_mu_from_state
+
+  subroutine timestep_full_orbit(state, ierr)
+    type(FullOrbitState), intent(inout) :: state
+    integer, intent(out) :: ierr
+
+    select case (state%orbit_model)
+    case (ORBIT_BORIS)
+      select case (state%ncoord)
+      case (COORD_CART)
+        call boris_step_cart(state, ierr)
+      case (COORD_CYL)
+        call boris_step_cyl(state, ierr)
+      case default
+        ierr = FO_ERR_OUT_OF_DOMAIN
+      end select
+    case (ORBIT_PAULI)
+      ! CPP variational step not implemented yet. The seam (canonical-field
+      ! provider method, vpar in z(4), mu, FO_ERR_NO_CONVERGE channel) is in
+      ! place; flag not-implemented without touching the Boris branch.
+      ierr = FO_ERR_NO_CONVERGE
+    case default
+      ierr = FO_ERR_OUT_OF_DOMAIN
+    end select
+  end subroutine timestep_full_orbit
+
+  ! Cartesian Boris, drift-kick-drift (leapfrog), CGS:
+  !   m dv/dt = (q/c) v x B,  Omega = q B/(m c).
+  subroutine boris_step_cart(state, ierr)
+    type(FullOrbitState), intent(inout) :: state
+    integer, intent(out) :: ierr
+    real(dp) :: x(3), v(3), Bvec(3), Bmod, hcov(3)
+    real(dp) :: t(3), s(3), vprime(3), tmag2
+    real(dp) :: Phi, dPhi(3), Efield(3)
+    real(dp) :: dt, qmc
+
+    dt  = state%dt
+    qmc = state%qm / c
+    x = state%z(1:3)
+    v = state%z(4:6)
+
+    ! half position drift
+    x = x + 0.5_dp * dt * v
+
+    call state%prov%eval_field(x, Bvec, Bmod, hcov, ierr)
+    if (ierr /= FO_OK) return
+
+    ! half electric kick (E = -grad Phi); mocks return Phi=0
+    call state%prov%eval_potential(x, Phi, dPhi)
+    Efield = -dPhi
+    v = v + 0.5_dp * dt * state%qm * Efield
+
+    ! magnetic rotation (exact for constant B over the step)
+    t = qmc * Bvec * 0.5_dp * dt
+    tmag2 = dot_product(t, t)
+    s = 2.0_dp * t / (1.0_dp + tmag2)
+    vprime = v + cross(v, t)
+    v = v + cross(vprime, s)
+
+    ! second half electric kick
+    v = v + 0.5_dp * dt * state%qm * Efield
+
+    ! half position drift
+    x = x + 0.5_dp * dt * v
+
+    state%z(1:3) = x
+    state%z(4:6) = v
+    ierr = FO_OK
+  end subroutine boris_step_cart
+
+  ! Cylindrical Boris in coordinates (R,phi,Z), contravariant velocity in
+  ! z(4:6). Symmetric splitting: half geodesic kick / half drift / orthonormal
+  ! magnetic rotation / half drift / half geodesic kick. The geodesic kick
+  ! applies -Gamma^i_{mn} v^m v^n from the provider's Christoffel symbols.
+  subroutine boris_step_cyl(state, ierr)
+    type(FullOrbitState), intent(inout) :: state
+    integer, intent(out) :: ierr
+    real(dp) :: u(3), v(3), Bvec(3), Bmod, hcov(3)
+    real(dp) :: dt, qmc, R
+    real(dp) :: vorth(3), t(3), sv(3), vprime(3), tmag2
+
+    dt  = state%dt
+    qmc = state%qm / c
+    u = state%z(1:3)
+    v = state%z(4:6)
+
+    call geodesic_half_kick(state, u, v, 0.5_dp*dt)
+
+    u = u + 0.5_dp * dt * v
+    R = u(1)
+    if (R <= 0.0_dp) then
+      ierr = FO_ERR_OUT_OF_DOMAIN
+      return
+    end if
+
+    call state%prov%eval_field(u, Bvec, Bmod, hcov, ierr)
+    if (ierr /= FO_OK) return
+
+    ! magnetic rotation in the local orthonormal frame
+    vorth = contravar_to_orth(v, R)
+    t = qmc * Bvec * 0.5_dp * dt
+    tmag2 = dot_product(t, t)
+    sv = 2.0_dp * t / (1.0_dp + tmag2)
+    vprime = vorth + cross(vorth, t)
+    vorth = vorth + cross(vprime, sv)
+    v = orth_to_contravar(vorth, R)
+
+    u = u + 0.5_dp * dt * v
+    if (u(1) <= 0.0_dp) then
+      ierr = FO_ERR_OUT_OF_DOMAIN
+      return
+    end if
+
+    call geodesic_half_kick(state, u, v, 0.5_dp*dt)
+
+    state%z(1:3) = u
+    state%z(4:6) = v
+    ierr = FO_OK
+  end subroutine boris_step_cyl
+
+  subroutine geodesic_half_kick(state, u, v, h)
+    type(FullOrbitState), intent(in) :: state
+    real(dp), intent(in)    :: u(3), h
+    real(dp), intent(inout) :: v(3)
+    real(dp) :: Gamma(3,3,3), acc(3)
+    integer :: i, m, n
+
+    call state%prov%christoffel(u, Gamma)
+    acc = 0.0_dp
+    do i = 1, 3
+      do m = 1, 3
+        do n = 1, 3
+          acc(i) = acc(i) - Gamma(i,m,n) * v(m) * v(n)
+        end do
+      end do
+    end do
+    v = v + h * acc
+  end subroutine geodesic_half_kick
+
+  ! Orthonormal cylindrical components (vR,vphi_phys,vZ) from contravariant
+  ! (v^R, v^phi, v^Z): vphi_phys = R v^phi.
+  pure function contravar_to_orth(v, R) result(vorth)
+    real(dp), intent(in) :: v(3), R
+    real(dp) :: vorth(3)
+    vorth = [v(1), R * v(2), v(3)]
+  end function contravar_to_orth
+
+  pure function orth_to_contravar(vorth, R) result(v)
+    real(dp), intent(in) :: vorth(3), R
+    real(dp) :: v(3)
+    v = [vorth(1), vorth(2) / R, vorth(3)]
+  end function orth_to_contravar
+
+  pure function vperp_sq_cyl(R, v, hcov) result(vperp2)
+    real(dp), intent(in) :: R, v(3), hcov(3)
+    real(dp) :: vperp2, vorth(3), hunit(3), vpar, vsq
+    vorth = contravar_to_orth(v, R)
+    ! hcov are covariant unit-field comps; orthonormal unit field is hcov/g_ii.
+    ! For the toroidal mock h_orth = (0,1,0).
+    hunit = [hcov(1), hcov(2) / R, hcov(3)]
+    vpar = dot_product(vorth, hunit)
+    vsq  = dot_product(vorth, vorth)
+    vperp2 = max(vsq - vpar*vpar, 0.0_dp)
+  end function vperp_sq_cyl
+
+  pure function cross(a, b) result(c)
+    real(dp), intent(in) :: a(3), b(3)
+    real(dp) :: c(3)
+    c(1) = a(2)*b(3) - a(3)*b(2)
+    c(2) = a(3)*b(1) - a(1)*b(3)
+    c(3) = a(1)*b(2) - a(2)*b(1)
+  end function cross
+
+  ! Gyro-average to guiding-center scalars. For the analytic mocks this returns
+  ! position-coordinate scalars and the instantaneous pitch/speed; full
+  ! gyro-averaging over coordinate maps lands with the libneo PR.
+  subroutine convert_full_to_gc(state, s, theta, phi, lambda, v)
+    type(FullOrbitState), intent(in)  :: state
+    real(dp), intent(out) :: s, theta, phi, lambda, v
+    real(dp) :: Bvec(3), Bmod, hcov(3), vpar, speed
+    real(dp) :: vorth(3), hunit(3)
+    integer :: ierr
+
+    call state%prov%eval_field(state%z(1:3), Bvec, Bmod, hcov, ierr)
+    select case (state%ncoord)
+    case (COORD_CYL)
+      s = state%z(1); theta = state%z(3); phi = state%z(2)
+      vorth = contravar_to_orth(state%z(4:6), state%z(1))
+      hunit = [hcov(1), hcov(2)/state%z(1), hcov(3)]
+      speed = sqrt(dot_product(vorth, vorth))
+      vpar  = dot_product(vorth, hunit)
+    case default
+      s = state%z(1); theta = state%z(2); phi = state%z(3)
+      speed = sqrt(dot_product(state%z(4:6), state%z(4:6)))
+      vpar  = dot_product(state%z(4:6), hcov)
+    end select
+    v = speed
+    if (speed > 0.0_dp) then
+      lambda = vpar / speed
+    else
+      lambda = 0.0_dp
+    end if
+  end subroutine convert_full_to_gc
+
+  ! 0.5*m*|v|^2 (+ q*Phi). Velocity magnitude uses the metric in curvilinear
+  ! coordinates so it is the physical speed.
+  function compute_energy(state) result(energy)
+    type(FullOrbitState), intent(in) :: state
+    real(dp) :: energy
+    real(dp) :: speed2, Phi, dPhi(3), vorth(3)
+
+    select case (state%ncoord)
+    case (COORD_CYL)
+      vorth = contravar_to_orth(state%z(4:6), state%z(1))
+      speed2 = dot_product(vorth, vorth)
+    case default
+      speed2 = dot_product(state%z(4:6), state%z(4:6))
+    end select
+    call state%prov%eval_potential(state%z(1:3), Phi, dPhi)
+    energy = 0.5_dp * state%mass * speed2 + state%charge * Phi
+  end function compute_energy
+
+end module orbit_full

--- a/src/orbit_full_mock_cart.f90
+++ b/src/orbit_full_mock_cart.f90
@@ -1,0 +1,120 @@
+module orbit_full_mock_cart
+  ! Cartesian mock field/metric provider, no libneo dependency on the analytic
+  ! paths. Flat metric (g = I), zero Christoffel. B is either uniform, a linear
+  ! gradient, or (FIELD_COILS) a Biot-Savart evaluation of a coil set.
+  use, intrinsic :: iso_fortran_env, only: dp => real64
+  use orbit_full_provider, only: field_metric_provider_t, FO_ERR_FIELD
+  use neo_biotsavart, only: coils_t, compute_magnetic_field, compute_vector_potential
+  implicit none
+  private
+  public :: cartesian_provider_t
+  public :: FIELD_UNIFORM, FIELD_LINGRAD, FIELD_COILS
+
+  integer, parameter :: FIELD_UNIFORM = 1
+  integer, parameter :: FIELD_LINGRAD = 2
+  integer, parameter :: FIELD_COILS   = 3
+
+  type, extends(field_metric_provider_t), public :: cartesian_provider_t
+    integer  :: field_kind = FIELD_UNIFORM
+    real(dp) :: B0(3)      = [0.0_dp, 0.0_dp, 1.0_dp]
+    real(dp) :: gradB(3,3) = 0.0_dp        ! B_i(x) = B0_i + sum_j gradB(i,j) x_j
+    type(coils_t), pointer :: coils => null()
+  contains
+    procedure :: eval_field     => cart_eval_field
+    procedure :: metric         => cart_metric
+    procedure :: christoffel    => cart_christoffel
+    procedure :: eval_canfield  => cart_eval_canfield
+    procedure :: eval_potential => cart_eval_potential
+  end type cartesian_provider_t
+
+contains
+
+  subroutine cart_eval_field(self, x, Bvec, Bmod, hcov, ierr)
+    class(cartesian_provider_t), intent(in) :: self
+    real(dp), intent(in)  :: x(3)
+    real(dp), intent(out) :: Bvec(3), Bmod, hcov(3)
+    integer,  intent(out) :: ierr
+    integer :: i
+
+    ierr = 0
+    select case (self%field_kind)
+    case (FIELD_UNIFORM)
+      Bvec = self%B0
+    case (FIELD_LINGRAD)
+      do i = 1, 3
+        Bvec(i) = self%B0(i) + dot_product(self%gradB(i, :), x)
+      end do
+    case (FIELD_COILS)
+      if (.not. associated(self%coils)) then
+        ierr = FO_ERR_FIELD
+        Bvec = 0.0_dp; Bmod = 0.0_dp; hcov = 0.0_dp
+        return
+      end if
+      Bvec = compute_magnetic_field(self%coils, x)
+    case default
+      ierr = FO_ERR_FIELD
+      Bvec = 0.0_dp; Bmod = 0.0_dp; hcov = 0.0_dp
+      return
+    end select
+
+    Bmod = sqrt(Bvec(1)**2 + Bvec(2)**2 + Bvec(3)**2)
+    if (Bmod <= 0.0_dp) then
+      ierr = FO_ERR_FIELD
+      hcov = 0.0_dp
+      return
+    end if
+    hcov = Bvec / Bmod
+  end subroutine cart_eval_field
+
+  subroutine cart_metric(self, x, g, ginv, sqrtg)
+    class(cartesian_provider_t), intent(in) :: self
+    real(dp), intent(in)  :: x(3)
+    real(dp), intent(out) :: g(3,3), ginv(3,3), sqrtg
+    integer :: i
+
+    g = 0.0_dp
+    ginv = 0.0_dp
+    do i = 1, 3
+      g(i,i) = 1.0_dp
+      ginv(i,i) = 1.0_dp
+    end do
+    sqrtg = 1.0_dp
+  end subroutine cart_metric
+
+  subroutine cart_christoffel(self, x, Gamma)
+    class(cartesian_provider_t), intent(in) :: self
+    real(dp), intent(in)  :: x(3)
+    real(dp), intent(out) :: Gamma(3,3,3)
+
+    Gamma = 0.0_dp
+  end subroutine cart_christoffel
+
+  ! Declared seam for the CPP/Pauli path; the Boris path never calls it. The
+  ! mock has no analytic canonical-field model, so it flags not-implemented.
+  subroutine cart_eval_canfield(self, x, Ath, Aph, hth, hph, Bmod, &
+      dAth, dAph, dhth, dhph, dBmod, &
+      d2Ath, d2Aph, d2hth, d2hph, d2Bmod, ierr)
+    class(cartesian_provider_t), intent(in) :: self
+    real(dp), intent(in)  :: x(3)
+    real(dp), intent(out) :: Ath, Aph, hth, hph, Bmod
+    real(dp), intent(out) :: dAth(3), dAph(3), dhth(3), dhph(3), dBmod(3)
+    real(dp), intent(out) :: d2Ath(6), d2Aph(6), d2hth(6), d2hph(6), d2Bmod(6)
+    integer,  intent(out) :: ierr
+
+    Ath = 0.0_dp; Aph = 0.0_dp; hth = 0.0_dp; hph = 0.0_dp; Bmod = 0.0_dp
+    dAth = 0.0_dp; dAph = 0.0_dp; dhth = 0.0_dp; dhph = 0.0_dp; dBmod = 0.0_dp
+    d2Ath = 0.0_dp; d2Aph = 0.0_dp; d2hth = 0.0_dp; d2hph = 0.0_dp
+    d2Bmod = 0.0_dp
+    ierr = FO_ERR_FIELD
+  end subroutine cart_eval_canfield
+
+  subroutine cart_eval_potential(self, x, Phi, dPhi)
+    class(cartesian_provider_t), intent(in) :: self
+    real(dp), intent(in)  :: x(3)
+    real(dp), intent(out) :: Phi, dPhi(3)
+
+    Phi = 0.0_dp
+    dPhi = 0.0_dp
+  end subroutine cart_eval_potential
+
+end module orbit_full_mock_cart

--- a/src/orbit_full_mock_cyl.f90
+++ b/src/orbit_full_mock_cyl.f90
@@ -1,0 +1,112 @@
+module orbit_full_mock_cyl
+  ! Cylindrical mock provider in coordinates u = (R, phi, Z), no libneo
+  ! dependency. Analytic metric and closed-form Christoffel symbols, plus an
+  ! axisymmetric purely-toroidal 1/R field for the curvature + grad-B drift
+  ! oracle.
+  !
+  !   g    = diag(1, R^2, 1),  ginv = diag(1, 1/R^2, 1),  sqrtg = R
+  !   B    = B0*R0/R in the orthonormal toroidal direction (|B| = B0*R0/R)
+  !   B_phi^cov = |B|*R = B0*R0  (covariant toroidal component)
+  !
+  ! Nonzero Christoffel (second kind), Gamma(i,m,n) = Gamma^i_{mn}:
+  !   Gamma^R_{phi phi}  = Gamma(1,2,2) = -R
+  !   Gamma^phi_{R phi}  = Gamma(2,1,2) =  1/R
+  !   Gamma^phi_{phi R}  = Gamma(2,2,1) =  1/R
+  use, intrinsic :: iso_fortran_env, only: dp => real64
+  use orbit_full_provider, only: field_metric_provider_t, FO_ERR_FIELD
+  implicit none
+  private
+  public :: cylindrical_provider_t
+
+  type, extends(field_metric_provider_t), public :: cylindrical_provider_t
+    real(dp) :: B0 = 1.0_dp
+    real(dp) :: R0 = 1.0_dp
+  contains
+    procedure :: eval_field     => cyl_eval_field
+    procedure :: metric         => cyl_metric
+    procedure :: christoffel    => cyl_christoffel
+    procedure :: eval_canfield  => cyl_eval_canfield
+    procedure :: eval_potential => cyl_eval_potential
+  end type cylindrical_provider_t
+
+contains
+
+  ! Bvec returned in the orthonormal cylindrical frame (e_R, e_phi, e_Z);
+  ! hcov holds the covariant unit-field components h_i = B_i/|B|, so that
+  ! h_phi = R for this purely-toroidal field.
+  subroutine cyl_eval_field(self, x, Bvec, Bmod, hcov, ierr)
+    class(cylindrical_provider_t), intent(in) :: self
+    real(dp), intent(in)  :: x(3)
+    real(dp), intent(out) :: Bvec(3), Bmod, hcov(3)
+    integer,  intent(out) :: ierr
+    real(dp) :: R
+
+    R = x(1)
+    if (R <= 0.0_dp) then
+      ierr = FO_ERR_FIELD
+      Bvec = 0.0_dp; Bmod = 0.0_dp; hcov = 0.0_dp
+      return
+    end if
+    ierr = 0
+    Bmod = self%B0 * self%R0 / R
+    Bvec = [0.0_dp, Bmod, 0.0_dp]          ! orthonormal toroidal
+    hcov = [0.0_dp, R, 0.0_dp]             ! h_phi^cov = B_phi^cov/|B| = R
+  end subroutine cyl_eval_field
+
+  subroutine cyl_metric(self, x, g, ginv, sqrtg)
+    class(cylindrical_provider_t), intent(in) :: self
+    real(dp), intent(in)  :: x(3)
+    real(dp), intent(out) :: g(3,3), ginv(3,3), sqrtg
+    real(dp) :: R
+
+    R = x(1)
+    g = 0.0_dp
+    ginv = 0.0_dp
+    g(1,1) = 1.0_dp;     ginv(1,1) = 1.0_dp
+    g(2,2) = R*R;        ginv(2,2) = 1.0_dp / (R*R)
+    g(3,3) = 1.0_dp;     ginv(3,3) = 1.0_dp
+    sqrtg = R
+  end subroutine cyl_metric
+
+  subroutine cyl_christoffel(self, x, Gamma)
+    class(cylindrical_provider_t), intent(in) :: self
+    real(dp), intent(in)  :: x(3)
+    real(dp), intent(out) :: Gamma(3,3,3)
+    real(dp) :: R
+
+    R = x(1)
+    Gamma = 0.0_dp
+    Gamma(1,2,2) = -R
+    Gamma(2,1,2) = 1.0_dp / R
+    Gamma(2,2,1) = 1.0_dp / R
+  end subroutine cyl_christoffel
+
+  ! Declared CPP/Pauli seam; not exercised by the Boris path. Flags
+  ! not-implemented rather than returning a partial canonical model.
+  subroutine cyl_eval_canfield(self, x, Ath, Aph, hth, hph, Bmod, &
+      dAth, dAph, dhth, dhph, dBmod, &
+      d2Ath, d2Aph, d2hth, d2hph, d2Bmod, ierr)
+    class(cylindrical_provider_t), intent(in) :: self
+    real(dp), intent(in)  :: x(3)
+    real(dp), intent(out) :: Ath, Aph, hth, hph, Bmod
+    real(dp), intent(out) :: dAth(3), dAph(3), dhth(3), dhph(3), dBmod(3)
+    real(dp), intent(out) :: d2Ath(6), d2Aph(6), d2hth(6), d2hph(6), d2Bmod(6)
+    integer,  intent(out) :: ierr
+
+    Ath = 0.0_dp; Aph = 0.0_dp; hth = 0.0_dp; hph = 0.0_dp; Bmod = 0.0_dp
+    dAth = 0.0_dp; dAph = 0.0_dp; dhth = 0.0_dp; dhph = 0.0_dp; dBmod = 0.0_dp
+    d2Ath = 0.0_dp; d2Aph = 0.0_dp; d2hth = 0.0_dp; d2hph = 0.0_dp
+    d2Bmod = 0.0_dp
+    ierr = FO_ERR_FIELD
+  end subroutine cyl_eval_canfield
+
+  subroutine cyl_eval_potential(self, x, Phi, dPhi)
+    class(cylindrical_provider_t), intent(in) :: self
+    real(dp), intent(in)  :: x(3)
+    real(dp), intent(out) :: Phi, dPhi(3)
+
+    Phi = 0.0_dp
+    dPhi = 0.0_dp
+  end subroutine cyl_eval_potential
+
+end module orbit_full_mock_cyl

--- a/src/orbit_full_provider.f90
+++ b/src/orbit_full_provider.f90
@@ -1,0 +1,77 @@
+module orbit_full_provider
+  ! Abstract field/metric provider for the full-orbit pushers.
+  !
+  ! Kept in its own module so the Boris path carries no libneo symbol: the
+  ! mocks extend this type, orbit_full only depends on the abstract interface.
+  use, intrinsic :: iso_fortran_env, only: dp => real64
+  implicit none
+  private
+  public :: field_metric_provider_t
+  public :: FO_OK, FO_ERR_FIELD, FO_ERR_NO_CONVERGE, FO_ERR_OUT_OF_DOMAIN
+
+  ! Error codes shared by the provider seam and the integrator. Defined here so
+  ! the mocks can flag a not-implemented eval_canfield without depending on
+  ! orbit_full (which would create a use cycle); orbit_full re-exports them.
+  integer, parameter :: FO_OK = 0
+  integer, parameter :: FO_ERR_FIELD = 1        ! provider field eval failed
+  integer, parameter :: FO_ERR_NO_CONVERGE = 2  ! CPP Newton did not converge
+  integer, parameter :: FO_ERR_OUT_OF_DOMAIN = 3
+
+  type, abstract :: field_metric_provider_t
+  contains
+    procedure(eval_field_if),     deferred :: eval_field
+    procedure(metric_if),         deferred :: metric
+    procedure(christoffel_if),    deferred :: christoffel
+    procedure(eval_canfield_if),  deferred :: eval_canfield
+    procedure(eval_potential_if), deferred :: eval_potential
+  end type field_metric_provider_t
+
+  abstract interface
+    ! Physical B vector, |B|, and covariant unit-vector components h_i = B_i/|B|.
+    subroutine eval_field_if(self, x, Bvec, Bmod, hcov, ierr)
+      import :: field_metric_provider_t, dp
+      class(field_metric_provider_t), intent(in) :: self
+      real(dp), intent(in)  :: x(3)
+      real(dp), intent(out) :: Bvec(3), Bmod, hcov(3)
+      integer,  intent(out) :: ierr
+    end subroutine eval_field_if
+
+    ! Metric for the curvilinear push: g_ij, g^ij, sqrt(det g).
+    subroutine metric_if(self, x, g, ginv, sqrtg)
+      import :: field_metric_provider_t, dp
+      class(field_metric_provider_t), intent(in) :: self
+      real(dp), intent(in)  :: x(3)
+      real(dp), intent(out) :: g(3,3), ginv(3,3), sqrtg
+    end subroutine metric_if
+
+    ! Christoffel symbols of the second kind, Gamma(i,m,n) = Gamma^i_{mn}.
+    subroutine christoffel_if(self, x, Gamma)
+      import :: field_metric_provider_t, dp
+      class(field_metric_provider_t), intent(in) :: self
+      real(dp), intent(in)  :: x(3)
+      real(dp), intent(out) :: Gamma(3,3,3)
+    end subroutine christoffel_if
+
+    ! CPP / Pauli canonical field quantities, all in provider coordinates.
+    ! Second-derivative layout d2?(6): order (11,12,13,22,23,33).
+    subroutine eval_canfield_if(self, x, Ath, Aph, hth, hph, Bmod, &
+        dAth, dAph, dhth, dhph, dBmod, &
+        d2Ath, d2Aph, d2hth, d2hph, d2Bmod, ierr)
+      import :: field_metric_provider_t, dp
+      class(field_metric_provider_t), intent(in) :: self
+      real(dp), intent(in)  :: x(3)
+      real(dp), intent(out) :: Ath, Aph, hth, hph, Bmod
+      real(dp), intent(out) :: dAth(3), dAph(3), dhth(3), dhph(3), dBmod(3)
+      real(dp), intent(out) :: d2Ath(6), d2Aph(6), d2hth(6), d2hph(6), d2Bmod(6)
+      integer,  intent(out) :: ierr
+    end subroutine eval_canfield_if
+
+    ! Electrostatic potential Phi and covariant gradient. Mocks return 0.
+    subroutine eval_potential_if(self, x, Phi, dPhi)
+      import :: field_metric_provider_t, dp
+      class(field_metric_provider_t), intent(in) :: self
+      real(dp), intent(in)  :: x(3)
+      real(dp), intent(out) :: Phi, dPhi(3)
+    end subroutine eval_potential_if
+  end interface
+end module orbit_full_provider

--- a/src/params.f90
+++ b/src/params.f90
@@ -45,6 +45,10 @@ module params
 
     integer :: integmode = EXPL_IMPL_EULER
 
+    ! Orbit model selector: 0 guiding-center (default, symplectic GC path),
+    ! 1 Pauli/CPP full orbit, 2 Boris full orbit. See src/orbit_full.f90.
+    integer :: orbit_model = 0
+
     integer :: kpart = 0 ! progress counter for particles
 
     real(dp) :: relerr = 1d-13
@@ -109,7 +113,7 @@ module params
 	        trace_time, num_surf, sbeg, phibeg, thetabeg, contr_pp, &
 	        facE_al, npoiper2, n_e, n_d, netcdffile, ns_s, ns_tp, multharm, &
 	        isw_field_type, generate_start_only, startmode, grid_density, &
-	        special_ants_file, integmode, relerr, tcut, nturns, debug, &
+	        special_ants_file, integmode, orbit_model, relerr, tcut, nturns, debug, &
 	        class_plot, cut_in_per, fast_class, vmec_B_scale, &
 	        vmec_RZ_scale, swcoll, deterministic, old_axis_healing, &
 	        old_axis_healing_boundary, am1, am2, Z1, Z2, &

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -570,6 +570,11 @@ add_executable(test_orbit_symplectic_base.x test_orbit_symplectic_base.f90)
 target_link_libraries(test_orbit_symplectic_base.x simple)
 add_test(NAME test_orbit_symplectic_base COMMAND test_orbit_symplectic_base.x)
 
+add_executable(test_full_orbit.x test_full_orbit.f90)
+target_link_libraries(test_full_orbit.x simple)
+add_test(NAME test_full_orbit COMMAND test_full_orbit.x)
+set_tests_properties(test_full_orbit PROPERTIES LABELS "unit")
+
 add_executable(test_field_base.x test_field_base.f90)
 target_link_libraries(test_field_base.x simple)
 add_test(NAME test_field_base COMMAND test_field_base.x)

--- a/test/tests/test_full_orbit.f90
+++ b/test/tests/test_full_orbit.f90
@@ -1,0 +1,392 @@
+program test_full_orbit
+  ! Behavioral tests for the full-orbit Boris pusher using only the analytic
+  ! Cartesian and cylindrical mock providers (no libneo field). Oracles:
+  !   1. uniform-B exact gyration: |v|, vpar, energy, mu conserved; closed
+  !      circle of Larmor radius r_L = m c vperp/(q B), period T = 2pi m c/(qB).
+  !   2. Cartesian linear grad-B drift vs analytic v_gradB.
+  !   3. cylindrical 1/R curvature + grad-B drift vs analytic v_d, separated
+  !      into pure curvature (vperp=0) and pure grad-B (vpar=0).
+  !   4. mu adiabatic invariance over many gyroperiods.
+  !   5. cylindrical Christoffel mock vs closed form.
+  use, intrinsic :: iso_fortran_env, only: dp => real64
+  use util, only: c, twopi, pi, p_mass, e_charge
+  use orbit_full, only: FullOrbitState, init_full_orbit_state, &
+      timestep_full_orbit, convert_full_to_gc, compute_energy, &
+      ORBIT_BORIS, COORD_CART, COORD_CYL, FO_OK
+  use orbit_full_mock_cart, only: cartesian_provider_t, FIELD_UNIFORM, FIELD_LINGRAD
+  use orbit_full_mock_cyl, only: cylindrical_provider_t
+  implicit none
+
+  integer :: nfail
+  nfail = 0
+
+  call test_uniform_gyration(nfail)
+  call test_cart_gradb_drift(nfail)
+  call test_cyl_curvature_drift(nfail)
+  call test_cyl_gradb_drift(nfail)
+  call test_mu_invariance(nfail)
+  call test_cyl_christoffel(nfail)
+
+  if (nfail == 0) then
+    print *, 'ALL FULL-ORBIT TESTS PASSED'
+  else
+    print *, 'FULL-ORBIT TESTS FAILED: ', nfail
+    error stop 1
+  end if
+
+contains
+
+  subroutine check(name, ok, nfail)
+    character(*), intent(in) :: name
+    logical, intent(in) :: ok
+    integer, intent(inout) :: nfail
+    if (ok) then
+      print '(A,A)', 'PASS  ', name
+    else
+      print '(A,A)', 'FAIL  ', name
+      nfail = nfail + 1
+    end if
+  end subroutine check
+
+  subroutine test_uniform_gyration(nfail)
+    integer, intent(inout) :: nfail
+    type(cartesian_provider_t), target :: prov
+    type(FullOrbitState) :: st
+    real(dp) :: mass, charge, B0, vperp, vpar, speed0
+    real(dp) :: Omega, period, dt, rL
+    real(dp) :: x0(3), v0(3), xstart(3)
+    real(dp) :: e0, e1, mu0, vz0, errpos, errv
+    integer :: i, nstep, ierr
+
+    mass   = 4.0_dp * p_mass
+    charge = 2.0_dp * e_charge
+    B0     = 1.0d4
+    prov%field_kind = FIELD_UNIFORM
+    prov%B0 = [0.0_dp, 0.0_dp, B0]
+
+    vperp = 1.0d7
+    vpar  = 3.0d6
+    speed0 = sqrt(vperp**2 + vpar**2)
+    Omega = charge * B0 / (mass * c)
+    period = twopi / Omega
+    rL = mass * c * vperp / (charge * B0)
+    nstep = 400
+    dt = period / nstep
+
+    x0 = [0.0_dp, 0.0_dp, 0.0_dp]
+    v0 = [vperp, 0.0_dp, vpar]
+    call init_full_orbit_state(st, x0, v0, ORBIT_BORIS, COORD_CART, &
+                               mass, charge, dt, prov)
+    xstart = st%z(1:3)
+    e0  = compute_energy(st)
+    mu0 = st%mu
+    vz0 = st%z(6)
+
+    do i = 1, nstep
+      call timestep_full_orbit(st, ierr)
+      if (ierr /= FO_OK) then
+        call check('uniform: timestep ierr', .false., nfail)
+        return
+      end if
+    end do
+
+    e1 = compute_energy(st)
+    errv = abs(sqrt(dot_product(st%z(4:6), st%z(4:6))) - speed0) / speed0
+    ! transverse return: z advances by vpar*period, so only (x,y) close.
+    errpos = sqrt((st%z(1)-xstart(1))**2 + (st%z(2)-xstart(2))**2)
+
+    print '(A,ES12.4,A,ES12.4)', '  uniform: r_L=', rL, ' period=', period
+    print '(A,ES12.4,A,ES12.4)', '  uniform: |v| relerr=', errv, &
+        ' return-pos err=', errpos
+    print '(A,ES12.4)', '  uniform: dE/E=', abs(e1-e0)/e0
+    print '(A,ES12.4)', '  uniform: dmu/mu=', abs(st%mu-mu0)/mu0
+
+    call check('uniform: |v| constant', errv < 1d-10, nfail)
+    call check('uniform: energy constant', abs(e1-e0)/e0 < 1d-9, nfail)
+    call check('uniform: vpar=vz constant', abs(st%z(6)-vz0) < 1d-6*speed0, nfail)
+    ! closed circle: error scales with dt; Boris is 2nd order -> bound on rL.
+    call check('uniform: return to start', errpos < 1d-3*rL, nfail)
+    call check('uniform: mu constant', abs(st%mu-mu0)/mu0 < 1d-9, nfail)
+  end subroutine test_uniform_gyration
+
+  subroutine test_cart_gradb_drift(nfail)
+    integer, intent(inout) :: nfail
+    type(cartesian_provider_t), target :: prov
+    type(FullOrbitState) :: st
+    real(dp) :: mass, charge, B0, g, vperp, vpar
+    real(dp) :: Omega, period, dt, vd_exact, vd_meas
+    real(dp) :: x0(3), v0(3), ygc0, ygc1, t_total
+    integer :: i, nper_run, nstep_per, nstep, ierr
+
+    mass   = 4.0_dp * p_mass
+    charge = 2.0_dp * e_charge
+    B0     = 1.0d4
+    g      = 1.0d2           ! G/cm gradient of B_z along x
+    prov%field_kind = FIELD_LINGRAD
+    prov%B0 = [0.0_dp, 0.0_dp, B0]
+    prov%gradB = 0.0_dp
+    prov%gradB(3,1) = g       ! B_z = B0 + g*x
+
+    vperp = 1.0d7
+    vpar  = 0.0_dp
+    Omega = charge * B0 / (mass * c)
+    period = twopi / Omega
+    nstep_per = 200
+    nper_run = 2000
+    nstep = nstep_per * nper_run
+    dt = period / nstep_per
+
+    ! analytic grad-B drift: v = (m c vperp^2)/(2 q B0) * (g/B0), along +e_y for
+    ! q>0, B along +z, grad|B| along +x.
+    vd_exact = mass * c * vperp**2 / (2.0_dp * charge * B0) * (g / B0)
+
+    x0 = [0.0_dp, 0.0_dp, 0.0_dp]
+    v0 = [vperp, 0.0_dp, vpar]
+    call init_full_orbit_state(st, x0, v0, ORBIT_BORIS, COORD_CART, &
+                               mass, charge, dt, prov)
+    ygc0 = guiding_center_y_cart(st)
+    do i = 1, nstep
+      call timestep_full_orbit(st, ierr)
+      if (ierr /= FO_OK) then
+        call check('cart gradB: timestep ierr', .false., nfail)
+        return
+      end if
+    end do
+    ygc1 = guiding_center_y_cart(st)
+    t_total = nstep * dt
+    ! guiding-center y-drift removes the gyration, leaving the secular drift.
+    vd_meas = (ygc1 - ygc0) / t_total
+
+    print '(A,ES12.4,A,ES12.4)', '  cart gradB: vd_exact=', vd_exact, &
+        ' vd_meas=', vd_meas
+    call check('cart gradB: drift sign/magnitude', &
+        abs(vd_meas - vd_exact) < 0.05_dp*abs(vd_exact), nfail)
+  end subroutine test_cart_gradb_drift
+
+  ! Guiding-center y from the instantaneous Cartesian state:
+  ! x_gc = x - (1/Omega) (b x v), Omega = qB/(mc), b = B/|B|.
+  function guiding_center_y_cart(st) result(ygc)
+    type(FullOrbitState), intent(in) :: st
+    real(dp) :: ygc
+    real(dp) :: Bvec(3), Bmod, hcov(3), Omega, rho(3)
+    integer :: ierr
+    call st%prov%eval_field(st%z(1:3), Bvec, Bmod, hcov, ierr)
+    Omega = st%qm * Bmod / c
+    rho = cross_local(hcov, st%z(4:6)) / Omega
+    ygc = st%z(2) - rho(2)
+  end function guiding_center_y_cart
+
+  pure function cross_local(a, b) result(cc)
+    real(dp), intent(in) :: a(3), b(3)
+    real(dp) :: cc(3)
+    cc(1) = a(2)*b(3) - a(3)*b(2)
+    cc(2) = a(3)*b(1) - a(1)*b(3)
+    cc(3) = a(1)*b(2) - a(2)*b(1)
+  end function cross_local
+
+  subroutine test_cyl_curvature_drift(nfail)
+    ! Pure curvature: vperp -> 0 (small), vpar finite. v_d = (mc/qBR) vpar^2.
+    integer, intent(inout) :: nfail
+    call run_cyl_drift(nfail, 'cyl curvature', vpar_in=1.0d7, vperp_in=1.0d5)
+  end subroutine test_cyl_curvature_drift
+
+  subroutine test_cyl_gradb_drift(nfail)
+    ! Pure grad-B: vpar -> 0 (small), vperp finite. v_d = (mc/qBR)(vperp^2/2).
+    integer, intent(inout) :: nfail
+    call run_cyl_drift(nfail, 'cyl gradB', vpar_in=1.0d5, vperp_in=1.0d7)
+  end subroutine test_cyl_gradb_drift
+
+  subroutine run_cyl_drift(nfail, tag, vpar_in, vperp_in)
+    integer, intent(inout) :: nfail
+    character(*), intent(in) :: tag
+    real(dp), intent(in) :: vpar_in, vperp_in
+    type(cylindrical_provider_t), target :: prov
+    type(FullOrbitState) :: st
+    real(dp) :: mass, charge, B0, R0, R, Bloc
+    real(dp) :: Omega, period, dt, vd_exact, vd_meas
+    real(dp) :: u0(3), w0(3), z0, t_total
+    integer :: i, nstep_per, nper_run, nstep, ierr
+
+    mass   = 4.0_dp * p_mass
+    charge = 2.0_dp * e_charge
+    B0     = 1.0d4
+    R0     = 200.0_dp
+    R      = 200.0_dp
+    prov%B0 = B0
+    prov%R0 = R0
+
+    Bloc = B0 * R0 / R       ! = B0 here since R=R0
+    Omega = charge * Bloc / (mass * c)
+    period = twopi / Omega
+    nstep_per = 300
+    nper_run = 40
+    nstep = nstep_per * nper_run
+    dt = period / nstep_per
+
+    ! v_d = (m c)/(q B R) * (vpar^2 + vperp^2/2), along +Z for q>0, B toroidal.
+    vd_exact = (mass * c) / (charge * Bloc * R) * &
+               (vpar_in**2 + 0.5_dp * vperp_in**2)
+
+    ! contravariant velocity in (R,phi,Z): orthonormal vphi_phys=vpar (toroidal
+    ! is field direction); vperp put into v^R (radial). v^phi = vpar/R.
+    u0 = [R, 0.0_dp, 0.0_dp]
+    w0 = [vperp_in, vpar_in / R, 0.0_dp]
+    call init_full_orbit_state(st, u0, w0, ORBIT_BORIS, COORD_CYL, &
+                               mass, charge, dt, prov)
+    z0 = st%z(3)
+    do i = 1, nstep
+      call timestep_full_orbit(st, ierr)
+      if (ierr /= FO_OK) then
+        call check(tag//': timestep ierr', .false., nfail)
+        return
+      end if
+    end do
+    t_total = nstep * dt
+    vd_meas = (st%z(3) - z0) / t_total
+
+    print '(A,A,A,ES12.4,A,ES12.4)', '  ', tag, ': vd_exact=', vd_exact, &
+        ' vd_meas=', vd_meas
+    call check(tag//': vertical drift', &
+        abs(vd_meas - vd_exact) < 0.10_dp*abs(vd_exact), nfail)
+  end subroutine run_cyl_drift
+
+  subroutine test_mu_invariance(nfail)
+    integer, intent(inout) :: nfail
+    type(cartesian_provider_t), target :: prov
+    type(FullOrbitState) :: st
+    real(dp) :: mass, charge, B0, g, vperp, vpar
+    real(dp) :: Omega, period, dt, mu0, mumax_dev, mu_now
+    real(dp) :: Bvec(3), Bmod, hcov(3), vperp2, vpar_now
+    real(dp) :: x0(3), v0(3)
+    integer :: i, nstep, ierr
+
+    mass   = 4.0_dp * p_mass
+    charge = 2.0_dp * e_charge
+    B0     = 1.0d4
+    g      = 1.0d0
+    prov%field_kind = FIELD_LINGRAD
+    prov%B0 = [0.0_dp, 0.0_dp, B0]
+    prov%gradB = 0.0_dp
+    prov%gradB(3,1) = g
+
+    vperp = 1.0d7
+    vpar  = 2.0d6
+    Omega = charge * B0 / (mass * c)
+    period = twopi / Omega
+    nstep = 200 * 60
+    dt = period / 200
+
+    x0 = [0.0_dp, 0.0_dp, 0.0_dp]
+    v0 = [vperp, 0.0_dp, vpar]
+    call init_full_orbit_state(st, x0, v0, ORBIT_BORIS, COORD_CART, &
+                               mass, charge, dt, prov)
+    mu0 = st%mu
+    mumax_dev = 0.0_dp
+    do i = 1, nstep
+      call timestep_full_orbit(st, ierr)
+      if (ierr /= FO_OK) then
+        call check('mu inv: timestep ierr', .false., nfail)
+        return
+      end if
+      call prov%eval_field(st%z(1:3), Bvec, Bmod, hcov, ierr)
+      vpar_now = dot_product(st%z(4:6), hcov)
+      vperp2 = dot_product(st%z(4:6), st%z(4:6)) - vpar_now**2
+      mu_now = mass * vperp2 / (2.0_dp * Bmod)
+      mumax_dev = max(mumax_dev, abs(mu_now - mu0) / mu0)
+    end do
+
+    print '(A,ES12.4)', '  mu inv: max rel deviation=', mumax_dev
+    call check('mu adiabatic invariance', mumax_dev < 1d-3, nfail)
+  end subroutine test_mu_invariance
+
+  subroutine test_cyl_christoffel(nfail)
+    integer, intent(inout) :: nfail
+    type(cylindrical_provider_t) :: prov
+    real(dp) :: Gamma(3,3,3), x(3), R
+    real(dp) :: gfd(3,3,3), err
+    logical :: ok
+
+    prov%B0 = 1.0_dp
+    prov%R0 = 1.0_dp
+    R = 1.7_dp
+    x = [R, 0.3_dp, -0.5_dp]
+    call prov%christoffel(x, Gamma)
+
+    ! closed-form check
+    ok = abs(Gamma(1,2,2) - (-R)) < 1d-12 .and. &
+         abs(Gamma(2,1,2) - 1.0_dp/R) < 1d-12 .and. &
+         abs(Gamma(2,2,1) - 1.0_dp/R) < 1d-12
+    call check('cyl christoffel: closed form entries', ok, nfail)
+
+    ! symmetry Gamma^i_{mn} = Gamma^i_{nm}
+    ok = christoffel_symmetric(Gamma)
+    call check('cyl christoffel: symmetry', ok, nfail)
+
+    ! all other entries zero
+    call check('cyl christoffel: only known nonzeros', &
+        only_known_nonzero(Gamma, R), nfail)
+
+    ! finite-difference metric -> Gamma, compare to closed form
+    call christoffel_fd(prov, x, gfd)
+    err = maxval(abs(gfd - Gamma))
+    print '(A,ES12.4)', '  cyl christoffel: max FD-vs-analytic err=', err
+    call check('cyl christoffel: FD agrees', err < 1d-5, nfail)
+  end subroutine test_cyl_christoffel
+
+  logical function christoffel_symmetric(Gamma) result(ok)
+    real(dp), intent(in) :: Gamma(3,3,3)
+    integer :: i, m, n
+    ok = .true.
+    do i = 1, 3
+      do m = 1, 3
+        do n = 1, 3
+          if (abs(Gamma(i,m,n) - Gamma(i,n,m)) > 1d-14) ok = .false.
+        end do
+      end do
+    end do
+  end function christoffel_symmetric
+
+  logical function only_known_nonzero(Gamma, R) result(ok)
+    real(dp), intent(in) :: Gamma(3,3,3), R
+    real(dp) :: g(3,3,3)
+    g = Gamma
+    g(1,2,2) = 0.0_dp
+    g(2,1,2) = 0.0_dp
+    g(2,2,1) = 0.0_dp
+    ok = maxval(abs(g)) < 1d-14
+  end function only_known_nonzero
+
+  subroutine christoffel_fd(prov, x, gfd)
+    type(cylindrical_provider_t), intent(in) :: prov
+    real(dp), intent(in) :: x(3)
+    real(dp), intent(out) :: gfd(3,3,3)
+    real(dp) :: h, gp(3,3), gm(3,3), ginv(3,3), sqrtg
+    real(dp) :: dg(3,3,3), gnow(3,3), xp(3)
+    integer :: i, j, k, l
+    h = 1d-4
+
+    call prov%metric(x, gnow, ginv, sqrtg)
+    ! dg(k,i,j) = d g_ij / d x_k
+    do k = 1, 3
+      xp = x; xp(k) = x(k) + h
+      call prov%metric(xp, gp, ginv, sqrtg)
+      xp = x; xp(k) = x(k) - h
+      call prov%metric(xp, gm, ginv, sqrtg)
+      dg(k,:,:) = (gp - gm) / (2.0_dp*h)
+    end do
+    call prov%metric(x, gnow, ginv, sqrtg)
+
+    gfd = 0.0_dp
+    do i = 1, 3
+      do j = 1, 3       ! j = m
+        do k = 1, 3     ! k = n
+          do l = 1, 3
+            gfd(i,j,k) = gfd(i,j,k) + 0.5_dp*ginv(i,l) * &
+                (dg(j,l,k) + dg(k,l,j) - dg(l,j,k))
+          end do
+        end do
+      end do
+    end do
+  end subroutine christoffel_fd
+
+end program test_full_orbit


### PR DESCRIPTION
## Risk tier

- [ ] T0: docs, comments, small build metadata
- [ ] T1: pure refactor, no behavior change intended
- [x] T2: local numerical logic
- [ ] T3: physics, output behavior, coordinate convention
- [ ] T4: parallelism, GPU, dependency, CI, or security-sensitive build logic

## Correctness contract

### Intended behavior change

Add a gyro-resolved Lorentz (Boris) full-orbit integrator alongside the existing
symplectic guiding-center tracer. The Boris path runs against mock field/metric
providers (Cartesian and cylindrical) with zero libneo field dependency, so the
pusher and its oracles are testable in isolation. A `field_metric_provider_t`
abstract type defines the seam; the canonical-field and Christoffel methods are
declared now so the curvilinear and CPP/Pauli paths slot in later without
touching the Boris branch.

### Behavior that must not change

The guiding-center path is untouched. `orbit_model` defaults to `0`
(guiding-center) in the config namelist, so existing runs are unaffected. The
Pauli/CPP model is declared (`ORBIT_PAULI`) but dispatches to a non-fatal
`FO_ERR_NO_CONVERGE` channel; no CPP step is implemented in this PR.

### Coordinate / unit conventions

CGS Gaussian throughout, matching `src/util.F90`. The Lorentz force carries the
explicit `1/c`: `m dv/dt = (q/c) v x B`, gyrofrequency `Omega = qB/(mc)`. Boris
Cartesian state is `(x, v)` physical; cylindrical state is `(R,phi,Z)` with
contravariant velocity. Cylindrical metric `g = diag(1,R^2,1)`, `sqrtg = R`, and
the nonzero Christoffel symbols are `Gamma^R_{phi phi} = -R`,
`Gamma^phi_{R phi} = Gamma^phi_{phi R} = 1/R`.

### Numerical invariants

Uniform-B: `|v|`, `v_par`, kinetic energy, and `mu = m v_perp^2/(2B)` conserved;
transverse motion closes on a Larmor circle. Drifts match the analytic
guiding-center formulas: Cartesian grad-B `v = (m c v_perp^2)/(2 q B) |grad B|/B`
and cylindrical 1/R curvature+gradB `v_d = (m c)/(q B R)(v_par^2 + v_perp^2/2)`.

## Tests added

- unit: `test_full_orbit` (uniform-B gyration, Cartesian grad-B drift,
  cylindrical curvature drift, cylindrical grad-B drift, mu adiabatic
  invariance, cylindrical Christoffel closed-form + symmetry + FD agreement)
- integration: none
- system: none
- golden record: none

## Golden-record impact

- [x] unchanged
- [ ] changed

Default `orbit_model=0` keeps the guiding-center path bit-for-bit identical.

## Failure modes considered

- Provider use cycle avoided by housing the abstract type and `FO_*` codes in
  their own module.
- Out-of-domain `R <= 0` in the cylindrical push returns `FO_ERR_OUT_OF_DOMAIN`.
- The grad-B and curvature oracles measure the guiding-center position
  (gyration removed analytically) so residual gyrophase does not pollute the
  secular-drift comparison.

## Manual validation

`make CONFIG=Fast` builds clean; `test_full_orbit` and the smoke/orbit suites
pass. See Verification.

## Verification

Failing before (test target absent on `origin/main`):

```
$ git -C /home/ert/code/SIMPLE show origin/main:test/tests/test_full_orbit.f90
fatal: path 'test/tests/test_full_orbit.f90' does not exist in 'origin/main'
$ git -C /home/ert/code/SIMPLE show origin/main:src/orbit_full.f90
fatal: path 'src/orbit_full.f90' does not exist in 'origin/main'
```

Passing after (this branch, `make CONFIG=Fast` then run the test):

```
  uniform: r_L=  2.0879E-01 period=  1.3119E-07
  uniform: |v| relerr=  7.1364E-16 return-pos err=  2.6973E-05
  uniform: dE/E=  1.4179E-15
  uniform: dmu/mu=  0.0000E+00
PASS  uniform: |v| constant
PASS  uniform: energy constant
PASS  uniform: vpar=vz constant
PASS  uniform: return to start
PASS  uniform: mu constant
  cart gradB: vd_exact=  1.0439E+04 vd_meas=  1.0439E+04
PASS  cart gradB: drift sign/magnitude
  cyl curvature: vd_exact=  1.0440E+04 vd_meas=  1.0440E+04
PASS  cyl curvature: vertical drift
  cyl gradB: vd_exact=  5.2208E+03 vd_meas=  5.2227E+03
PASS  cyl gradB: vertical drift
  mu inv: max rel deviation=  2.0880E-05
PASS  mu adiabatic invariance
PASS  cyl christoffel: closed form entries
PASS  cyl christoffel: symmetry
PASS  cyl christoffel: only known nonzeros
  cyl christoffel: max FD-vs-analytic err=  1.0754E-12
PASS  cyl christoffel: FD agrees
 ALL FULL-ORBIT TESTS PASSED
```

ctest:

```
3/5 Test #28: test_full_orbit ..................   Passed    0.08 sec
100% tests passed, 0 tests failed out of 5
```

Smoke and symplectic-orbit suites unaffected:

```
6/6 Test #67: test_hctr_from_metric_vmec ...   Passed
100% tests passed, 0 tests failed out of 6   (smoke)
4/4 Test  #4: test_sympl_testfield .........   Passed
100% tests passed, 0 tests failed out of 4   (test_sympl*)
```
