### PR TITLE
Cross-validation suite and banana-orbit figures (GC vs CPP vs full orbit)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,6 +439,10 @@ add_executable(diag_traj.x
     app/simple_diag_traj.f90
 )
 
+add_executable(diag_traj_models.x
+    app/diag_traj_models.f90
+)
+
 # Apply SIMPLE-specific compile options to executable
 target_compile_options(simple.x PRIVATE ${SIMPLE_COMPILE_OPTIONS})
 
@@ -481,7 +485,10 @@ target_link_libraries(diag_albert.x PRIVATE simple)
 target_link_libraries(diag_newton.x PRIVATE simple)
 target_link_libraries(diag_orbit.x PRIVATE simple)
 target_link_libraries(diag_traj.x PRIVATE simple)
+target_link_libraries(diag_traj_models.x PRIVATE simple)
+target_compile_options(diag_traj_models.x PRIVATE ${SIMPLE_COMPILE_OPTIONS})
 set_target_properties(diag_traj.x PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set_target_properties(diag_traj_models.x PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set_target_properties(diag_meiss.x PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set_target_properties(diag_albert.x PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set_target_properties(diag_newton.x PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/app/diag_traj_models.f90
+++ b/app/diag_traj_models.f90
@@ -1,0 +1,348 @@
+program diag_traj_models
+  ! Dump one trapped (banana) orbit traced by three orbit models for the
+  ! cross-validation figures: GC (symplectic guiding center), CPP (flux-canonical
+  ! Pauli particle), and the gyro-resolved full orbit (Boris). Two field cases:
+  !
+  !   analytic : circular-tokamak "test" canonical chart for GC/CPP
+  !              (field_can_test, R0=1, a=0.5, B0=1, iota0=1) and the matching
+  !              analytic cylindrical tokamak provider for the full orbit
+  !              (orbit_full_tokamak, same equilibrium). No field file.
+  !   vmec     : BOOZER chart of the QA wout for GC/CPP. The full-orbit VMEC
+  !              curvilinear provider depends on libneo metric/Christoffel
+  !              (PR #322) and is not wired here, so the vmec case dumps GC and
+  !              CPP only.
+  !
+  ! Each model writes <outdir>/<case>_<model>.dat with columns
+  !   t   R   Z   Hrel   pphi   mu
+  ! where Hrel = H/H0 - 1, in R-Z [cm] for the figures (compare_gc_pauli.py).
+  !
+  ! Usage: ./diag_traj_models.x <analytic|vmec> <outdir> [nstep]
+  use, intrinsic :: iso_fortran_env, only: dp => real64
+  use util, only: twopi, c, p_mass, e_charge
+  use field_can_mod, only: field_can_t, field_can_from_name, evaluate, get_val, &
+      integ_to_ref
+  use orbit_symplectic, only: orbit_timestep_sympl, orbit_sympl_init
+  use orbit_symplectic_base, only: symplectic_integrator_t, GAUSS1
+  use orbit_cpp, only: orbit_timestep_cpp, orbit_cpp_init, cpp_stages_from_mode
+  use orbit_full, only: FullOrbitState, init_full_orbit_state, &
+      timestep_full_orbit, compute_energy, ORBIT_BORIS, COORD_CYL, FO_OK
+  use orbit_full_tokamak, only: tokamak_provider_t
+  use simple, only: tracer_t, init_sympl, init_params
+  use simple_main, only: init_field
+  use simple_coordinates, only: get_transform, transform_i
+  use params, only: isw_field_type, field_input, coord_input, integmode
+  use new_vmec_stuff_mod, only: rmajor
+  use magfie_sub, only: BOOZER
+
+  implicit none
+
+  character(64)  :: case_arg, nstep_arg
+  character(256) :: outdir
+  integer :: nargs, nstep
+  type(tracer_t) :: norb
+
+  nargs = command_argument_count()
+  if (nargs < 2) then
+    print *, 'Usage: ./diag_traj_models.x <analytic|vmec> <outdir> [nstep]'
+    error stop 1
+  end if
+  call get_command_argument(1, case_arg)
+  call get_command_argument(2, outdir)
+  nstep = 600
+  if (nargs >= 3) then
+    call get_command_argument(3, nstep_arg); read(nstep_arg, *) nstep
+  end if
+
+  select case (trim(case_arg))
+  case ('analytic')
+    call run_analytic(trim(outdir), nstep)
+  case ('vmec')
+    call run_vmec(norb, trim(outdir), nstep)
+  case default
+    print *, 'unknown case: ', trim(case_arg)
+    error stop 1
+  end select
+
+contains
+
+  ! Initialize GC on the analytic test chart with explicit Larmor scale ro0.
+  subroutine init_test_chart(si, f, z0, ro0_in, dt, ntau, rtol, mode)
+    type(symplectic_integrator_t), intent(inout) :: si
+    type(field_can_t), intent(inout) :: f
+    real(dp), intent(in) :: z0(5), ro0_in, dt, rtol
+    integer, intent(in) :: ntau, mode
+    real(dp) :: z(4)
+
+    call evaluate(f, z0(1), z0(2), z0(3), 0)
+    f%mu  = 0.5_dp*z0(4)**2*(1.0_dp - z0(5)**2)/f%Bmod*2.0_dp
+    f%ro0 = ro0_in
+    f%vpar = z0(4)*z0(5)*sqrt(2.0_dp)
+    z(1:3) = z0(1:3)
+    z(4)   = f%vpar*f%hph + f%Aph/f%ro0
+    call orbit_sympl_init(si, f, z, dt, ntau, rtol, mode)
+  end subroutine init_test_chart
+
+  subroutine run_analytic(outdir, nstep)
+    character(*), intent(in) :: outdir
+    integer, intent(in) :: nstep
+    real(dp), parameter :: R0 = 1.0_dp, a = 0.5_dp, B0 = 1.0_dp, iota0 = 1.0_dp
+    real(dp) :: z0(5), dt, rtol, ro0
+    integer :: s
+
+    call field_can_from_name('test')
+    if (.not. associated(evaluate)) error stop 'evaluate not associated (test)'
+
+    ! Trapped banana IC on the analytic chart: outer-mid-radius surface
+    ! (r=0.45 of a=0.5), small pitch, deeply trapped so the banana is stable
+    ! over the whole trace and wide enough to be visible.
+    z0   = [0.45_dp, 0.0_dp, 0.0_dp, 1.0_dp, 0.20_dp]
+    dt   = 2.0_dp
+    rtol = 1.0e-13_dp
+    ro0  = 1.0e-3_dp
+    s = cpp_stages_from_mode(GAUSS1)
+
+    call dump_gc_analytic(outdir, z0, ro0, dt, rtol, GAUSS1, nstep, R0)
+    call dump_cpp_analytic(outdir, z0, ro0, dt, rtol, GAUSS1, s, nstep, R0)
+    call dump_fullorbit_analytic(outdir, z0, ro0, dt, nstep, R0, a, B0, iota0)
+  end subroutine run_analytic
+
+  subroutine dump_gc_analytic(outdir, z0, ro0, dt, rtol, mode, nstep, R0)
+    character(*), intent(in) :: outdir
+    real(dp), intent(in) :: z0(5), ro0, dt, rtol, R0
+    integer, intent(in) :: mode, nstep
+    type(symplectic_integrator_t) :: si
+    type(field_can_t) :: f
+    integer :: it, ierr, u
+    real(dp) :: H0, t
+
+    call init_test_chart(si, f, z0, ro0, dt, 1, rtol, mode)
+    call get_val(f, si%z(4)); H0 = f%H
+    open(newunit=u, file=outdir//'/analytic_gc.dat', status='replace')
+    write(u, '(A)') '# t  R  Z  Hrel  pphi  mu'
+    call write_can_row(u, 0.0_dp, si%z, f%H, H0, si%z(4), f%mu, R0)
+    do it = 1, nstep
+      call orbit_timestep_sympl(si, f, ierr)
+      if (ierr /= 0) exit
+      call get_val(f, si%z(4))
+      t = it*dt
+      call write_can_row(u, t, si%z, f%H, H0, si%z(4), f%mu, R0)
+    end do
+    close(u)
+    print '(A,I0,A)', 'analytic GC: ', it-1, ' steps -> analytic_gc.dat'
+  end subroutine dump_gc_analytic
+
+  subroutine dump_cpp_analytic(outdir, z0, ro0, dt, rtol, mode, s, nstep, R0)
+    character(*), intent(in) :: outdir
+    real(dp), intent(in) :: z0(5), ro0, dt, rtol, R0
+    integer, intent(in) :: mode, s, nstep
+    type(symplectic_integrator_t) :: si
+    type(field_can_t) :: f
+    integer :: it, ierr, u
+    real(dp) :: H0, t
+
+    call init_test_chart(si, f, z0, ro0, dt, 1, rtol, mode)
+    call orbit_cpp_init(si, f)
+    call get_val(f, si%z(4)); H0 = f%H
+    open(newunit=u, file=outdir//'/analytic_cpp.dat', status='replace')
+    write(u, '(A)') '# t  R  Z  Hrel  pphi  mu'
+    call write_can_row(u, 0.0_dp, si%z, f%H, H0, si%z(4), f%mu, R0)
+    do it = 1, nstep
+      call orbit_timestep_cpp(si, f, s, ierr)
+      if (ierr /= 0) exit
+      call get_val(f, si%z(4))
+      t = it*dt
+      call write_can_row(u, t, si%z, f%H, H0, si%z(4), f%mu, R0)
+    end do
+    close(u)
+    print '(A,I0,A)', 'analytic CPP: ', it-1, ' steps -> analytic_cpp.dat'
+  end subroutine dump_cpp_analytic
+
+  ! Full orbit (Boris) on the matching analytic cylindrical tokamak. The IC is
+  ! placed at the banana's outer-midplane turning point with vpar from the same
+  ! pitch lambda, so the gyro-resolved orbit gyrates around the GC banana.
+  subroutine dump_fullorbit_analytic(outdir, z0, ro0, dt_gc, nstep, R0, a, B0, iota0)
+    character(*), intent(in) :: outdir
+    real(dp), intent(in) :: z0(5), ro0, dt_gc, R0, a, B0, iota0
+    integer, intent(in) :: nstep
+    type(tokamak_provider_t), target :: prov
+    type(FullOrbitState) :: st
+    real(dp) :: mass, charge, vtot, lambda, r_min, R, Z
+    real(dp) :: Bvec(3), Bmod, hcov(3), vpar, vperp
+    real(dp) :: u0(3), w0(3), b_hat(3), e1(3), e2(3)
+    real(dp) :: Omega, period, dt, t, H0
+    integer :: it, ierr, u, nsub, isub, ierrf, nout
+
+    prov%R0 = R0; prov%a = a; prov%B0 = B0; prov%iota0 = iota0
+
+    ! Physical scale: choose v0 so r_L/a = ro0 (matches GC ro0 = Larmor scale).
+    ! r_L = m c vperp/(q B0). Pick mass/charge of an alpha, derive v from ro0.
+    mass   = 4.0_dp * p_mass
+    charge = 2.0_dp * e_charge
+
+    r_min  = z0(1)              ! r is already the physical minor radius (<= a)
+    lambda = z0(5)
+    ! speed unit: r_L(at vperp=vtot) = ro0*a  =>  vtot = ro0*a*q*B0/(m c)
+    vtot   = ro0 * a * charge * B0 / (mass * c)
+    vpar   = lambda * vtot
+    vperp  = sqrt(max(vtot*vtot - vpar*vpar, 0.0_dp))
+
+    ! Start at outer midplane of the flux surface r_min: (R,Z) = (R0+r_min, 0).
+    R = R0 + r_min
+    Z = 0.0_dp
+    u0 = [R, 0.0_dp, Z]
+
+    call prov%eval_field(u0, Bvec, Bmod, hcov, ierrf)
+    if (ierrf /= FO_OK) then
+      print *, 'analytic full orbit: field eval failed at start'
+      return
+    end if
+    ! orthonormal field unit vector and a perpendicular basis (e1 in R-Z plane).
+    b_hat = Bvec / Bmod
+    e1 = [0.0_dp, 0.0_dp, 1.0_dp]                 ! e_Z (in poloidal plane)
+    e1 = e1 - dot_product(e1, b_hat)*b_hat
+    e1 = e1 / sqrt(dot_product(e1, e1))
+    e2 = cross(b_hat, e1)
+    ! orthonormal velocity, then contravariant (v^phi = v_phi^orth / R).
+    w0 = vpar*b_hat + vperp*e1
+    w0 = [w0(1), w0(2)/R, w0(3)]                  ! contravariant in (R,phi,Z)
+
+    Omega  = charge * Bmod / (mass * c)
+    period = twopi / Omega
+    ! resolve the gyration: many substeps per gyroperiod, dump per gyroperiod
+    ! sample so the output stride ~ matches the GC step count.
+    nsub   = 60
+    dt     = period / nsub
+    nout   = nstep                                 ! number of gyroperiods to dump
+
+    call init_full_orbit_state(st, u0, w0, ORBIT_BORIS, COORD_CYL, &
+                               mass, charge, dt, prov)
+    H0 = compute_energy(st)
+
+    open(newunit=u, file=outdir//'/analytic_fullorbit.dat', status='replace')
+    write(u, '(A)') '# t  R  Z  Hrel  pphi  mu'
+    t = 0.0_dp
+    call write_fo_row(u, t, st, H0)
+    do it = 1, nout
+      do isub = 1, nsub
+        call timestep_full_orbit(st, ierr)
+        if (ierr /= FO_OK) then
+          print '(A,I0)', 'analytic full orbit: stopped at gyroperiod ', it
+          close(u)
+          return
+        end if
+      end do
+      t = it*period
+      call write_fo_row(u, t, st, H0)
+    end do
+    close(u)
+    print '(A,I0,A)', 'analytic full orbit: ', nout, &
+        ' gyroperiods -> analytic_fullorbit.dat'
+  end subroutine dump_fullorbit_analytic
+
+  subroutine run_vmec(norb, outdir, nstep)
+    type(tracer_t), intent(inout) :: norb
+    character(*), intent(in) :: outdir
+    integer, intent(in) :: nstep
+    integer, parameter :: ans_s = 5, ans_tp = 5, amultharm = 5
+    real(dp) :: z0(5), dtau, rtol, rbig
+    integer :: s
+
+    isw_field_type = BOOZER
+    field_input = 'wout.nc'
+    coord_input = 'wout.nc'
+    call init_field(norb, 'wout.nc', ans_s, ans_tp, amultharm, GAUSS1)
+    call init_params(norb, 2, 4, 3.5e6_dp, 256, 1, 1.0e-12_dp)
+    if (.not. associated(evaluate)) error stop 'evaluate not associated (boozer)'
+
+    rbig = rmajor*1.0e2_dp
+    dtau = twopi*rbig/256.0_dp
+    rtol = 1.0e-13_dp
+    s = cpp_stages_from_mode(GAUSS1)
+    integmode = GAUSS1
+    norb%relerr = rtol
+
+    ! Trapped IC (small pitch) on a mid-radius surface.
+    z0 = [0.5_dp, 0.0_dp, 0.0_dp, 1.0_dp, 0.1_dp]
+
+    call dump_vmec_model(outdir, 'vmec_gc.dat',  z0, dtau, rtol, GAUSS1, s, nstep, .false.)
+    call dump_vmec_model(outdir, 'vmec_cpp.dat', z0, dtau, rtol, GAUSS1, s, nstep, .true.)
+  end subroutine run_vmec
+
+  subroutine dump_vmec_model(outdir, fname, z0, dtau, rtol, mode, s, nstep, use_cpp)
+    character(*), intent(in) :: outdir, fname
+    real(dp), intent(in) :: z0(5), dtau, rtol
+    integer, intent(in) :: mode, s, nstep
+    logical, intent(in) :: use_cpp
+    type(symplectic_integrator_t) :: si
+    type(field_can_t) :: f
+    procedure(transform_i), pointer :: integ2ref_cyl
+    real(dp) :: H0, t
+    integer :: it, ierr, u
+
+    call init_sympl(si, f, z0, dtau, dtau, rtol, mode)
+    if (use_cpp) call orbit_cpp_init(si, f)
+    integ2ref_cyl => get_transform('vmec', 'cyl')
+    call get_val(f, si%z(4)); H0 = f%H
+
+    open(newunit=u, file=outdir//'/'//fname, status='replace')
+    write(u, '(A)') '# t  R  Z  Hrel  pphi  mu'
+    call write_vmec_row(u, 0.0_dp, si%z, f%H, H0, si%z(4), f%mu, integ2ref_cyl)
+    do it = 1, nstep
+      if (use_cpp) then
+        call orbit_timestep_cpp(si, f, s, ierr)
+      else
+        call orbit_timestep_sympl(si, f, ierr)
+      end if
+      if (ierr /= 0) exit
+      call get_val(f, si%z(4))
+      t = it*dtau
+      call write_vmec_row(u, t, si%z, f%H, H0, si%z(4), f%mu, integ2ref_cyl)
+    end do
+    close(u)
+    print '(A,A,A,I0,A)', 'vmec ', trim(fname), ': ', it-1, ' steps'
+  end subroutine dump_vmec_model
+
+  ! --- row writers ---
+
+  ! Analytic test chart: the radial coordinate r is the minor-radius-like
+  ! variable used directly in field_can_test (0 <= r <= a = 0.5), so the
+  ! circular cross-section maps as R = R0 + r cos th, Z = r sin th.
+  subroutine write_can_row(u, t, z, H, H0, pphi, mu, R0)
+    integer, intent(in) :: u
+    real(dp), intent(in) :: t, z(4), H, H0, pphi, mu, R0
+    real(dp) :: Rc, Zc
+    Rc = R0 + z(1)*cos(z(2))
+    Zc = z(1)*sin(z(2))
+    write(u, '(6ES18.9)') t, Rc, Zc, H/H0 - 1.0_dp, pphi, mu
+  end subroutine write_can_row
+
+  ! VMEC BOOZER: integ -> ref (VMEC) -> cyl (R,phi,Z) [cm].
+  subroutine write_vmec_row(u, t, z, H, H0, pphi, mu, to_cyl)
+    integer, intent(in) :: u
+    real(dp), intent(in) :: t, z(4), H, H0, pphi, mu
+    procedure(transform_i), pointer, intent(in) :: to_cyl
+    real(dp) :: ref(3), cyl(3)
+    call integ_to_ref(z(1:3), ref)
+    call to_cyl(ref, cyl)
+    write(u, '(6ES18.9)') t, cyl(1), cyl(3), H/H0 - 1.0_dp, pphi, mu
+  end subroutine write_vmec_row
+
+  subroutine write_fo_row(u, t, st, H0)
+    integer, intent(in) :: u
+    real(dp), intent(in) :: t, H0
+    type(FullOrbitState), intent(in) :: st
+    real(dp) :: H
+    H = compute_energy(st)
+    ! pphi and mu not canonical here; report mu_full = m vperp^2/(2B), pphi=0.
+    write(u, '(6ES18.9)') t, st%z(1), st%z(3), H/H0 - 1.0_dp, 0.0_dp, st%mu
+  end subroutine write_fo_row
+
+  pure function cross(a, b) result(cc)
+    real(dp), intent(in) :: a(3), b(3)
+    real(dp) :: cc(3)
+    cc(1) = a(2)*b(3) - a(3)*b(2)
+    cc(2) = a(3)*b(1) - a(1)*b(3)
+    cc(3) = a(1)*b(2) - a(2)*b(1)
+  end function cross
+
+end program diag_traj_models

--- a/examples/compare_gc_pauli.py
+++ b/examples/compare_gc_pauli.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Banana-orbit cross-validation figures: GC vs CPP vs full orbit.
+
+Plotting-only harness for the figures of the full-orbit / CPP cross-validation
+suite. It runs the production trajectory dumper diag_traj_models.x (which traces
+ONE trapped banana with the real symplectic GC integrator, the CPP pusher, and
+the gyro-resolved Boris full orbit), reads its .dat output, and produces, per
+field case:
+
+  Panel A  R-Z poloidal projection of the banana, GC vs CPP vs full orbit
+           overlaid. GC traces the smooth banana, CPP overlaps GC, the full
+           orbit gyrates around it.
+  Panel B  conservation vs time: H(t)/H(0)-1, p_phi(t)-p_phi(0), mu(t)/mu(0).
+
+Field cases:
+  analytic  circular-tokamak "test" canonical chart (GC/CPP) and the matching
+            analytic cylindrical tokamak field (full orbit).
+  vmec      BOOZER chart of the QA wout (GC/CPP). The full-orbit VMEC
+            curvilinear path depends on libneo metric/Christoffel (PR #322) and
+            is not wired here, so the vmec full-orbit curve is omitted.
+
+PNGs are written to the output directory (default /tmp/crossval), four files:
+  {analytic,vmec}_rz_overlay.png and {analytic,vmec}_conservation.png
+
+Usage:
+  python examples/compare_gc_pauli.py [--build-dir build] [--outdir /tmp/crossval]
+                                      [--nstep-analytic 1500] [--nstep-vmec 2500]
+                                      [--no-run]
+"""
+import argparse
+import os
+import subprocess
+import sys
+
+import numpy as np
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+MODELS = ("gc", "cpp", "fullorbit")
+STYLE = {
+    "gc":        dict(color="tab:blue",   lw=2.2, ls="-",  label="GC (symplectic)"),
+    "cpp":       dict(color="tab:orange", lw=1.3, ls="--", label="CPP (Pauli)"),
+    "fullorbit": dict(color="tab:green",  lw=0.6, ls="-",  alpha=0.7,
+                      label="full orbit (Boris)"),
+}
+
+
+def load(outdir, case, model):
+    path = os.path.join(outdir, f"{case}_{model}.dat")
+    if not os.path.isfile(path):
+        return None
+    data = np.loadtxt(path)
+    if data.ndim == 1 or data.shape[0] < 2:
+        return None
+    return data  # columns: t R Z Hrel pphi mu
+
+
+def run_dumper(exe, case, outdir, nstep):
+    cmd = [exe, case, outdir, str(nstep)]
+    print("run:", " ".join(cmd))
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    sys.stdout.write(res.stdout)
+    if res.returncode != 0:
+        sys.stderr.write(res.stderr)
+        print(f"  WARNING: dumper exited {res.returncode} for case {case}")
+
+
+def plot_rz(outdir, case, title):
+    fig, ax = plt.subplots(figsize=(5.2, 6.0))
+    any_curve = False
+    for model in MODELS:
+        d = load(outdir, case, model)
+        if d is None:
+            continue
+        ax.plot(d[:, 1], d[:, 2], **STYLE[model])
+        any_curve = True
+    if not any_curve:
+        plt.close(fig)
+        return None
+    ax.set_xlabel("R")
+    ax.set_ylabel("Z")
+    ax.set_aspect("equal", adjustable="datalim")
+    ax.set_title(f"{title}\nbanana poloidal projection")
+    ax.legend(loc="best", fontsize=9)
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    out = os.path.join(outdir, f"{case}_rz_overlay.png")
+    fig.savefig(out, dpi=140)
+    plt.close(fig)
+    print("wrote", out)
+    return out
+
+
+def plot_conservation(outdir, case, title):
+    fig, axes = plt.subplots(3, 1, figsize=(7.0, 7.5), sharex=True)
+    hax, pax, max_ = axes
+    any_curve = False
+    for model in MODELS:
+        d = load(outdir, case, model)
+        if d is None:
+            continue
+        t = d[:, 0]
+        hax.plot(t, d[:, 3], **STYLE[model])
+        # p_phi is canonical only for GC/CPP; full orbit reports 0 -> skip.
+        if model != "fullorbit":
+            pax.plot(t, d[:, 4] - d[0, 4], **STYLE[model])
+        mu0 = d[0, 5]
+        if mu0 != 0.0:
+            max_.plot(t, d[:, 5] / mu0 - 1.0, **STYLE[model])
+        any_curve = True
+    if not any_curve:
+        plt.close(fig)
+        return None
+    hax.set_ylabel(r"$H/H_0 - 1$")
+    hax.set_title(f"{title}\ninvariant conservation vs time")
+    pax.set_ylabel(r"$p_\varphi(t) - p_\varphi(0)$")
+    max_.set_ylabel(r"$\mu/\mu_0 - 1$")
+    max_.set_xlabel("t")
+    for a in axes:
+        a.grid(True, alpha=0.3)
+        a.legend(loc="best", fontsize=8)
+    fig.tight_layout()
+    out = os.path.join(outdir, f"{case}_conservation.png")
+    fig.savefig(out, dpi=140)
+    plt.close(fig)
+    print("wrote", out)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--build-dir", default="build")
+    ap.add_argument("--outdir", default="/tmp/crossval")
+    ap.add_argument("--nstep-analytic", type=int, default=1500)
+    ap.add_argument("--nstep-vmec", type=int, default=2500)
+    ap.add_argument("--no-run", action="store_true",
+                    help="reuse existing .dat files, do not run the dumper")
+    args = ap.parse_args()
+
+    os.makedirs(args.outdir, exist_ok=True)
+    exe = os.path.join(args.build_dir, "diag_traj_models.x")
+
+    if not args.no_run:
+        if not os.path.isfile(exe):
+            sys.exit(f"dumper not found: {exe} (build with make CONFIG=Fast)")
+        run_dumper(exe, "analytic", args.outdir, args.nstep_analytic)
+        run_dumper(exe, "vmec", args.outdir, args.nstep_vmec)
+
+    produced = []
+    for case, title in (("analytic", "Analytic circular tokamak"),
+                        ("vmec", "VMEC QA stellarator")):
+        rz = plot_rz(args.outdir, case, title)
+        co = plot_conservation(args.outdir, case, title)
+        produced += [p for p in (rz, co) if p]
+
+    print("\nfigures:")
+    for p in produced:
+        print(" ", p)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,7 @@
     orbit_full_provider.f90
     orbit_full_mock_cart.f90
     orbit_full_mock_cyl.f90
+    orbit_full_tokamak.f90
     orbit_full.f90
     util.F90
     samplers.f90

--- a/src/orbit_full_tokamak.f90
+++ b/src/orbit_full_tokamak.f90
@@ -1,0 +1,138 @@
+module orbit_full_tokamak
+  ! Analytic axisymmetric circular-tokamak provider in cylindrical coordinates
+  ! u = (R, phi, Z), no libneo dependency. It realizes the SAME circular-tokamak
+  ! equilibrium as the field_can "test" canonical chart (field_can_test): major
+  ! radius R0, minor radius a, on-axis modulus B0, constant rotational transform
+  ! iota0. The full-orbit Boris pusher traces a real banana here that overlays
+  ! the GC/CPP banana from the test chart.
+  !
+  ! Geometry: r = sqrt((R-R0)^2 + Z^2), poloidal angle th = atan2(Z, R-R0).
+  ! Field in the orthonormal cylindrical frame (e_R, e_phi, e_Z):
+  !   B_phi  = B0 R0 / R                       (toroidal, 1/R)
+  !   B_pol  = B0 (r/R0) iota0                  along e_th = (-sin th, 0, cos th)
+  ! so |B| ~ B0 R0/R to leading order, matching the test chart's
+  ! Bmod = B0 (1 - r/R0 cos th) near the axis.
+  !
+  ! Metric is the cylindrical one (g = diag(1, R^2, 1)); the closed-form
+  ! Christoffel symbols are identical to orbit_full_mock_cyl.
+  use, intrinsic :: iso_fortran_env, only: dp => real64
+  use orbit_full_provider, only: field_metric_provider_t, FO_ERR_FIELD
+  implicit none
+  private
+  public :: tokamak_provider_t
+
+  type, extends(field_metric_provider_t), public :: tokamak_provider_t
+    real(dp) :: B0    = 1.0_dp
+    real(dp) :: R0    = 1.0_dp
+    real(dp) :: a     = 0.5_dp
+    real(dp) :: iota0 = 1.0_dp
+  contains
+    procedure :: eval_field     => tok_eval_field
+    procedure :: metric         => tok_metric
+    procedure :: christoffel    => tok_christoffel
+    procedure :: eval_canfield  => tok_eval_canfield
+    procedure :: eval_potential => tok_eval_potential
+  end type tokamak_provider_t
+
+contains
+
+  ! Bvec in the orthonormal cylindrical frame (e_R, e_phi, e_Z); hcov holds the
+  ! covariant unit-field components h_i = B_i/|B| (h_phi^cov = R * h_phi^orth).
+  subroutine tok_eval_field(self, x, Bvec, Bmod, hcov, ierr)
+    class(tokamak_provider_t), intent(in) :: self
+    real(dp), intent(in)  :: x(3)
+    real(dp), intent(out) :: Bvec(3), Bmod, hcov(3)
+    integer,  intent(out) :: ierr
+    real(dp) :: R, Z, dR, r_min, cth, sth, Btor, Bpol
+
+    R = x(1); Z = x(3)
+    if (R <= 0.0_dp) then
+      ierr = FO_ERR_FIELD
+      Bvec = 0.0_dp; Bmod = 0.0_dp; hcov = 0.0_dp
+      return
+    end if
+    ierr = 0
+    dR = R - self%R0
+    r_min = sqrt(dR*dR + Z*Z)
+    if (r_min > 0.0_dp) then
+      cth = dR / r_min
+      sth = Z / r_min
+    else
+      cth = 1.0_dp; sth = 0.0_dp
+    end if
+
+    Btor = self%B0 * self%R0 / R
+    Bpol = self%B0 * (r_min / self%R0) * self%iota0
+
+    ! e_th = (-sin th, 0, cos th) in (e_R, e_phi, e_Z)
+    Bvec(1) = -Bpol * sth
+    Bvec(2) =  Btor
+    Bvec(3) =  Bpol * cth
+
+    Bmod = sqrt(Bvec(1)**2 + Bvec(2)**2 + Bvec(3)**2)
+    if (Bmod <= 0.0_dp) then
+      ierr = FO_ERR_FIELD
+      hcov = 0.0_dp
+      return
+    end if
+    ! covariant unit-field: h_R = B_R/|B|, h_phi^cov = R*B_phi/|B|, h_Z = B_Z/|B|
+    hcov(1) = Bvec(1) / Bmod
+    hcov(2) = R * Bvec(2) / Bmod
+    hcov(3) = Bvec(3) / Bmod
+  end subroutine tok_eval_field
+
+  subroutine tok_metric(self, x, g, ginv, sqrtg)
+    class(tokamak_provider_t), intent(in) :: self
+    real(dp), intent(in)  :: x(3)
+    real(dp), intent(out) :: g(3,3), ginv(3,3), sqrtg
+    real(dp) :: R
+
+    R = x(1)
+    g = 0.0_dp; ginv = 0.0_dp
+    g(1,1) = 1.0_dp;  ginv(1,1) = 1.0_dp
+    g(2,2) = R*R;     ginv(2,2) = 1.0_dp/(R*R)
+    g(3,3) = 1.0_dp;  ginv(3,3) = 1.0_dp
+    sqrtg = R
+  end subroutine tok_metric
+
+  subroutine tok_christoffel(self, x, Gamma)
+    class(tokamak_provider_t), intent(in) :: self
+    real(dp), intent(in)  :: x(3)
+    real(dp), intent(out) :: Gamma(3,3,3)
+    real(dp) :: R
+
+    R = x(1)
+    Gamma = 0.0_dp
+    Gamma(1,2,2) = -R
+    Gamma(2,1,2) = 1.0_dp / R
+    Gamma(2,2,1) = 1.0_dp / R
+  end subroutine tok_christoffel
+
+  ! CPP/Pauli seam: not exercised here (CPP runs on field_can_test).
+  subroutine tok_eval_canfield(self, x, Ath, Aph, hth, hph, Bmod, &
+      dAth, dAph, dhth, dhph, dBmod, &
+      d2Ath, d2Aph, d2hth, d2hph, d2Bmod, ierr)
+    class(tokamak_provider_t), intent(in) :: self
+    real(dp), intent(in)  :: x(3)
+    real(dp), intent(out) :: Ath, Aph, hth, hph, Bmod
+    real(dp), intent(out) :: dAth(3), dAph(3), dhth(3), dhph(3), dBmod(3)
+    real(dp), intent(out) :: d2Ath(6), d2Aph(6), d2hth(6), d2hph(6), d2Bmod(6)
+    integer,  intent(out) :: ierr
+
+    Ath = 0.0_dp; Aph = 0.0_dp; hth = 0.0_dp; hph = 0.0_dp; Bmod = 0.0_dp
+    dAth = 0.0_dp; dAph = 0.0_dp; dhth = 0.0_dp; dhph = 0.0_dp; dBmod = 0.0_dp
+    d2Ath = 0.0_dp; d2Aph = 0.0_dp; d2hth = 0.0_dp; d2hph = 0.0_dp
+    d2Bmod = 0.0_dp
+    ierr = FO_ERR_FIELD
+  end subroutine tok_eval_canfield
+
+  subroutine tok_eval_potential(self, x, Phi, dPhi)
+    class(tokamak_provider_t), intent(in) :: self
+    real(dp), intent(in)  :: x(3)
+    real(dp), intent(out) :: Phi, dPhi(3)
+
+    Phi = 0.0_dp
+    dPhi = 0.0_dp
+  end subroutine tok_eval_potential
+
+end module orbit_full_tokamak

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -598,6 +598,16 @@ foreach(cpp_test test_cpp_equals_gc_largestep test_cpp_invariants)
     set_tests_properties(${cpp_test} PROPERTIES LABELS "integration" TIMEOUT 120)
 endforeach()
 
+# Three-system cross-validation (GC == CPP == gyro-averaged full orbit) on
+# analytic oracle fields only: no field file required.
+add_executable(test_cpp_gc_fullorbit_convergence.x
+    test_cpp_gc_fullorbit_convergence.f90)
+target_link_libraries(test_cpp_gc_fullorbit_convergence.x simple)
+add_test(NAME test_cpp_gc_fullorbit_convergence
+    COMMAND test_cpp_gc_fullorbit_convergence.x)
+set_tests_properties(test_cpp_gc_fullorbit_convergence
+    PROPERTIES LABELS "unit" TIMEOUT 120)
+
 add_executable(test_field_base.x test_field_base.f90)
 target_link_libraries(test_field_base.x simple)
 add_test(NAME test_field_base COMMAND test_field_base.x)

--- a/test/tests/test_cpp_gc_fullorbit_convergence.f90
+++ b/test/tests/test_cpp_gc_fullorbit_convergence.f90
@@ -1,0 +1,218 @@
+program test_cpp_gc_fullorbit_convergence
+  ! Three-system cross-validation on analytic oracle fields (no spline, no field
+  ! file): GC ~= CPP ~= gyro-averaged full orbit as rho* -> 0.
+  !
+  !   A. CPP == GC on the analytic circular-tokamak "test" canonical chart
+  !      (field_can_test, finite rotational transform iota0). The CPP Gauss
+  !      residual is the GC degenerate-Lagrangian system at fixed mu, so on the
+  !      same chart, same stage, same dt the 4D state agrees to Newton tolerance
+  !      (atol-level), independent of rho*. Checked across GAUSS1..GAUSS3 for a
+  !      trapped (banana) initial condition; p_phi conserved (axisymmetric).
+  !
+  !   B. GC == gyro-averaged full orbit as rho* -> 0 in the cylindrical 1/R mock
+  !      (closed-form curvature + grad-B drift). The Boris orbit averaged over a
+  !      bounce of one gyroperiod has a vertical drift speed; GC has the analytic
+  !      drift. The relative drift error scales linearly with rho* = r_L/R
+  !      (first-order GC accuracy): slope check across rho* in {1e-1,1e-2,1e-3}.
+  use, intrinsic :: iso_fortran_env, only: dp => real64
+  use util, only: c, twopi, pi, p_mass, e_charge
+  use field_can_mod, only: field_can_t, field_can_from_name, evaluate, get_val
+  use field_can_base, only: n_field_evaluations
+  use orbit_symplectic, only: orbit_timestep_sympl, orbit_sympl_init
+  use orbit_symplectic_base, only: symplectic_integrator_t, GAUSS1, GAUSS2, GAUSS3
+  use orbit_cpp, only: orbit_timestep_cpp, orbit_cpp_init, cpp_stages_from_mode
+  use orbit_full, only: FullOrbitState, init_full_orbit_state, &
+      timestep_full_orbit, convert_full_to_gc, ORBIT_BORIS, COORD_CYL, FO_OK
+  use orbit_full_mock_cyl, only: cylindrical_provider_t
+
+  implicit none
+
+  integer :: nfail
+  nfail = 0
+
+  ! Analytic circular-tokamak canonical chart: no field file required.
+  call field_can_from_name('test')
+  if (.not. associated(evaluate)) then
+    print *, 'evaluate pointer not associated for test chart'
+    error stop 1
+  end if
+
+  call test_cpp_equals_gc_analytic(GAUSS1, 'GAUSS1', nfail)
+  call test_cpp_equals_gc_analytic(GAUSS2, 'GAUSS2', nfail)
+  call test_cpp_equals_gc_analytic(GAUSS3, 'GAUSS3', nfail)
+  call test_gc_fullorbit_convergence(nfail)
+
+  if (nfail == 0) then
+    print *, 'ALL THREE-SYSTEM CONVERGENCE TESTS PASSED'
+  else
+    print *, 'THREE-SYSTEM CONVERGENCE TESTS FAILED: ', nfail
+    error stop 1
+  end if
+
+contains
+
+  ! Initialize a GC symplectic step on the test chart with an explicit Larmor
+  ! scale ro0 (rho*). Mirrors simple%init_sympl arithmetic but bypasses the
+  ! global ro0/rmu so the analytic chart needs no field file. z0 = (r,th,ph,p,la).
+  subroutine init_test_chart(si, f, z0, ro0_in, dt, ntau, rtol, mode)
+    type(symplectic_integrator_t), intent(inout) :: si
+    type(field_can_t), intent(inout) :: f
+    real(dp), intent(in) :: z0(5), ro0_in, dt, rtol
+    integer, intent(in) :: ntau, mode
+    real(dp) :: z(4)
+
+    call evaluate(f, z0(1), z0(2), z0(3), 0)
+    f%mu  = 0.5_dp*z0(4)**2*(1.0_dp - z0(5)**2)/f%Bmod*2.0_dp
+    f%ro0 = ro0_in
+    f%vpar = z0(4)*z0(5)*sqrt(2.0_dp)
+    z(1:3) = z0(1:3)
+    z(4)   = f%vpar*f%hph + f%Aph/f%ro0
+    call orbit_sympl_init(si, f, z, dt, ntau, rtol, mode)
+  end subroutine init_test_chart
+
+  ! A. CPP == GC on the analytic chart, plus banana confinement and p_phi
+  ! conservation. Trapped IC: small pitch so the particle mirrors.
+  subroutine test_cpp_equals_gc_analytic(mode, tag, nfail)
+    integer, intent(in) :: mode
+    character(*), intent(in) :: tag
+    integer, intent(inout) :: nfail
+
+    type(symplectic_integrator_t) :: si_gc, si_cpp
+    type(field_can_t) :: f_gc, f_cpp
+    real(dp) :: z0(5), dt, rtol, maxdiff, d, pphi0, pdev, rmin, rmax
+    integer :: it, ierr_gc, ierr_cpp, s, nstep
+
+    ! Trapped (banana) IC on the analytic chart: pitch lambda small.
+    z0 = [0.3_dp, 0.0_dp, 0.0_dp, 1.0_dp, 0.15_dp]
+    dt    = 2.0_dp
+    rtol  = 1.0e-13_dp
+    nstep = 400
+    s = cpp_stages_from_mode(mode)
+
+    call init_test_chart(si_gc,  f_gc,  z0, 1.0e-3_dp, dt, 1, rtol, mode)
+    call init_test_chart(si_cpp, f_cpp, z0, 1.0e-3_dp, dt, 1, rtol, mode)
+    call orbit_cpp_init(si_cpp, f_cpp)
+
+    pphi0 = si_gc%z(4); pdev = 0.0_dp
+    rmin = z0(1); rmax = z0(1)
+    maxdiff = 0.0_dp
+    do it = 1, nstep
+      call orbit_timestep_sympl(si_gc, f_gc, ierr_gc)
+      call orbit_timestep_cpp(si_cpp, f_cpp, s, ierr_cpp)
+      if (ierr_gc /= 0 .or. ierr_cpp /= 0) then
+        print '(A,A,A,I0,A,I0)', '  ', tag, ': early exit ierr_gc=', ierr_gc, &
+            ' ierr_cpp=', ierr_cpp
+        exit
+      end if
+      d = maxval(abs(si_cpp%z - si_gc%z))
+      maxdiff = max(maxdiff, d)
+      pdev = max(pdev, abs(si_gc%z(4) - pphi0))
+      rmin = min(rmin, si_gc%z(1)); rmax = max(rmax, si_gc%z(1))
+    end do
+
+    print '(A,A,A,ES12.4)', '  ', tag, ': max |z_CPP - z_GC| = ', maxdiff
+    print '(A,A,A,ES12.4,A,ES12.4)', '  ', tag, ': pphi excursion = ', pdev, &
+        '  banana radial width = ', rmax - rmin
+    call check(tag//': CPP == GC to Newton tol', maxdiff < 1.0e-10_dp, nfail)
+    ! Axisymmetric analytic chart: p_phi exactly conserved.
+    call check(tag//': p_phi conserved (axisymmetric)', pdev < 1.0e-10_dp, nfail)
+    ! Trapped particle: finite radial banana width, stays confined.
+    call check(tag//': trapped banana (finite width, confined)', &
+               (rmax - rmin) > 1.0e-4_dp .and. rmax < 0.5_dp, nfail)
+  end subroutine test_cpp_equals_gc_analytic
+
+  ! B. GC drift vs gyro-averaged Boris drift in the 1/R mock, O(rho*) slope.
+  ! GC analytic vertical drift speed (CGS) for the toroidal 1/R field at major
+  ! radius R: v_d = (m c)/(q B R) (vpar^2 + vperp^2/2). The Boris orbit drifts
+  ! at v_d + O(rho*) corrections; the relative error must fall ~ linearly in
+  ! rho* = r_L/R. GC reference is the same closed form (the test chart has no
+  ! 1/R cylindrical analogue, so the closed form is the GC oracle here).
+  subroutine test_gc_fullorbit_convergence(nfail)
+    integer, intent(inout) :: nfail
+    real(dp) :: rhostar(3), err(3)
+    integer :: k
+
+    rhostar = [1.0e-1_dp, 1.0e-2_dp, 1.0e-3_dp]
+    do k = 1, 3
+      err(k) = boris_drift_relerr(rhostar(k))
+      print '(A,ES10.2,A,ES12.4)', '  rho* = ', rhostar(k), &
+          '  full-orbit drift relerr vs GC = ', err(k)
+    end do
+
+    ! First-order GC: relerr ~ rho*. Each decade in rho* must cut the error by
+    ! at least ~5x (allowing geometric slack); and the smallest rho* must be
+    ! well below the largest.
+    call check('FO->GC drift error decreases with rho*', &
+               err(2) < 0.4_dp*err(1) .and. err(3) < 0.4_dp*err(2), nfail)
+    call check('FO->GC drift converges (relerr < 1% at rho*=1e-3)', &
+               err(3) < 1.0e-2_dp, nfail)
+  end subroutine test_gc_fullorbit_convergence
+
+  ! Run one Boris orbit in the 1/R cylindrical mock at a chosen rho* = r_L/R,
+  ! measure the gyro-averaged vertical (Z) drift speed, return its relative
+  ! error against the analytic GC drift. rho* is varied through B0 at fixed
+  ! velocities (r_L = m c vperp/(q B)).
+  function boris_drift_relerr(rhostar) result(relerr)
+    real(dp), intent(in) :: rhostar
+    real(dp) :: relerr
+    type(cylindrical_provider_t), target :: prov
+    type(FullOrbitState) :: st
+    real(dp) :: mass, charge, R0, R, vpar_in, vperp_in
+    real(dp) :: Bloc, B0, Omega, period, dt, vd_exact, vd_meas
+    real(dp) :: u0(3), w0(3), z0, t_total, rL
+    integer :: i, nstep_per, nper, nstep, ierr
+
+    mass    = 4.0_dp * p_mass
+    charge  = 2.0_dp * e_charge
+    R0      = 200.0_dp
+    R       = 200.0_dp
+    vpar_in  = 1.0d7
+    vperp_in = 1.0d6
+
+    ! rho* = r_L/R = m c vperp/(q B R)  =>  B = m c vperp/(q rho* R)
+    Bloc = mass * c * vperp_in / (charge * rhostar * R)
+    B0   = Bloc * R / R0
+    prov%B0 = B0
+    prov%R0 = R0
+
+    Omega  = charge * Bloc / (mass * c)
+    period = twopi / Omega
+    rL     = mass * c * vperp_in / (charge * Bloc)
+    nstep_per = 200
+    nper = 50
+    nstep = nstep_per * nper
+    dt = period / nstep_per
+
+    vd_exact = (mass * c) / (charge * Bloc * R) * &
+               (vpar_in**2 + 0.5_dp * vperp_in**2)
+
+    u0 = [R, 0.0_dp, 0.0_dp]
+    w0 = [vperp_in, vpar_in / R, 0.0_dp]
+    call init_full_orbit_state(st, u0, w0, ORBIT_BORIS, COORD_CYL, &
+                               mass, charge, dt, prov)
+    z0 = st%z(3)
+    do i = 1, nstep
+      call timestep_full_orbit(st, ierr)
+      if (ierr /= FO_OK) then
+        relerr = huge(1.0_dp)
+        return
+      end if
+    end do
+    t_total = nstep * dt
+    vd_meas = (st%z(3) - z0) / t_total
+    relerr = abs(vd_meas - vd_exact) / abs(vd_exact)
+  end function boris_drift_relerr
+
+  subroutine check(name, ok, nfail)
+    character(*), intent(in) :: name
+    logical, intent(in) :: ok
+    integer, intent(inout) :: nfail
+    if (ok) then
+      print '(A,A)', 'PASS  ', name
+    else
+      print '(A,A)', 'FAIL  ', name
+      nfail = nfail + 1
+    end if
+  end subroutine check
+
+end program test_cpp_gc_fullorbit_convergence


### PR DESCRIPTION
Stacked on `feature/full-orbit-cpp-symplectic` (PR-B core: CPP and full-orbit-symplectic pushers). This PR adds the acceptance cross-validation test and the banana-orbit figures.

## What this adds

- **Three-system convergence test** `test/tests/test_cpp_gc_fullorbit_convergence.f90` (no field file, analytic oracles only):
  - CPP == GC to Newton tolerance on the analytic circular-tokamak "test" canonical chart (`field_can_test`) across GAUSS1..3, with `p_phi` exactly conserved and a confined trapped banana.
  - full orbit -> GC drift error in the cylindrical 1/R mock falls with `rho*` (first-order GC accuracy), below 1% at `rho* = 1e-3`.
- **`src/orbit_full_tokamak.f90`**: analytic axisymmetric circular-tokamak provider (cylindrical), same equilibrium as `field_can_test`, so the Boris full orbit traces a real banana for the overlay.
- **`app/diag_traj_models.f90`**: trajectory dumper using the production GC, CPP, and Boris integrators; streams `t, R, Z, H/H0-1, p_phi, mu` for one trapped banana.
- **`examples/compare_gc_pauli.py`**: runs the dumper, writes the R-Z banana overlay and the conservation panels (matplotlib).

## Figures (litterbox, 72h)

Analytic circular tokamak (GC / CPP / full orbit overlaid):
- R-Z banana overlay: https://litter.catbox.moe/6he7kq.png
- conservation (H, p_phi, mu): https://litter.catbox.moe/x5mol0.png

Real QA VMEC (GC / CPP overlaid; see honesty note):
- R-Z banana overlay: https://litter.catbox.moe/8ye7bm.png
- conservation (H, p_phi, mu): https://litter.catbox.moe/d5g1tp.png

In the analytic overlay, CPP (orange dashed) lies exactly on the GC banana (blue), and the green Boris orbit gyrates around it. In the VMEC overlay, CPP overlaps GC to floating-point on a real banana of the QA equilibrium.

## Honesty notes

- The analytic R-Z overlay shows **real orbits from all three integrators**. GC and CPP run on the `field_can_test` canonical chart; the Boris full orbit runs on `orbit_full_tokamak`, an analytic cylindrical realization of the *same* circular-tokamak equilibrium (R0=1, a=0.5, B0=1, iota0=1). The two are the same physical equilibrium, not a shared spline, so the full orbit gyrates around the GC banana with a small banana-center offset rather than tracing it identically.
- The **VMEC case dumps GC and CPP only**. The full-orbit VMEC curvilinear path needs a concrete `field_metric_provider_t` over VMEC flux coordinates with metric/Christoffel from libneo PR #322 (`feature/metric-christoffel`); that provider is not wired in this branch, so the libneo FetchContent ref is left unchanged. The VMEC full-orbit overlay is therefore deferred until #322 is consumed. GC and CPP on the real QA equilibrium overlap to floating point and conserve `p_phi` to the quasi-axisymmetry floor.
- `mu` is plotted normalized to its initial value; GC/CPP and the full orbit use different `mu` normalizations, so the absolute scales differ while both are flat.

## Verification

Build (`make CONFIG=Fast`) succeeds. New + PR-B cross-validation tests:

```
$ ctest --test-dir build -R 'cpp|fo_symplectic|full_orbit|orbit_model_dispatch|convergence'
1/6 Test #28: test_full_orbit ...................   Passed    0.08 sec
2/6 Test #29: test_fo_symplectic ................   Passed    0.13 sec
3/6 Test #30: test_orbit_model_dispatch .........   Passed    0.06 sec
4/6 Test #31: test_cpp_equals_gc_largestep ......   Passed    2.35 sec
5/6 Test #32: test_cpp_invariants ...............   Passed    2.38 sec
6/6 Test #33: test_cpp_gc_fullorbit_convergence .   Passed    0.09 sec
100% tests passed, 0 tests failed out of 6
```

Convergence test detail:

```
  GAUSS1: max |z_CPP - z_GC| =   8.2334E-12
PASS  GAUSS1: CPP == GC to Newton tol
PASS  GAUSS1: p_phi conserved (axisymmetric)
PASS  GAUSS1: trapped banana (finite width, confined)
  ... GAUSS2, GAUSS3 likewise ...
  rho* =   1.00E-01  full-orbit drift relerr vs GC =   1.3226E-01
  rho* =   1.00E-02  full-orbit drift relerr vs GC =   3.3490E-02
  rho* =   1.00E-03  full-orbit drift relerr vs GC =   4.1675E-04
PASS  FO->GC drift error decreases with rho*
PASS  FO->GC drift converges (relerr < 1% at rho*=1e-3)
 ALL THREE-SYSTEM CONVERGENCE TESTS PASSED
```

Full unit suite (`ctest -L unit`): 22/22 passed, including `test_gpu_orbit_bench` unchanged.

Figures reproduced with:

```
python examples/compare_gc_pauli.py --build-dir build --outdir /tmp/crossval
```
