### PR TITLE
Reformat 31 files with fprettify (no semantic change)

### DIFF
--- a/app/simple_diag_meiss.f90
+++ b/app/simple_diag_meiss.f90
@@ -1,77 +1,77 @@
 program diag_meiss_main
 !> Diagnostic application for field_can_meiss analysis
-!> 
+!>
 !> Reads configuration from simple.in (default) or specified file,
 !> initializes the field, and generates diagnostic plots for canonical coordinates
 
 use params, only: read_config, netcdffile, ns_s, ns_tp, multharm, integmode, params_init, isw_field_type
-use simple, only: tracer_t, init_vmec
-use timing, only: init_timer, print_phase_time
-use diag_meiss, only: plot_rh_can_vs_rc
-use field_can_mod, only: field_can_from_id
-use field, only: field_from_file, vmec_field_t, create_vmec_field
-use field_can_meiss, only: init_transformation_arrays
+    use simple, only: tracer_t, init_vmec
+    use timing, only: init_timer, print_phase_time
+    use diag_meiss, only: plot_rh_can_vs_rc
+    use field_can_mod, only: field_can_from_id
+    use field, only: field_from_file, vmec_field_t, create_vmec_field
+    use field_can_meiss, only: init_transformation_arrays
 
-implicit none
+    implicit none
 
-character(256) :: config_file
-type(tracer_t) :: norb
-type(vmec_field_t) :: vmec_field
+    character(256) :: config_file
+    type(tracer_t) :: norb
+    type(vmec_field_t) :: vmec_field
 
 ! Initialize timing
-call init_timer()
+    call init_timer()
 
 ! Read configuration file name from command line arguments
-if (command_argument_count() == 0) then
-    config_file = 'simple.in'
-else
-    call get_command_argument(1, config_file)
-end if
-call print_phase_time('Command line parsing completed')
+    if (command_argument_count() == 0) then
+        config_file = 'simple.in'
+    else
+        call get_command_argument(1, config_file)
+    end if
+    call print_phase_time('Command line parsing completed')
 
 ! Initialize the system following simple.x pattern BUT stop before init_field_can
-call read_config(config_file)
-call print_phase_time('Configuration reading completed')
+    call read_config(config_file)
+    call print_phase_time('Configuration reading completed')
 
 ! Call init_vmec directly (like init_field does) but skip init_field_can
-call init_vmec(netcdffile, ns_s, ns_tp, multharm, norb%fper)
-call print_phase_time('VMEC initialization completed')
+    call init_vmec(netcdffile, ns_s, ns_tp, multharm, norb%fper)
+    call print_phase_time('VMEC initialization completed')
 
-norb%integmode = integmode
-call print_phase_time('Integration mode set')
+    norb%integmode = integmode
+    call print_phase_time('Integration mode set')
 
 ! Initialize field_can system up to the point before expensive computation
-if (norb%integmode >= 0) then
-    call create_vmec_field(vmec_field)
-    call field_can_from_id(isw_field_type, vmec_field)
-    call print_phase_time('Field canonical setup completed')
-    
-    ! Initialize only the transformation arrays (without expensive computation)
-    call init_transformation_arrays()
-    call print_phase_time('Transformation arrays initialized')
-end if
+    if (norb%integmode >= 0) then
+        call create_vmec_field(vmec_field)
+        call field_can_from_id(isw_field_type, vmec_field)
+        call print_phase_time('Field canonical setup completed')
 
-call params_init
-call print_phase_time('Parameter initialization completed')
+        ! Initialize only the transformation arrays (without expensive computation)
+        call init_transformation_arrays()
+        call print_phase_time('Transformation arrays initialized')
+    end if
 
-print *, "Generating diagnostic plots..."
+    call params_init
+    call print_phase_time('Parameter initialization completed')
+
+    print *, "Generating diagnostic plots..."
 
 ! Generate plots for different grid indices
-print *, "Creating plot for i_th=1, i_phi=1..."
-call plot_rh_can_vs_rc(1, 1, "diag_meiss_1_1.pdf")
+    print *, "Creating plot for i_th=1, i_phi=1..."
+    call plot_rh_can_vs_rc(1, 1, "diag_meiss_1_1.pdf")
 
-print *, "Creating plot for i_th=2, i_phi=2..."  
-call plot_rh_can_vs_rc(1, 2, "diag_meiss_1_2.pdf")
+    print *, "Creating plot for i_th=2, i_phi=2..."
+    call plot_rh_can_vs_rc(1, 2, "diag_meiss_1_2.pdf")
 
-print *, "Creating plot for i_th=2, i_phi=2..."  
-call plot_rh_can_vs_rc(2, 1, "diag_meiss_2_1.pdf")
+    print *, "Creating plot for i_th=2, i_phi=2..."
+    call plot_rh_can_vs_rc(2, 1, "diag_meiss_2_1.pdf")
 
-print *, "Creating plot for i_th=2, i_phi=2..."
-call plot_rh_can_vs_rc(2, 2, "diag_meiss_2_2.pdf")
+    print *, "Creating plot for i_th=2, i_phi=2..."
+    call plot_rh_can_vs_rc(2, 2, "diag_meiss_2_2.pdf")
 
-print *, "Diagnostic plots completed successfully!"
-print *, "Generated files: diag_meiss.pdf, diag_meiss_1_1.pdf, diag_meiss_2_2.pdf"
+    print *, "Diagnostic plots completed successfully!"
+    print *, "Generated files: diag_meiss.pdf, diag_meiss_1_1.pdf, diag_meiss_2_2.pdf"
 
-call print_phase_time('Diagnostic analysis completed')
+    call print_phase_time('Diagnostic analysis completed')
 
 end program diag_meiss_main

--- a/app/simple_diag_orbit.f90
+++ b/app/simple_diag_orbit.f90
@@ -1,142 +1,142 @@
 program diag_orbit_main
 !> Diagnostic application for orbit trajectory analysis
-!> 
+!>
 !> Reads configuration from simple.in (default) or specified file,
 !> validates the integration setup, initializes the field exactly like simple.x,
 !> and provides detailed orbit trajectory plotting for the Nth particle
 
-use params, only: read_config, netcdffile, ns_s, ns_tp, multharm, &
-    integmode, params_init, isw_field_type, dtaumin, relerr, ntestpart, ntimstep, ntau, &
-    zstart, startmode, grid_density, special_ants_file, reuse_batch, num_surf, sbeg
-use simple, only: tracer_t, init_sympl
-use simple_main, only: init_field
-use magfie_sub, only: init_magfie, VMEC
-use samplers, only: init_starting_surf, sample, START_FILE
-use timing, only: init_timer, print_phase_time
-use diag_orbit, only: integrate_orbit_with_trajectory_debug
-use orbit_symplectic_base, only: symplectic_integrator_t
-use field_can_mod, only: field_can_t, get_val, eval_field => evaluate
+    use params, only: read_config, netcdffile, ns_s, ns_tp, multharm, &
+   integmode, params_init, isw_field_type, dtaumin, relerr, ntestpart, ntimstep, ntau, &
+         zstart, startmode, grid_density, special_ants_file, reuse_batch, num_surf, sbeg
+    use simple, only: tracer_t, init_sympl
+    use simple_main, only: init_field
+    use magfie_sub, only: init_magfie, VMEC
+    use samplers, only: init_starting_surf, sample, START_FILE
+    use timing, only: init_timer, print_phase_time
+    use diag_orbit, only: integrate_orbit_with_trajectory_debug
+    use orbit_symplectic_base, only: symplectic_integrator_t
+    use field_can_mod, only: field_can_t, get_val, eval_field => evaluate
 
-implicit none
+    implicit none
 
-character(256) :: config_file, particle_arg
-type(tracer_t) :: norb
-type(symplectic_integrator_t) :: si
-type(field_can_t) :: field_can
-integer :: particle_number
+    character(256) :: config_file, particle_arg
+    type(tracer_t) :: norb
+    type(symplectic_integrator_t) :: si
+    type(field_can_t) :: field_can
+    integer :: particle_number
 
 ! Initialize timing
-call init_timer()
+    call init_timer()
 
 ! Read configuration file name from command line arguments
-if (command_argument_count() == 0) then
-    config_file = 'simple.in'
-    particle_number = 1  ! Default to first particle
-elseif (command_argument_count() == 1) then
-    call get_command_argument(1, particle_arg)
-    read(particle_arg, *) particle_number
-    config_file = 'simple.in'
-elseif (command_argument_count() == 2) then
-    call get_command_argument(1, config_file)
-    call get_command_argument(2, particle_arg)
-    read(particle_arg, *) particle_number
-else
-    print *, 'Usage: ./diag_orbit.x [config_file] [particle_number]'
-    print *, '  or:  ./diag_orbit.x [particle_number]'
-    print *, 'Example: ./diag_orbit.x simple.in 2'
-    print *, '         ./diag_orbit.x 3'
-    stop
-end if
-call print_phase_time('Command line parsing completed')
+    if (command_argument_count() == 0) then
+        config_file = 'simple.in'
+        particle_number = 1  ! Default to first particle
+    elseif (command_argument_count() == 1) then
+        call get_command_argument(1, particle_arg)
+        read (particle_arg, *) particle_number
+        config_file = 'simple.in'
+    elseif (command_argument_count() == 2) then
+        call get_command_argument(1, config_file)
+        call get_command_argument(2, particle_arg)
+        read (particle_arg, *) particle_number
+    else
+        print *, 'Usage: ./diag_orbit.x [config_file] [particle_number]'
+        print *, '  or:  ./diag_orbit.x [particle_number]'
+        print *, 'Example: ./diag_orbit.x simple.in 2'
+        print *, '         ./diag_orbit.x 3'
+        stop
+    end if
+    call print_phase_time('Command line parsing completed')
 
 ! Initialize the system following simple.x pattern
-call read_config(config_file)
-call print_phase_time('Configuration reading completed')
+    call read_config(config_file)
+    call print_phase_time('Configuration reading completed')
 
 ! Validate particle number against ntestpart
-if (particle_number < 1 .or. particle_number > ntestpart) then
-    print *, 'ERROR: Invalid particle number!'
-    print '(A,I0)', 'Requested particle: ', particle_number
-    print '(A,I0)', 'Available particles (ntestpart): ', ntestpart
-    print *, 'Please adjust particle number or ntestpart in config file.'
-    error stop 'Invalid particle number for orbit trajectory diagnostic'
-end if
-call print_phase_time('Particle number validation completed')
+    if (particle_number < 1 .or. particle_number > ntestpart) then
+        print *, 'ERROR: Invalid particle number!'
+        print '(A,I0)', 'Requested particle: ', particle_number
+        print '(A,I0)', 'Available particles (ntestpart): ', ntestpart
+        print *, 'Please adjust particle number or ntestpart in config file.'
+        error stop 'Invalid particle number for orbit trajectory diagnostic'
+    end if
+    call print_phase_time('Particle number validation completed')
 
 ! Use the complete field initialization from simple_main
-call init_field(norb, netcdffile, ns_s, ns_tp, multharm, integmode)
-call print_phase_time('Complete field initialization completed')
+    call init_field(norb, netcdffile, ns_s, ns_tp, multharm, integmode)
+    call print_phase_time('Complete field initialization completed')
 
-call params_init
-call print_phase_time('Parameter initialization completed')
+    call params_init
+    call print_phase_time('Parameter initialization completed')
 
 ! Initialize VMEC magnetic field (required for sampling)
-call init_magfie(VMEC)
-call print_phase_time('VMEC magnetic field initialization completed')
+    call init_magfie(VMEC)
+    call print_phase_time('VMEC magnetic field initialization completed')
 
 ! Initialize starting surfaces (required before sampling)
-call init_starting_surf
-call print_phase_time('Starting surface initialization completed')
+    call init_starting_surf
+    call print_phase_time('Starting surface initialization completed')
 
 ! Perform particle sampling exactly like simple_main.f90
-if (1 == startmode) then
-    if ((0d0 < grid_density) .and. (1d0 > grid_density)) then
-        call sample(zstart, grid_density)
+    if (1 == startmode) then
+        if ((0d0 < grid_density) .and. (1d0 > grid_density)) then
+            call sample(zstart, grid_density)
+        else
+            call sample(zstart)
+        end if
+    elseif (2 == startmode) then
+        call sample(zstart, START_FILE)
+    elseif (3 == startmode) then
+        call sample(special_ants_file)
+    elseif (4 == startmode) then
+        call sample(zstart, reuse_batch)
+    elseif (5 == startmode) then
+        if (0 == num_surf) then
+            call sample(zstart, 0.0d0, 1.0d0)
+        elseif (1 == num_surf) then
+            call sample(zstart, 0.0d0, sbeg(1))
+        elseif (2 == num_surf) then
+            call sample(zstart, sbeg(1), sbeg(num_surf))
+        else
+            print *, 'Invalid surface range for volume sample defined.'
+            error stop 'Invalid surface range for volume sample'
+        end if
     else
-        call sample(zstart)
-    endif
-elseif (2 == startmode) then
-    call sample(zstart, START_FILE)
-elseif (3 == startmode) then
-    call sample(special_ants_file)
-elseif (4 == startmode) then
-    call sample(zstart, reuse_batch)
-elseif (5 == startmode) then
-    if (0 == num_surf) then
-        call sample(zstart, 0.0d0, 1.0d0)
-    elseif (1 == num_surf) then
-        call sample(zstart, 0.0d0, sbeg(1))
-    elseif (2 == num_surf) then
-        call sample(zstart, sbeg(1), sbeg(num_surf))
-    else
-        print *, 'Invalid surface range for volume sample defined.'
-        error stop 'Invalid surface range for volume sample'
-    endif
-else
-    print *, 'Invalid startmode: ', startmode
-    error stop 'Invalid startmode'
-endif
-call print_phase_time('Particle sampling completed')
+        print *, 'Invalid startmode: ', startmode
+        error stop 'Invalid startmode'
+    end if
+    call print_phase_time('Particle sampling completed')
 
-print *, "Orbit Trajectory Diagnostic Program"
-print *, "==================================="
-print *
-print *, "This program provides detailed orbit trajectory plotting"
-print *, "for individual particles using real physics integration."
-print *
-print '(A,A)', "Configuration file: ", trim(config_file)
-print '(A,I0,A,I0)', "Selected particle: ", particle_number, " out of ", ntestpart
-print '(A,I0)', "Field type (isw_field_type): ", isw_field_type
-print '(A,I0)', "Integration mode: ", integmode
+    print *, "Orbit Trajectory Diagnostic Program"
+    print *, "==================================="
+    print *
+    print *, "This program provides detailed orbit trajectory plotting"
+    print *, "for individual particles using real physics integration."
+    print *
+    print '(A,A)', "Configuration file: ", trim(config_file)
+    print '(A,I0,A,I0)', "Selected particle: ", particle_number, " out of ", ntestpart
+    print '(A,I0)', "Field type (isw_field_type): ", isw_field_type
+    print '(A,I0)', "Integration mode: ", integmode
 print '(A,I0,A,I0,A,I0,A)', "Integration: ", ntimstep, " macrosteps × ", ntau, " substeps = ", ntimstep*ntau, " total timesteps"
-print *
+    print *
 
-print '(A,ES12.5)', 'dtaumin (integration time step): ', dtaumin
-print '(A,I0)', 'ntau (substeps per dtau): ', ntau
-print '(A,ES12.5)', 'Relative tolerance: ', relerr
-print *
+    print '(A,ES12.5)', 'dtaumin (integration time step): ', dtaumin
+    print '(A,I0)', 'ntau (substeps per dtau): ', ntau
+    print '(A,ES12.5)', 'Relative tolerance: ', relerr
+    print *
 
 ! NOTE: Symplectic integrator initialization happens per-particle in integrate_orbit_with_trajectory_debug
 ! following the exact same sequence as simple_main.f90 trace_orbit()
 
 ! Perform orbit trajectory diagnostic integration
-call integrate_orbit_with_trajectory_debug(si, field_can, particle_number)
+    call integrate_orbit_with_trajectory_debug(si, field_can, particle_number)
 
-call print_phase_time('Orbit trajectory diagnostic analysis completed')
+    call print_phase_time('Orbit trajectory diagnostic analysis completed')
 
-print *
-print *, "Orbit Trajectory Diagnostic completed successfully!"
-print *, "Generated detailed trajectory plots showing real particle"
-print *, "motion in the magnetic field using symplectic integration."
+    print *
+    print *, "Orbit Trajectory Diagnostic completed successfully!"
+    print *, "Generated detailed trajectory plots showing real particle"
+    print *, "motion in the magnetic field using symplectic integration."
 
 end program diag_orbit_main

--- a/app/simple_diag_traj.f90
+++ b/app/simple_diag_traj.f90
@@ -9,114 +9,114 @@ program diag_traj_main
 !>
 !> Usage: ./diag_traj.x [config_file] particle_number [stride]
 
-use, intrinsic :: iso_fortran_env, only: dp => real64
-use params, only: read_config, netcdffile, ns_s, ns_tp, multharm, integmode, &
-    params_init, dtaumin, relerr, ntestpart, zstart, startmode, grid_density, &
-    special_ants_file, reuse_batch, num_surf, sbeg, trace_time, v0
-use simple, only: tracer_t, init_sympl
-use simple_main, only: init_field
-use magfie_sub, only: init_magfie, VMEC
-use samplers, only: init_starting_surf, sample, START_FILE
-use field_can_mod, only: field_can_t, get_val, eval_field => evaluate, ref_to_integ
-use orbit_symplectic, only: orbit_timestep_sympl
-use orbit_symplectic_base, only: symplectic_integrator_t
-use alpha_lifetime_sub, only: orbit_timestep_axis
-use diag_counters, only: diag_counters_init, diag_counters_reset, &
-    diag_counters_total, EVT_R_NEGATIVE
-use util, only: twopi
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use params, only: read_config, netcdffile, ns_s, ns_tp, multharm, integmode, &
+             params_init, dtaumin, relerr, ntestpart, zstart, startmode, grid_density, &
+                      special_ants_file, reuse_batch, num_surf, sbeg, trace_time, v0
+    use simple, only: tracer_t, init_sympl
+    use simple_main, only: init_field
+    use magfie_sub, only: init_magfie, VMEC
+    use samplers, only: init_starting_surf, sample, START_FILE
+    use field_can_mod, only: field_can_t, get_val, eval_field => evaluate, ref_to_integ
+    use orbit_symplectic, only: orbit_timestep_sympl
+    use orbit_symplectic_base, only: symplectic_integrator_t
+    use alpha_lifetime_sub, only: orbit_timestep_axis
+    use diag_counters, only: diag_counters_init, diag_counters_reset, &
+                             diag_counters_total, EVT_R_NEGATIVE
+    use util, only: twopi
 
-implicit none
+    implicit none
 
-character(256) :: config_file, arg
-type(tracer_t) :: norb
-type(symplectic_integrator_t) :: si
-type(field_can_t) :: f
-integer :: pnum, stride, nargs
-real(dp), dimension(5) :: z
-real(dp) :: t, s, smin, H
-integer(8) :: kt
-integer :: ierr, unit
-character(64) :: fname
+    character(256) :: config_file, arg
+    type(tracer_t) :: norb
+    type(symplectic_integrator_t) :: si
+    type(field_can_t) :: f
+    integer :: pnum, stride, nargs
+    real(dp), dimension(5) :: z
+    real(dp) :: t, s, smin, H
+    integer(8) :: kt
+    integer :: ierr, unit
+    character(64) :: fname
 
-config_file = 'simple.in'
-stride = 1
-nargs = command_argument_count()
-if (nargs == 1) then
-    call get_command_argument(1, arg); read(arg,*) pnum
-elseif (nargs == 2) then
-    call get_command_argument(1, arg)
-    ! second arg is either config (non-numeric) or stride; assume "pnum stride"
-    read(arg,*) pnum
-    call get_command_argument(2, arg); read(arg,*) stride
-elseif (nargs == 3) then
-    call get_command_argument(1, config_file)
-    call get_command_argument(2, arg); read(arg,*) pnum
-    call get_command_argument(3, arg); read(arg,*) stride
-else
-    print *, 'Usage: ./diag_traj.x [config] particle_number [stride]'
-    stop
-end if
-
-call read_config(config_file)
-call init_field(norb, netcdffile, ns_s, ns_tp, multharm, integmode)
-call params_init
-call init_magfie(VMEC)
-call init_starting_surf
-if (startmode == 2) then
-    call sample(zstart, START_FILE)
-elseif (startmode == 5) then
-    if (num_surf == 1) then
-        call sample(zstart, 0.0d0, sbeg(1))
+    config_file = 'simple.in'
+    stride = 1
+    nargs = command_argument_count()
+    if (nargs == 1) then
+        call get_command_argument(1, arg); read (arg, *) pnum
+    elseif (nargs == 2) then
+        call get_command_argument(1, arg)
+        ! second arg is either config (non-numeric) or stride; assume "pnum stride"
+        read (arg, *) pnum
+        call get_command_argument(2, arg); read (arg, *) stride
+    elseif (nargs == 3) then
+        call get_command_argument(1, config_file)
+        call get_command_argument(2, arg); read (arg, *) pnum
+        call get_command_argument(3, arg); read (arg, *) stride
     else
-        call sample(zstart, sbeg(1), sbeg(num_surf))
+        print *, 'Usage: ./diag_traj.x [config] particle_number [stride]'
+        stop
     end if
-else
-    call sample(zstart, START_FILE)
-end if
 
-if (pnum < 1 .or. pnum > ntestpart) then
-    print *, 'particle out of range', pnum, ntestpart; error stop
-end if
-
-call diag_counters_init()
-call diag_counters_reset()
-
-call ref_to_integ(zstart(1:3, pnum), z(1:3))
-z(4:5) = zstart(4:5, pnum)
-if (integmode > 0) call init_sympl(si, f, z, dtaumin, dtaumin, relerr, integmode)
-
-write(fname, '(A,I0,A,I0,A)') 'traj_p', pnum, '_im', integmode, '.dat'
-open(newunit=unit, file=trim(fname), status='replace')
-write(unit, '(A)') '# t[s]    s    theta    phi    pphi/z4    H'
-
-kt = 0; t = 0.0_dp; smin = z(1); ierr = 0
-do
-    if (integmode <= 0) then
-        call orbit_timestep_axis(z, dtaumin, dtaumin, relerr, ierr)
-        s = z(1)
-        H = -1.0_dp
+    call read_config(config_file)
+    call init_field(norb, netcdffile, ns_s, ns_tp, multharm, integmode)
+    call params_init
+    call init_magfie(VMEC)
+    call init_starting_surf
+    if (startmode == 2) then
+        call sample(zstart, START_FILE)
+    elseif (startmode == 5) then
+        if (num_surf == 1) then
+            call sample(zstart, 0.0d0, sbeg(1))
+        else
+            call sample(zstart, sbeg(1), sbeg(num_surf))
+        end if
     else
-        call orbit_timestep_sympl(si, f, ierr)
-        z(1:4) = si%z
-        s = si%z(1)
-        call get_val(f, si%z(4))
-        H = f%H
+        call sample(zstart, START_FILE)
     end if
-    kt = kt + 1
-    t = kt*dtaumin/v0
-    smin = min(smin, s)
-    if (mod(kt, int(stride,8)) == 0_8 .or. ierr /= 0) then
-        write(unit, '(6ES16.8)') t, s, mod(z(2), twopi), mod(z(3), twopi), z(4), H
-    end if
-    if (ierr /= 0) exit
-    if (t >= trace_time) exit
-end do
-close(unit)
 
-print '(A,I0,A,I0)', 'particle ', pnum, '  integmode ', integmode
-print '(A,L1,A,ES12.5)', 'lost = ', (ierr /= 0), '   t_end[s] = ', t
-print '(A,ES12.5)', 'min(s) reached       = ', smin
-print '(A,I0)',     'axis crossings (R<0) = ', int(diag_counters_total(EVT_R_NEGATIVE))
-print '(A,A)',      'trajectory written   : ', trim(fname)
+    if (pnum < 1 .or. pnum > ntestpart) then
+        print *, 'particle out of range', pnum, ntestpart; error stop
+    end if
+
+    call diag_counters_init()
+    call diag_counters_reset()
+
+    call ref_to_integ(zstart(1:3, pnum), z(1:3))
+    z(4:5) = zstart(4:5, pnum)
+    if (integmode > 0) call init_sympl(si, f, z, dtaumin, dtaumin, relerr, integmode)
+
+    write (fname, '(A,I0,A,I0,A)') 'traj_p', pnum, '_im', integmode, '.dat'
+    open (newunit=unit, file=trim(fname), status='replace')
+    write (unit, '(A)') '# t[s]    s    theta    phi    pphi/z4    H'
+
+    kt = 0; t = 0.0_dp; smin = z(1); ierr = 0
+    do
+        if (integmode <= 0) then
+            call orbit_timestep_axis(z, dtaumin, dtaumin, relerr, ierr)
+            s = z(1)
+            H = -1.0_dp
+        else
+            call orbit_timestep_sympl(si, f, ierr)
+            z(1:4) = si%z
+            s = si%z(1)
+            call get_val(f, si%z(4))
+            H = f%H
+        end if
+        kt = kt + 1
+        t = kt*dtaumin/v0
+        smin = min(smin, s)
+        if (mod(kt, int(stride, 8)) == 0_8 .or. ierr /= 0) then
+            write (unit, '(6ES16.8)') t, s, mod(z(2), twopi), mod(z(3), twopi), z(4), H
+        end if
+        if (ierr /= 0) exit
+        if (t >= trace_time) exit
+    end do
+    close (unit)
+
+    print '(A,I0,A,I0)', 'particle ', pnum, '  integmode ', integmode
+    print '(A,L1,A,ES12.5)', 'lost = ', (ierr /= 0), '   t_end[s] = ', t
+    print '(A,ES12.5)', 'min(s) reached       = ', smin
+    print '(A,I0)', 'axis crossings (R<0) = ', int(diag_counters_total(EVT_R_NEGATIVE))
+    print '(A,A)', 'trajectory written   : ', trim(fname)
 
 end program diag_traj_main

--- a/examples/fortran/orbit_symplectic_test.f90
+++ b/examples/fortran/orbit_symplectic_test.f90
@@ -1,50 +1,50 @@
 program orbit_symplectic_test
 
-use field_can_mod, only: eval_field
-use diag_mod, only : icounter
+    use field_can_mod, only: eval_field
+    use diag_mod, only: icounter
 
-use orbit_symplectic, only: orbit_sympl_init, orbit_timestep_sympl, &
-  mu, ro0, f, df, d2f, z, pth, ntau
+    use orbit_symplectic, only: orbit_sympl_init, orbit_timestep_sympl, &
+                                mu, ro0, f, df, d2f, z, pth, ntau
 
-implicit none
+    implicit none
 
-integer, parameter :: n = 6
+    integer, parameter :: n = 6
 
-double precision :: dt0, vpar
-double precision, dimension(6) :: z0, fvec
-integer :: info
+    double precision :: dt0, vpar
+    double precision, dimension(6) :: z0, fvec
+    integer :: info
 
-integer :: k
+    integer :: k
 
-integer :: nts = 1000
-integer :: kwrite = 1
+    integer :: nts = 1000
+    integer :: kwrite = 1
 
-ntau = 1
+    ntau = 1
 
-mu = 0.1d0
-ro0 = 1d0
-dt0 = 0.5*0.13*dsqrt(2d0)
+    mu = 0.1d0
+    ro0 = 1d0
+    dt0 = 0.5*0.13*dsqrt(2d0)
 
-z(1) = 0.3d0
-z(2) = 1.5d0
-z(3) = 0.0d0
+    z(1) = 0.3d0
+    z(2) = 1.5d0
+    z(3) = 0.0d0
 
-vpar = 0.1d0
-call eval_field(z(1), z(2), z(3), 0)
-z(4) = vpar*f%hph + f%Aph/ro0
-pth = vpar*f%hth + f%Ath/ro0
+    vpar = 0.1d0
+    call eval_field(z(1), z(2), z(3), 0)
+    z(4) = vpar*f%hph + f%Aph/ro0
+    pth = vpar*f%hth + f%Ath/ro0
 
-z0 = 0d0
-z0(1:3) = z(1:3)
-z0(4) = vpar**2/2d0 + mu*f%Bmod
-z0(5) = vpar/sqrt(vpar**2/2d0 + mu*f%Bmod)
-write(4001,*) z0
+    z0 = 0d0
+    z0(1:3) = z(1:3)
+    z0(4) = vpar**2/2d0 + mu*f%Bmod
+    z0(5) = vpar/sqrt(vpar**2/2d0 + mu*f%Bmod)
+    write (4001, *) z0
 
-do k = 1, nts
-  call orbit_timestep_sympl(z0, info)
-  if (mod(k, kwrite) == 0) write(4001,*) z0
-end do
+    do k = 1, nts
+        call orbit_timestep_sympl(z0, info)
+        if (mod(k, kwrite) == 0) write (4001, *) z0
+    end do
 
-print *,'done. Evaluations: ', icounter
+    print *, 'done. Evaluations: ', icounter
 
 end program orbit_symplectic_test

--- a/src/coordinates/array_utils.f90
+++ b/src/coordinates/array_utils.f90
@@ -1,27 +1,27 @@
 module array_utils
-  use, intrinsic :: iso_fortran_env, only: dp => real64
-  implicit none
-  
-  private
-  public :: init_derivative_factors
-  
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    implicit none
+
+    private
+    public :: init_derivative_factors
+
 contains
 
-  !> Initialize factorial-based derivative factors for polynomial derivatives
-  !> derf1(k) = (k-1)
-  !> derf2(k) = (k-1)*(k-2) 
-  !> derf3(k) = (k-1)*(k-2)*(k-3)
-  pure subroutine init_derivative_factors(ns_max, derf1, derf2, derf3)
-    integer, intent(in) :: ns_max
-    double precision, intent(out) :: derf1(ns_max), derf2(ns_max), derf3(ns_max)
-    integer :: k
-    
-    do k = 1, ns_max
-      derf1(k) = dble(k-1)
-      derf2(k) = dble((k-1)*(k-2))
-      derf3(k) = dble((k-1)*(k-2)*(k-3))
-    enddo
-    
-  end subroutine init_derivative_factors
+    !> Initialize factorial-based derivative factors for polynomial derivatives
+    !> derf1(k) = (k-1)
+    !> derf2(k) = (k-1)*(k-2)
+    !> derf3(k) = (k-1)*(k-2)*(k-3)
+    pure subroutine init_derivative_factors(ns_max, derf1, derf2, derf3)
+        integer, intent(in) :: ns_max
+        double precision, intent(out) :: derf1(ns_max), derf2(ns_max), derf3(ns_max)
+        integer :: k
+
+        do k = 1, ns_max
+            derf1(k) = dble(k - 1)
+            derf2(k) = dble((k - 1)*(k - 2))
+            derf3(k) = dble((k - 1)*(k - 2)*(k - 3))
+        end do
+
+    end subroutine init_derivative_factors
 
 end module array_utils

--- a/src/coordinates/reference_coordinates.f90
+++ b/src/coordinates/reference_coordinates.f90
@@ -3,8 +3,8 @@ module reference_coordinates
     use, intrinsic :: iso_fortran_env, only: dp => real64
     use field_boozer_chartmap, only: is_boozer_chartmap
     use libneo_coordinates, only: coordinate_system_t, make_vmec_coordinate_system, &
-        make_chartmap_coordinate_system, detect_refcoords_file_type, &
-        refcoords_file_chartmap, refcoords_file_vmec_wout, refcoords_file_unknown
+                          make_chartmap_coordinate_system, detect_refcoords_file_type, &
+               refcoords_file_chartmap, refcoords_file_vmec_wout, refcoords_file_unknown
     use new_vmec_stuff_mod, only: vmec_RZ_scale
     use scaled_chartmap_coordinates, only: wrap_scaled_chartmap_coordinate_system
 
@@ -26,7 +26,7 @@ contains
             error stop
         end if
 
-        if (allocated(ref_coords)) deallocate(ref_coords)
+        if (allocated(ref_coords)) deallocate (ref_coords)
 
         if (is_boozer_chartmap(coord_input)) then
             call make_chartmap_coordinate_system(ref_coords, coord_input)
@@ -49,7 +49,7 @@ contains
             case (refcoords_file_unknown)
                 print *, 'reference_coordinates.init_reference_coordinates: ', &
                     'unknown file type for ', trim(coord_input)
-                print *, 'Expected VMEC wout (*.nc with rmnc) or chartmap (*.nc with ', &
+               print *, 'Expected VMEC wout (*.nc with rmnc) or chartmap (*.nc with ', &
                     'rho/theta/zeta dims and x/y/z vars)'
                 error stop
             case default

--- a/src/coordinates/stencil_utils.f90
+++ b/src/coordinates/stencil_utils.f90
@@ -1,47 +1,47 @@
 module stencil_utils
-  use, intrinsic :: iso_fortran_env, only: dp => real64
-  implicit none
-  
-  private
-  public :: init_derivative_stencil
-  
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    implicit none
+
+    private
+    public :: init_derivative_stencil
+
 contains
 
-  pure subroutine init_derivative_stencil(nh_stencil, h_grid, stencil)
-    integer, intent(in) :: nh_stencil
-    double precision, intent(in) :: h_grid
-    double precision, intent(out) :: stencil(-nh_stencil:nh_stencil)
-    
-    select case(nh_stencil)
-    case(1)
-      ! 2nd order centered difference
-      stencil(-1) = -0.5d0
-      stencil(0) = 0.0d0
-      stencil(1) = 0.5d0
-    case(2)
-      ! 4th order centered difference
-      stencil(-2) = 1.d0/12.d0
-      stencil(-1) = -2.d0/3.d0
-      stencil(0) = 0.0d0
-      stencil(1) = 2.d0/3.d0
-      stencil(2) = -1.d0/12.d0
-    case(3)
-      ! 6th order centered difference
-      stencil(-3) = -1.d0/60.d0
-      stencil(-2) = 0.15d0
-      stencil(-1) = -0.75d0
-      stencil(0) = 0.0d0
-      stencil(1) = 0.75d0
-      stencil(2) = -0.15d0
-      stencil(3) = 1.d0/60.d0
-    case default
-      ! This should never happen if input validation is done properly
-      stencil = 0.0d0
-    end select
-    
-    ! Scale by grid spacing
-    stencil = stencil / h_grid
-    
-  end subroutine init_derivative_stencil
+    pure subroutine init_derivative_stencil(nh_stencil, h_grid, stencil)
+        integer, intent(in) :: nh_stencil
+        double precision, intent(in) :: h_grid
+        double precision, intent(out) :: stencil(-nh_stencil:nh_stencil)
+
+        select case (nh_stencil)
+        case (1)
+            ! 2nd order centered difference
+            stencil(-1) = -0.5d0
+            stencil(0) = 0.0d0
+            stencil(1) = 0.5d0
+        case (2)
+            ! 4th order centered difference
+            stencil(-2) = 1.d0/12.d0
+            stencil(-1) = -2.d0/3.d0
+            stencil(0) = 0.0d0
+            stencil(1) = 2.d0/3.d0
+            stencil(2) = -1.d0/12.d0
+        case (3)
+            ! 6th order centered difference
+            stencil(-3) = -1.d0/60.d0
+            stencil(-2) = 0.15d0
+            stencil(-1) = -0.75d0
+            stencil(0) = 0.0d0
+            stencil(1) = 0.75d0
+            stencil(2) = -0.15d0
+            stencil(3) = 1.d0/60.d0
+        case default
+            ! This should never happen if input validation is done properly
+            stencil = 0.0d0
+        end select
+
+        ! Scale by grid spacing
+        stencil = stencil/h_grid
+
+    end subroutine init_derivative_stencil
 
 end module stencil_utils

--- a/src/diag/diag_meiss.f90
+++ b/src/diag/diag_meiss.f90
@@ -3,112 +3,112 @@ module diag_meiss
 !> Diagnostic routines for field_can_meiss.f90
 !> Provides visualization and analysis tools for canonical coordinate transformations
 
-use, intrinsic :: iso_fortran_env, only: dp => real64
-use field_can_meiss, only: rh_can, grid_indices_t, n_r, xmin, xmax, h_r
-use fortplot, only: figure, plot, savefig, xlabel, ylabel, title
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use field_can_meiss, only: rh_can, grid_indices_t, n_r, xmin, xmax, h_r
+    use fortplot, only: figure, plot, savefig, xlabel, ylabel, title
 
-implicit none
-private
+    implicit none
+    private
 
-public :: plot_rh_can_vs_rc
+    public :: plot_rh_can_vs_rc
 
 contains
 
-subroutine plot_rh_can_vs_rc(i_th_in, i_phi_in, filename)
-    !> Plot rh_can over r_c for fixed i_th and i_phi indices
-    !>
-    !> @param i_th_in  Theta grid index (default: 1)
-    !> @param i_phi_in Phi grid index (default: 1)
-    !> @param filename Output filename (default: "diag_meiss.pdf")
+    subroutine plot_rh_can_vs_rc(i_th_in, i_phi_in, filename)
+        !> Plot rh_can over r_c for fixed i_th and i_phi indices
+        !>
+        !> @param i_th_in  Theta grid index (default: 1)
+        !> @param i_phi_in Phi grid index (default: 1)
+        !> @param filename Output filename (default: "diag_meiss.pdf")
 
-    integer, intent(in), optional :: i_th_in, i_phi_in
-    character(len=*), intent(in), optional :: filename
+        integer, intent(in), optional :: i_th_in, i_phi_in
+        character(len=*), intent(in), optional :: filename
 
-    ! Local variables
-    integer :: i_th, i_phi
-    integer :: i, n_points
-    real(dp), dimension(:), allocatable :: r_c_array, dz1_vals, dz2_vals
-    real(dp), dimension(2) :: z, dz
-    character(len=100) :: output_file, output_file1, output_file2
-    character(len=50) :: plot_title
+        ! Local variables
+        integer :: i_th, i_phi
+        integer :: i, n_points
+        real(dp), dimension(:), allocatable :: r_c_array, dz1_vals, dz2_vals
+        real(dp), dimension(2) :: z, dz
+        character(len=100) :: output_file, output_file1, output_file2
+        character(len=50) :: plot_title
 
-    ! Set defaults
-    i_th = 1
-    i_phi = 1
-    if (present(i_th_in)) i_th = i_th_in
-    if (present(i_phi_in)) i_phi = i_phi_in
+        ! Set defaults
+        i_th = 1
+        i_phi = 1
+        if (present(i_th_in)) i_th = i_th_in
+        if (present(i_phi_in)) i_phi = i_phi_in
 
-    output_file = "diag_meiss.pdf"
-    if (present(filename)) output_file = trim(filename)
+        output_file = "diag_meiss.pdf"
+        if (present(filename)) output_file = trim(filename)
 
-    ! Create separate filenames for the two plots
-    output_file1 = trim(output_file(1:len_trim(output_file)-4)) // "_dz1.pdf"
-    output_file2 = trim(output_file(1:len_trim(output_file)-4)) // "_dz2.pdf"
+        ! Create separate filenames for the two plots
+        output_file1 = trim(output_file(1:len_trim(output_file) - 4))//"_dz1.pdf"
+        output_file2 = trim(output_file(1:len_trim(output_file) - 4))//"_dz2.pdf"
 
-    ! Create r_c array - use same grid as field_can_meiss
-    n_points = n_r
-    allocate(r_c_array(n_points))
-    allocate(dz1_vals(n_points))
-    allocate(dz2_vals(n_points))
+        ! Create r_c array - use same grid as field_can_meiss
+        n_points = n_r
+        allocate (r_c_array(n_points))
+        allocate (dz1_vals(n_points))
+        allocate (dz2_vals(n_points))
 
-    ! Fill r_c array
-    do i = 1, n_points
-        r_c_array(i) = xmin(1) + (xmax(1) - xmin(1)) * real(i-1, dp) / real(n_points-1, dp)
-    end do
+        ! Fill r_c array
+        do i = 1, n_points
+     r_c_array(i) = xmin(1) + (xmax(1) - xmin(1))*real(i - 1, dp)/real(n_points - 1, dp)
+        end do
 
-    ! Initialize z (lam_phi=0, chi_gauge=0 for diagnostic purposes)
-    z = [0.0_dp, 0.0_dp]
+        ! Initialize z (lam_phi=0, chi_gauge=0 for diagnostic purposes)
+        z = [0.0_dp, 0.0_dp]
 
-    ! Compute both components of rh_can
-    do i = 1, n_points
-        call rh_can(r_c_array(i), z, dz, i_th, i_phi)
-        dz1_vals(i) = dz(1)  ! dz(1) = -hr/hp
-        dz2_vals(i) = dz(2)  ! dz(2) = Ar + Ap*dz(1)
-    end do
+        ! Compute both components of rh_can
+        do i = 1, n_points
+            call rh_can(r_c_array(i), z, dz, i_th, i_phi)
+            dz1_vals(i) = dz(1)  ! dz(1) = -hr/hp
+            dz2_vals(i) = dz(2)  ! dz(2) = Ar + Ap*dz(1)
+        end do
 
-    ! Create two separate plots for better visualization
+        ! Create two separate plots for better visualization
 
-    ! First plot: dz(1) = -hr/hp
-    call figure()
-    call plot(r_c_array, dz1_vals, label="dz(1) = -hr/hp", linestyle="b-")
-    call xlabel("r_c")
-    call ylabel("dz(1) = -hr/hp")
-    write(plot_title, '(A,I0,A,I0,A)') "dz(1) vs r_c (i_th=", i_th, ", i_phi=", i_phi, ")"
-    call title(trim(plot_title))
+        ! First plot: dz(1) = -hr/hp
+        call figure()
+        call plot(r_c_array, dz1_vals, label="dz(1) = -hr/hp", linestyle="b-")
+        call xlabel("r_c")
+        call ylabel("dz(1) = -hr/hp")
+ write (plot_title, '(A,I0,A,I0,A)') "dz(1) vs r_c (i_th=", i_th, ", i_phi=", i_phi, ")"
+        call title(trim(plot_title))
 
-    ! Save first plot
-    call savefig(trim(output_file1))
+        ! Save first plot
+        call savefig(trim(output_file1))
 
-    ! Second plot: dz(2) = Ar + Ap*dz(1)
-    call figure()
-    call plot(r_c_array, dz2_vals, label="dz(2) = Ar + Ap*dz(1)", linestyle="r-")
-    call xlabel("r_c")
-    call ylabel("dz(2) = Ar + Ap*dz(1)")
-    write(plot_title, '(A,I0,A,I0,A)') "dz(2) vs r_c (i_th=", i_th, ", i_phi=", i_phi, ")"
-    call title(trim(plot_title))
+        ! Second plot: dz(2) = Ar + Ap*dz(1)
+        call figure()
+        call plot(r_c_array, dz2_vals, label="dz(2) = Ar + Ap*dz(1)", linestyle="r-")
+        call xlabel("r_c")
+        call ylabel("dz(2) = Ar + Ap*dz(1)")
+ write (plot_title, '(A,I0,A,I0,A)') "dz(2) vs r_c (i_th=", i_th, ", i_phi=", i_phi, ")"
+        call title(trim(plot_title))
 
-    ! Save second plot
-    call savefig(trim(output_file2))
+        ! Save second plot
+        call savefig(trim(output_file2))
 
-    ! Cleanup
-    deallocate(r_c_array, dz1_vals, dz2_vals)
+        ! Cleanup
+        deallocate (r_c_array, dz1_vals, dz2_vals)
 
-    print *, "Diagnostic plots saved to: ", trim(output_file1), " and ", trim(output_file2)
+ print *, "Diagnostic plots saved to: ", trim(output_file1), " and ", trim(output_file2)
 
-end subroutine plot_rh_can_vs_rc
+    end subroutine plot_rh_can_vs_rc
 
 end module diag_meiss
 #else
 module diag_meiss
 !> Stub module when fortplot is not available (e.g., nvfortran builds)
-implicit none
-private
-public :: plot_rh_can_vs_rc
+    implicit none
+    private
+    public :: plot_rh_can_vs_rc
 contains
-subroutine plot_rh_can_vs_rc(i_th_in, i_phi_in, filename)
-    integer, intent(in), optional :: i_th_in, i_phi_in
-    character(len=*), intent(in), optional :: filename
-    print *, "Warning: plot_rh_can_vs_rc requires fortplot (disabled for this build)"
-end subroutine
+    subroutine plot_rh_can_vs_rc(i_th_in, i_phi_in, filename)
+        integer, intent(in), optional :: i_th_in, i_phi_in
+        character(len=*), intent(in), optional :: filename
+       print *, "Warning: plot_rh_can_vs_rc requires fortplot (disabled for this build)"
+    end subroutine
 end module diag_meiss
 #endif

--- a/src/diag/diag_newton.f90
+++ b/src/diag/diag_newton.f90
@@ -3,139 +3,139 @@ module diag_newton
 !> Provides detailed analysis of Newton iteration convergence behavior
 !> during orbit integration using midpoint rule
 
-use, intrinsic :: iso_fortran_env, only: dp => real64
-use util, only: pi, twopi
-use field_can_mod, only: field_can_t, get_val, eval_field => evaluate
-use orbit_symplectic_base, only: symplectic_integrator_t
-use vector_potentail_mod, only: torflux
-use lapack_interfaces, only: dgesv
-use params, only: dtau
-use orbit_symplectic, only: f_midpoint_part1, f_midpoint_part2, &
-    jac_midpoint_part1, jac_midpoint_part2
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use util, only: pi, twopi
+    use field_can_mod, only: field_can_t, get_val, eval_field => evaluate
+    use orbit_symplectic_base, only: symplectic_integrator_t
+    use vector_potentail_mod, only: torflux
+    use lapack_interfaces, only: dgesv
+    use params, only: dtau
+    use orbit_symplectic, only: f_midpoint_part1, f_midpoint_part2, &
+                                jac_midpoint_part1, jac_midpoint_part2
 
-implicit none
-private
+    implicit none
+    private
 
-public :: newton_midpoint_debug, integrate_orbit_with_newton_debug
+    public :: newton_midpoint_debug, integrate_orbit_with_newton_debug
 
 contains
 
 !> EXACT copy of newton_midpoint from orbit_symplectic.f90 with debug output
-subroutine newton_midpoint_debug(si, f, x, atol, rtol, maxit, xlast, step_num)
-  type(symplectic_integrator_t), intent(inout) :: si
-  type(field_can_t), intent(inout) :: f
-  type(field_can_t) :: fmid
-  integer, parameter :: n = 5
-  integer :: kit
-  real(dp), intent(inout) :: x(n)  ! = (rend, thend, phend, pphend, rmid)
-  real(dp), intent(in) :: atol, rtol
-  integer, intent(in) :: maxit
-  real(dp), intent(out) :: xlast(n)
-  integer, intent(in) :: step_num
-  real(dp) :: fvec(n), fjac(n,n)
-  integer :: pivot(n), info
-  real(dp) :: xabs(n), tolref(n), fabs(n)
-  
-  ! DEBUG OUTPUT
-  print '(A,I0)', 'Newton Midpoint Debug - Step ', step_num
-  print '(A,ES12.5,A,ES12.5)', 'Tolerances: atol = ', atol, ', rtol = ', rtol
-  
-  tolref(1) = 1d0
-  tolref(2) = twopi
-  tolref(3) = twopi
-  tolref(4) = dabs(1d1*torflux/f%ro0)
-  tolref(5) = 1d0
-  
-  print '(A,5ES12.5)', 'Initial Tolref = [', tolref, ']'
-  print '(A,5ES12.5)', 'Initial x = [', x, ']'
-  print *
-  
-  do kit = 1, maxit
-    if(x(1) > 1.0) return
-    if(x(1) < 0.0) x(1) = 0.01
-    if(x(5) < 0.0) x(5) = 0.01
-    call f_midpoint_part1(si, f, n, x, fvec)
-    call jac_midpoint_part1(si, f, x, fjac)
-    fmid = f
-    call f_midpoint_part2(si, f, n, x, fvec)
-    call jac_midpoint_part2(si, f, fmid, x, fjac)
-    fabs = dabs(fvec)
-    xlast = x
-    call dgesv(n, 1, fjac, n, pivot, fvec, n, info)
-    ! after solution: fvec = (xold-xnew)_Newton
-    x = x - fvec
-    xabs = dabs(x - xlast)
-    ! Don't take too small values in pphi as tolerance reference
-    tolref(4) = max(dabs(x(4)), tolref(4))
-    
-    ! DEBUG OUTPUT
-    print '(A,I0,A,5ES12.5)', 'Iteration ', kit, ': fabs = [', fabs, ']'
-    print '(A,I0,A,5ES12.5)', 'Iteration ', kit, ': xabs = [', xabs, ']'
-    print '(A,5ES12.5)', 'Tolref = [', tolref, ']'
-    print '(A,5ES12.5)', 'rtol*tolref = [', rtol*tolref, ']'
-    
-    if (all(fabs < atol)) then
-        print '(A,I0,A)', 'Iteration ', kit, ': Convergence achieved (fabs < atol)'
-        return
-    end if
-    if (all(xabs < rtol*tolref)) then
-        print '(A,I0,A)', 'Iteration ', kit, ': Convergence achieved (xabs < rtol*tolref)'
-        return
-    end if
-    
-    print '(A,I0,A,5ES12.5)', 'Iteration ', kit, ': Updated x = [', x, ']'
-    print *
-  enddo
-  print '(A,I0)', 'newton_midpoint: maximum iterations reached: ', maxit
-  !write(6603,*) x(1), x(2), x(3), x(4), x(5), xabs, fvec
-  ! TODO fix criterion for convergence
-end subroutine newton_midpoint_debug
+    subroutine newton_midpoint_debug(si, f, x, atol, rtol, maxit, xlast, step_num)
+        type(symplectic_integrator_t), intent(inout) :: si
+        type(field_can_t), intent(inout) :: f
+        type(field_can_t) :: fmid
+        integer, parameter :: n = 5
+        integer :: kit
+        real(dp), intent(inout) :: x(n)  ! = (rend, thend, phend, pphend, rmid)
+        real(dp), intent(in) :: atol, rtol
+        integer, intent(in) :: maxit
+        real(dp), intent(out) :: xlast(n)
+        integer, intent(in) :: step_num
+        real(dp) :: fvec(n), fjac(n, n)
+        integer :: pivot(n), info
+        real(dp) :: xabs(n), tolref(n), fabs(n)
+
+        ! DEBUG OUTPUT
+        print '(A,I0)', 'Newton Midpoint Debug - Step ', step_num
+        print '(A,ES12.5,A,ES12.5)', 'Tolerances: atol = ', atol, ', rtol = ', rtol
+
+        tolref(1) = 1d0
+        tolref(2) = twopi
+        tolref(3) = twopi
+        tolref(4) = dabs(1d1*torflux/f%ro0)
+        tolref(5) = 1d0
+
+        print '(A,5ES12.5)', 'Initial Tolref = [', tolref, ']'
+        print '(A,5ES12.5)', 'Initial x = [', x, ']'
+        print *
+
+        do kit = 1, maxit
+            if (x(1) > 1.0) return
+            if (x(1) < 0.0) x(1) = 0.01
+            if (x(5) < 0.0) x(5) = 0.01
+            call f_midpoint_part1(si, f, n, x, fvec)
+            call jac_midpoint_part1(si, f, x, fjac)
+            fmid = f
+            call f_midpoint_part2(si, f, n, x, fvec)
+            call jac_midpoint_part2(si, f, fmid, x, fjac)
+            fabs = dabs(fvec)
+            xlast = x
+            call dgesv(n, 1, fjac, n, pivot, fvec, n, info)
+            ! after solution: fvec = (xold-xnew)_Newton
+            x = x - fvec
+            xabs = dabs(x - xlast)
+            ! Don't take too small values in pphi as tolerance reference
+            tolref(4) = max(dabs(x(4)), tolref(4))
+
+            ! DEBUG OUTPUT
+            print '(A,I0,A,5ES12.5)', 'Iteration ', kit, ': fabs = [', fabs, ']'
+            print '(A,I0,A,5ES12.5)', 'Iteration ', kit, ': xabs = [', xabs, ']'
+            print '(A,5ES12.5)', 'Tolref = [', tolref, ']'
+            print '(A,5ES12.5)', 'rtol*tolref = [', rtol*tolref, ']'
+
+            if (all(fabs < atol)) then
+             print '(A,I0,A)', 'Iteration ', kit, ': Convergence achieved (fabs < atol)'
+                return
+            end if
+            if (all(xabs < rtol*tolref)) then
+      print '(A,I0,A)', 'Iteration ', kit, ': Convergence achieved (xabs < rtol*tolref)'
+                return
+            end if
+
+            print '(A,I0,A,5ES12.5)', 'Iteration ', kit, ': Updated x = [', x, ']'
+            print *
+        end do
+        print '(A,I0)', 'newton_midpoint: maximum iterations reached: ', maxit
+        !write(6603,*) x(1), x(2), x(3), x(4), x(5), xabs, fvec
+        ! TODO fix criterion for convergence
+    end subroutine newton_midpoint_debug
 
 !> Integration wrapper that calls debug newton_midpoint for specified number of steps
-subroutine integrate_orbit_with_newton_debug(si, f, num_steps)
-    type(symplectic_integrator_t), intent(inout) :: si
-    type(field_can_t), intent(inout) :: f
-    integer, intent(in) :: num_steps
-    
-    integer, parameter :: n = 5, maxit = 32
-    real(dp), dimension(n) :: x, xlast
-    integer :: step
-    
-    print *, 'Starting Newton Midpoint Integration Debug'
-    print '(A,I0,A)', 'Will integrate for ', num_steps, ' time steps'
-    print '(A,ES12.5)', 'dtau (large time step): ', dtau
-    print '(A,ES12.5)', 'dtaumin (integration time step): ', si%dt
-    print '(A,I0)', 'ntau (substeps per dtau): ', si%ntau
-    print '(A,ES12.5)', 'Absolute tolerance: ', si%atol
-    print '(A,ES12.5)', 'Relative tolerance: ', si%rtol
-    print '(A,4ES12.5)', 'Initial conditions: ', si%z
-    print *
-    
-    do step = 1, num_steps
-        si%pthold = f%pth
-        
-        x(1:4) = si%z
-        x(5) = si%z(1)
-        
-        call newton_midpoint_debug(si, f, x, si%atol, si%rtol, maxit, xlast, step)
-        
-        if (x(1) > 1.0_dp) then
-            print *, 'Particle lost: s > 1.0 at step ', step
-            exit
-        end if
-        
-        si%z = x(1:4)
-        
-        ! Update field
-        call eval_field(f, si%z(1), si%z(2), si%z(3), 0)
-        call get_val(f, si%z(4))
-        
-        print '(A,I0,A,4ES12.5)', 'Step ', step, ' completed. Final state: ', si%z
+    subroutine integrate_orbit_with_newton_debug(si, f, num_steps)
+        type(symplectic_integrator_t), intent(inout) :: si
+        type(field_can_t), intent(inout) :: f
+        integer, intent(in) :: num_steps
+
+        integer, parameter :: n = 5, maxit = 32
+        real(dp), dimension(n) :: x, xlast
+        integer :: step
+
+        print *, 'Starting Newton Midpoint Integration Debug'
+        print '(A,I0,A)', 'Will integrate for ', num_steps, ' time steps'
+        print '(A,ES12.5)', 'dtau (large time step): ', dtau
+        print '(A,ES12.5)', 'dtaumin (integration time step): ', si%dt
+        print '(A,I0)', 'ntau (substeps per dtau): ', si%ntau
+        print '(A,ES12.5)', 'Absolute tolerance: ', si%atol
+        print '(A,ES12.5)', 'Relative tolerance: ', si%rtol
+        print '(A,4ES12.5)', 'Initial conditions: ', si%z
         print *
-    end do
-    
-    print *, 'Newton Midpoint Integration Debug completed successfully!'
-    
-end subroutine integrate_orbit_with_newton_debug
+
+        do step = 1, num_steps
+            si%pthold = f%pth
+
+            x(1:4) = si%z
+            x(5) = si%z(1)
+
+            call newton_midpoint_debug(si, f, x, si%atol, si%rtol, maxit, xlast, step)
+
+            if (x(1) > 1.0_dp) then
+                print *, 'Particle lost: s > 1.0 at step ', step
+                exit
+            end if
+
+            si%z = x(1:4)
+
+            ! Update field
+            call eval_field(f, si%z(1), si%z(2), si%z(3), 0)
+            call get_val(f, si%z(4))
+
+            print '(A,I0,A,4ES12.5)', 'Step ', step, ' completed. Final state: ', si%z
+            print *
+        end do
+
+        print *, 'Newton Midpoint Integration Debug completed successfully!'
+
+    end subroutine integrate_orbit_with_newton_debug
 
 end module diag_newton

--- a/src/diag/diag_orbit.f90
+++ b/src/diag/diag_orbit.f90
@@ -3,270 +3,270 @@ module diag_orbit
 !> Provides trajectory plotting functionality for the Nth particle using
 !> full SIMPLE initialization and real orbit integration
 
-use, intrinsic :: iso_fortran_env, only: dp => real64
+    use, intrinsic :: iso_fortran_env, only: dp => real64
 use params, only: dtau, dtaumin, ntestpart, ntimstep, ntau, zstart, startmode, grid_density, &
     special_ants_file, reuse_batch, num_surf, sbeg, integmode, relerr, reset_seed_if_deterministic
-use samplers, only: sample, START_FILE
-use field_can_mod, only: field_can_t, get_val, eval_field => evaluate, ref_to_integ
-use orbit_symplectic_base, only: symplectic_integrator_t, extrap_field
-use orbit_symplectic, only: orbit_timestep_sympl, f_midpoint_part1, f_midpoint_part2, &
-    jac_midpoint_part1, jac_midpoint_part2
-use simple, only: init_sympl
-use vector_potentail_mod, only: torflux
-use lapack_interfaces, only: dgesv
-use util, only: twopi
+    use samplers, only: sample, START_FILE
+    use field_can_mod, only: field_can_t, get_val, eval_field => evaluate, ref_to_integ
+    use orbit_symplectic_base, only: symplectic_integrator_t, extrap_field
+ use orbit_symplectic, only: orbit_timestep_sympl, f_midpoint_part1, f_midpoint_part2, &
+                                jac_midpoint_part1, jac_midpoint_part2
+    use simple, only: init_sympl
+    use vector_potentail_mod, only: torflux
+    use lapack_interfaces, only: dgesv
+    use util, only: twopi
 
-implicit none
-private
+    implicit none
+    private
 
-public :: integrate_orbit_with_trajectory_debug
+    public :: integrate_orbit_with_trajectory_debug
 
 contains
 
 !> Newton midpoint solver that returns iteration count (no debug output)
 function newton_midpoint_count_iterations(si, f, x, atol, rtol, maxit, xlast, field_evals) result(iterations)
-  type(symplectic_integrator_t), intent(inout) :: si
-  type(field_can_t), intent(inout) :: f
-  type(field_can_t) :: fmid
-  integer, parameter :: n = 5
-  integer :: kit, iterations
-  real(dp), intent(inout) :: x(n)  ! = (rend, thend, phend, pphend, rmid)
-  real(dp), intent(in) :: atol, rtol
-  integer, intent(in) :: maxit
-  real(dp), intent(out) :: xlast(n)
-  integer, intent(inout) :: field_evals
-  real(dp) :: fvec(n), fjac(n,n)
-  integer :: pivot(n), info
-  real(dp) :: xabs(n), tolref(n), fabs(n)
-  
-  ! Buffers to store all iteration data (only printed if max iterations reached)
-  real(dp) :: x_buffer(n,maxit), fabs_buffer(n,maxit), xabs_buffer(n,maxit)
-  real(dp) :: x_initial(n)
-  integer :: k
-  
-  tolref(1) = 1d0
-  tolref(2) = twopi
-  tolref(3) = twopi
-  tolref(4) = max(dabs(f%Aph), dabs(1d1*torflux/f%ro0))  ! Use actual Aph from field
-  tolref(5) = 1d0
-  
-  ! Store initial conditions
-  x_initial = x
-  
-  do kit = 1, maxit
-    if(x(1) > 1.0) then
-        iterations = kit - 1
-        return
-    end if
-    if(x(1) < 0.0) x(1) = 0.01
-    if(x(5) < 0.0) x(5) = 0.01
-    call f_midpoint_part1(si, f, n, x, fvec)
-    call jac_midpoint_part1(si, f, x, fjac)
-    fmid = f
-    call f_midpoint_part2(si, f, n, x, fvec)
-    call jac_midpoint_part2(si, f, fmid, x, fjac)
-    ! Each Newton iteration involves multiple field evaluations
-    ! f_midpoint_part1 and f_midpoint_part2 each do field evaluations
-    field_evals = field_evals + 2
-    fabs = dabs(fvec)
-    xlast = x
-    call dgesv(n, 1, fjac, n, pivot, fvec, n, info)
-    x = x - fvec
-    xabs = dabs(x - xlast)
-    
-    ! Store iteration data in buffers
-    x_buffer(:,kit) = x
-    fabs_buffer(:,kit) = fabs
-    xabs_buffer(:,kit) = xabs
-    
-    ! Use reasonable absolute tolerance instead of machine epsilon
-    if (all(fabs < atol)) then
-        iterations = kit
-        return
-    end if
-    if (all(xabs < rtol*tolref)) then
-        iterations = kit
-        return
-    end if
-  enddo
-  
-  ! Maximum iterations reached - print complete iteration history
-  write(*,'(A)') '=== NEWTON SOLVER FAILURE: MAXIMUM ITERATIONS REACHED ==='
-  write(*,'(A,I0)') 'Maximum iterations: ', maxit
-  write(*,'(A,5ES12.5)') 'Initial x = [', x_initial, ']'
-  write(*,*)
-  write(*,'(A)') 'Complete iteration history:'
-  write(*,'(A)') 'Iter |    max(fabs)    |    max(xabs)    | Result'
-  write(*,'(A)') '-----|----------------|----------------|-------'
-  
-  do k = 1, maxit
-    write(*,'(I4,A,ES12.5,A,ES12.5,A)',advance='no') k, ' | ', maxval(fabs_buffer(:,k)), &
-        ' | ', maxval(xabs_buffer(:,k)), ' | '
-    
-    if (all(fabs_buffer(:,k) < atol)) then
-        write(*,'(A)') 'fabs < atol'
-    elseif (all(xabs_buffer(:,k) < rtol*tolref)) then
-        write(*,'(A)') 'xabs < rtol*tolref'
-    else
-        write(*,'(A)') 'continuing...'
-    end if
-  enddo
-  
-  write(*,*)
-  write(*,'(A,5ES12.5)') 'Final fabs = [', fabs_buffer(:,maxit), ']'
-  write(*,'(A,5ES12.5)') 'Final xabs = [', xabs_buffer(:,maxit), ']'
-  write(*,'(A,5ES12.5)') 'rtol*tolref= [', rtol*tolref, ']'
-  write(*,'(A,5ES12.5)') 'Final x    = [', x_buffer(:,maxit), ']'
-  write(*,*)
-  
-  iterations = maxit
-  error stop 'Newton solver failed to converge within maximum iterations'
-end function newton_midpoint_count_iterations
+        type(symplectic_integrator_t), intent(inout) :: si
+        type(field_can_t), intent(inout) :: f
+        type(field_can_t) :: fmid
+        integer, parameter :: n = 5
+        integer :: kit, iterations
+        real(dp), intent(inout) :: x(n)  ! = (rend, thend, phend, pphend, rmid)
+        real(dp), intent(in) :: atol, rtol
+        integer, intent(in) :: maxit
+        real(dp), intent(out) :: xlast(n)
+        integer, intent(inout) :: field_evals
+        real(dp) :: fvec(n), fjac(n, n)
+        integer :: pivot(n), info
+        real(dp) :: xabs(n), tolref(n), fabs(n)
+
+        ! Buffers to store all iteration data (only printed if max iterations reached)
+        real(dp) :: x_buffer(n, maxit), fabs_buffer(n, maxit), xabs_buffer(n, maxit)
+        real(dp) :: x_initial(n)
+        integer :: k
+
+        tolref(1) = 1d0
+        tolref(2) = twopi
+        tolref(3) = twopi
+        tolref(4) = max(dabs(f%Aph), dabs(1d1*torflux/f%ro0))  ! Use actual Aph from field
+        tolref(5) = 1d0
+
+        ! Store initial conditions
+        x_initial = x
+
+        do kit = 1, maxit
+            if (x(1) > 1.0) then
+                iterations = kit - 1
+                return
+            end if
+            if (x(1) < 0.0) x(1) = 0.01
+            if (x(5) < 0.0) x(5) = 0.01
+            call f_midpoint_part1(si, f, n, x, fvec)
+            call jac_midpoint_part1(si, f, x, fjac)
+            fmid = f
+            call f_midpoint_part2(si, f, n, x, fvec)
+            call jac_midpoint_part2(si, f, fmid, x, fjac)
+            ! Each Newton iteration involves multiple field evaluations
+            ! f_midpoint_part1 and f_midpoint_part2 each do field evaluations
+            field_evals = field_evals + 2
+            fabs = dabs(fvec)
+            xlast = x
+            call dgesv(n, 1, fjac, n, pivot, fvec, n, info)
+            x = x - fvec
+            xabs = dabs(x - xlast)
+
+            ! Store iteration data in buffers
+            x_buffer(:, kit) = x
+            fabs_buffer(:, kit) = fabs
+            xabs_buffer(:, kit) = xabs
+
+            ! Use reasonable absolute tolerance instead of machine epsilon
+            if (all(fabs < atol)) then
+                iterations = kit
+                return
+            end if
+            if (all(xabs < rtol*tolref)) then
+                iterations = kit
+                return
+            end if
+        end do
+
+        ! Maximum iterations reached - print complete iteration history
+        write (*, '(A)') '=== NEWTON SOLVER FAILURE: MAXIMUM ITERATIONS REACHED ==='
+        write (*, '(A,I0)') 'Maximum iterations: ', maxit
+        write (*, '(A,5ES12.5)') 'Initial x = [', x_initial, ']'
+        write (*, *)
+        write (*, '(A)') 'Complete iteration history:'
+        write (*, '(A)') 'Iter |    max(fabs)    |    max(xabs)    | Result'
+        write (*, '(A)') '-----|----------------|----------------|-------'
+
+        do k = 1, maxit
+  write(*,'(I4,A,ES12.5,A,ES12.5,A)',advance='no') k, ' | ', maxval(fabs_buffer(:,k)), &
+                ' | ', maxval(xabs_buffer(:, k)), ' | '
+
+            if (all(fabs_buffer(:, k) < atol)) then
+                write (*, '(A)') 'fabs < atol'
+            elseif (all(xabs_buffer(:, k) < rtol*tolref)) then
+                write (*, '(A)') 'xabs < rtol*tolref'
+            else
+                write (*, '(A)') 'continuing...'
+            end if
+        end do
+
+        write (*, *)
+        write (*, '(A,5ES12.5)') 'Final fabs = [', fabs_buffer(:, maxit), ']'
+        write (*, '(A,5ES12.5)') 'Final xabs = [', xabs_buffer(:, maxit), ']'
+        write (*, '(A,5ES12.5)') 'rtol*tolref= [', rtol*tolref, ']'
+        write (*, '(A,5ES12.5)') 'Final x    = [', x_buffer(:, maxit), ']'
+        write (*, *)
+
+        iterations = maxit
+        error stop 'Newton solver failed to converge within maximum iterations'
+    end function newton_midpoint_count_iterations
 
 !> Integration wrapper that plots the trajectory of the Nth particle
-subroutine integrate_orbit_with_trajectory_debug(si, f, particle_number)
-    type(symplectic_integrator_t), intent(inout) :: si
-    type(field_can_t), intent(inout) :: f
-    integer, intent(in) :: particle_number
-    
-    real(dp), allocatable :: s_traj(:), theta_traj(:), phi_traj(:), time_traj(:)
-    real(dp), allocatable :: pphi_traj(:)
-    integer, allocatable :: newton_iter_traj(:)
-    real(dp), dimension(5) :: z, xlast
-    integer :: it, ktau, point_idx, newton_iters
-    integer, parameter :: maxit = 32
-    real(dp) :: current_time
-    integer :: total_points, field_eval_count
-    
-    ! Validate particle number
-    if (particle_number < 1 .or. particle_number > ntestpart) then
-        print '(A,I0,A,I0)', 'ERROR: Invalid particle number ', particle_number, &
-            '. Must be between 1 and ', ntestpart
-        return
-    end if
-    
-    ! CRITICAL: Follow simple_main.f90 trace_orbit EXACTLY
-    ! 1. Reset random seed if deterministic
-    call reset_seed_if_deterministic
-    
-    ! 2. Get particle coordinates and transform ref -> integ (CRITICAL STEP MISSING!)
-    call ref_to_integ(zstart(1:3, particle_number), z(1:3))
-    z(4:5) = zstart(4:5, particle_number)
-    
-    ! 3. Initialize symplectic integrator with TRANSFORMED coordinates
-    if (integmode > 0) then
-        call init_sympl(si, f, z, dtaumin, dtaumin, relerr, integmode)
-    end if
-    
-    current_time = 0.0_dp
-    
-    ! Calculate total number of timesteps (macrosteps * substeps + initial)
-    total_points = ntimstep * ntau + 1
-    field_eval_count = 0
-    
-    ! Allocate trajectory arrays
-    allocate(s_traj(total_points))
-    allocate(theta_traj(total_points))
-    allocate(phi_traj(total_points))
-    allocate(pphi_traj(total_points))
-    allocate(newton_iter_traj(total_points))
-    allocate(time_traj(total_points))
-    
-    ! Store initial conditions (0 Newton iterations for initial state)
-    s_traj(1) = si%z(1)
-    theta_traj(1) = si%z(2)
-    phi_traj(1) = si%z(3)
-    pphi_traj(1) = si%z(4)
-    newton_iter_traj(1) = 0
-    time_traj(1) = current_time
-    
-    ! Initialize field at starting position
-    call eval_field(f, si%z(1), si%z(2), si%z(3), 0)
-    call get_val(f, si%z(4))
-    field_eval_count = field_eval_count + 1
-    
-    point_idx = 1
-    
-    ! Initialize xlast for field extrapolation to current coordinates
-    xlast(1:4) = si%z
-    xlast(5) = si%z(1)
-    
-    ! Use our custom Newton solver to get iteration counts (but with proper initialization now)
-    do it = 1, ntimstep
-        do ktau = 1, ntau
-            si%pthold = f%pth
-            
-            ! Set up for midpoint integration (like diag_newton)
-            z(1:4) = si%z
-            z(5) = si%z(1)
-            
-            ! Use custom Newton midpoint solver to get iteration count
-            newton_iters = newton_midpoint_count_iterations(si, f, z, si%atol, si%rtol, maxit, xlast, field_eval_count)
-            
-            current_time = current_time + dtaumin
-            
-            if (z(1) > 1.0_dp) then
-                exit
-            end if
-            
-            ! Update integrator state
-            si%z = z(1:4)
-            
-            ! Store trajectory point
-            point_idx = point_idx + 1
-            s_traj(point_idx) = si%z(1)
-            theta_traj(point_idx) = si%z(2)
-            phi_traj(point_idx) = si%z(3)
-            pphi_traj(point_idx) = si%z(4)
-            newton_iter_traj(point_idx) = newton_iters
-            time_traj(point_idx) = current_time
-            
-            ! Update field with extrapolation like production integrator
-            if (extrap_field) then
-                f%pth = f%pth + f%dpth(1)*(z(1)-xlast(1) + z(5) - xlast(5)) &  ! d/dr
-                              + f%dpth(2)*(z(2)-xlast(2)) &  ! d/dth
-                              + f%dpth(3)*(z(3)-xlast(3)) &  ! d/dph
-                              + f%dpth(4)*(z(4)-xlast(4))    ! d/dpph
-            else
-                call eval_field(f, si%z(1), si%z(2), si%z(3), 0)
-                call get_val(f, si%z(4))
-                field_eval_count = field_eval_count + 1
-            endif
-        end do
-        if (z(1) > 1.0_dp) exit
-    end do
-    
-    ! Write trajectory data to files for external plotting
-    call write_trajectory_data(time_traj(1:point_idx), s_traj(1:point_idx), &
-        theta_traj(1:point_idx), phi_traj(1:point_idx), pphi_traj(1:point_idx), &
-        newton_iter_traj(1:point_idx), point_idx, particle_number)
-    
-    ! Output field evaluation count
-    print '(A,I0)', 'Total field evaluations: ', field_eval_count
-    
-    ! Cleanup
-    deallocate(s_traj, theta_traj, phi_traj, pphi_traj, newton_iter_traj, time_traj)
-    
-end subroutine integrate_orbit_with_trajectory_debug
+    subroutine integrate_orbit_with_trajectory_debug(si, f, particle_number)
+        type(symplectic_integrator_t), intent(inout) :: si
+        type(field_can_t), intent(inout) :: f
+        integer, intent(in) :: particle_number
 
-subroutine write_trajectory_data(time_traj, s_traj, theta_traj, phi_traj, pphi_traj, &
-    newton_iter_traj, npoints, particle_number)
-    integer, intent(in) :: npoints, particle_number
+        real(dp), allocatable :: s_traj(:), theta_traj(:), phi_traj(:), time_traj(:)
+        real(dp), allocatable :: pphi_traj(:)
+        integer, allocatable :: newton_iter_traj(:)
+        real(dp), dimension(5) :: z, xlast
+        integer :: it, ktau, point_idx, newton_iters
+        integer, parameter :: maxit = 32
+        real(dp) :: current_time
+        integer :: total_points, field_eval_count
+
+        ! Validate particle number
+        if (particle_number < 1 .or. particle_number > ntestpart) then
+            print '(A,I0,A,I0)', 'ERROR: Invalid particle number ', particle_number, &
+                '. Must be between 1 and ', ntestpart
+            return
+        end if
+
+        ! CRITICAL: Follow simple_main.f90 trace_orbit EXACTLY
+        ! 1. Reset random seed if deterministic
+        call reset_seed_if_deterministic
+
+        ! 2. Get particle coordinates and transform ref -> integ (CRITICAL STEP MISSING!)
+        call ref_to_integ(zstart(1:3, particle_number), z(1:3))
+        z(4:5) = zstart(4:5, particle_number)
+
+        ! 3. Initialize symplectic integrator with TRANSFORMED coordinates
+        if (integmode > 0) then
+            call init_sympl(si, f, z, dtaumin, dtaumin, relerr, integmode)
+        end if
+
+        current_time = 0.0_dp
+
+        ! Calculate total number of timesteps (macrosteps * substeps + initial)
+        total_points = ntimstep*ntau + 1
+        field_eval_count = 0
+
+        ! Allocate trajectory arrays
+        allocate (s_traj(total_points))
+        allocate (theta_traj(total_points))
+        allocate (phi_traj(total_points))
+        allocate (pphi_traj(total_points))
+        allocate (newton_iter_traj(total_points))
+        allocate (time_traj(total_points))
+
+        ! Store initial conditions (0 Newton iterations for initial state)
+        s_traj(1) = si%z(1)
+        theta_traj(1) = si%z(2)
+        phi_traj(1) = si%z(3)
+        pphi_traj(1) = si%z(4)
+        newton_iter_traj(1) = 0
+        time_traj(1) = current_time
+
+        ! Initialize field at starting position
+        call eval_field(f, si%z(1), si%z(2), si%z(3), 0)
+        call get_val(f, si%z(4))
+        field_eval_count = field_eval_count + 1
+
+        point_idx = 1
+
+        ! Initialize xlast for field extrapolation to current coordinates
+        xlast(1:4) = si%z
+        xlast(5) = si%z(1)
+
+        ! Use our custom Newton solver to get iteration counts (but with proper initialization now)
+        do it = 1, ntimstep
+            do ktau = 1, ntau
+                si%pthold = f%pth
+
+                ! Set up for midpoint integration (like diag_newton)
+                z(1:4) = si%z
+                z(5) = si%z(1)
+
+                ! Use custom Newton midpoint solver to get iteration count
+            newton_iters = newton_midpoint_count_iterations(si, f, z, si%atol, si%rtol, maxit, xlast, field_eval_count)
+
+                current_time = current_time + dtaumin
+
+                if (z(1) > 1.0_dp) then
+                    exit
+                end if
+
+                ! Update integrator state
+                si%z = z(1:4)
+
+                ! Store trajectory point
+                point_idx = point_idx + 1
+                s_traj(point_idx) = si%z(1)
+                theta_traj(point_idx) = si%z(2)
+                phi_traj(point_idx) = si%z(3)
+                pphi_traj(point_idx) = si%z(4)
+                newton_iter_traj(point_idx) = newton_iters
+                time_traj(point_idx) = current_time
+
+                ! Update field with extrapolation like production integrator
+                if (extrap_field) then
+                    f%pth = f%pth + f%dpth(1)*(z(1) - xlast(1) + z(5) - xlast(5)) &  ! d/dr
+                            + f%dpth(2)*(z(2) - xlast(2)) &  ! d/dth
+                            + f%dpth(3)*(z(3) - xlast(3)) &  ! d/dph
+                            + f%dpth(4)*(z(4) - xlast(4))    ! d/dpph
+                else
+                    call eval_field(f, si%z(1), si%z(2), si%z(3), 0)
+                    call get_val(f, si%z(4))
+                    field_eval_count = field_eval_count + 1
+                end if
+            end do
+            if (z(1) > 1.0_dp) exit
+        end do
+
+        ! Write trajectory data to files for external plotting
+        call write_trajectory_data(time_traj(1:point_idx), s_traj(1:point_idx), &
+               theta_traj(1:point_idx), phi_traj(1:point_idx), pphi_traj(1:point_idx), &
+                              newton_iter_traj(1:point_idx), point_idx, particle_number)
+
+        ! Output field evaluation count
+        print '(A,I0)', 'Total field evaluations: ', field_eval_count
+
+        ! Cleanup
+       deallocate (s_traj, theta_traj, phi_traj, pphi_traj, newton_iter_traj, time_traj)
+
+    end subroutine integrate_orbit_with_trajectory_debug
+
+  subroutine write_trajectory_data(time_traj, s_traj, theta_traj, phi_traj, pphi_traj, &
+                                     newton_iter_traj, npoints, particle_number)
+        integer, intent(in) :: npoints, particle_number
     real(dp), dimension(npoints), intent(in) :: time_traj, s_traj, theta_traj, phi_traj, pphi_traj
-    integer, dimension(npoints), intent(in) :: newton_iter_traj
-    
-    integer :: i
-    character(len=100) :: filename
-    
-    write(filename, '(A,I0,A)') 'orbit_trajectory_particle_', particle_number, '.dat'
-    
-    open(unit=20, file=filename, status='replace')
-    write(20, '(A)') '# Time    s    theta    phi    pphi    newton_iters'
-    do i = 1, npoints
+        integer, dimension(npoints), intent(in) :: newton_iter_traj
+
+        integer :: i
+        character(len=100) :: filename
+
+      write (filename, '(A,I0,A)') 'orbit_trajectory_particle_', particle_number, '.dat'
+
+        open (unit=20, file=filename, status='replace')
+        write (20, '(A)') '# Time    s    theta    phi    pphi    newton_iters'
+        do i = 1, npoints
         write(20, '(5ES16.8,I8)') time_traj(i), s_traj(i), theta_traj(i), phi_traj(i), pphi_traj(i), newton_iter_traj(i)
-    end do
-    close(20)
-    
-end subroutine write_trajectory_data
+        end do
+        close (20)
+
+    end subroutine write_trajectory_data
 
 end module diag_orbit

--- a/src/field.F90
+++ b/src/field.F90
@@ -102,10 +102,10 @@ contains
                         ' to a VMEC wout.'
                     error stop
                 case (refcoords_file_unknown)
-                    print *, 'field_from_file: Unknown NetCDF file type: ', trim(filename)
+                  print *, 'field_from_file: Unknown NetCDF file type: ', trim(filename)
                     error stop
                 case default
-                    print *, 'field_from_file: Unexpected file_type ', file_type, ' for ', &
+                print *, 'field_from_file: Unexpected file_type ', file_type, ' for ', &
                         trim(filename)
                     error stop
                 end select

--- a/src/field/field_can_albert.f90
+++ b/src/field/field_can_albert.f90
@@ -20,229 +20,223 @@ module field_can_albert
     !>
     !> The Albert form simplifies the symplectic integrator since dA_theta/dr = 0.
 
-use, intrinsic :: iso_fortran_env, only: dp => real64
-use interpolate, only: &
-    BatchSplineData3D, construct_batch_splines_3d, &
-    evaluate_batch_splines_3d, evaluate_batch_splines_3d_der, &
-    evaluate_batch_splines_3d_der2
-use field_can_base, only: field_can_t, n_field_evaluations
-use field_can_meiss, only: xmin, xmax, n_r, n_th, n_phi, order, periodic, twopi, &
-    get_grid_point, &
-    init_albert => init_meiss, init_transformation, spline_transformation, &
-    init_canonical_field_components
-use psi_transform, only: grid_r_to_psi
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use interpolate, only: &
+        BatchSplineData3D, construct_batch_splines_3d, &
+        evaluate_batch_splines_3d, evaluate_batch_splines_3d_der, &
+        evaluate_batch_splines_3d_der2
+    use field_can_base, only: field_can_t, n_field_evaluations
+    use field_can_meiss, only: xmin, xmax, n_r, n_th, n_phi, order, periodic, twopi, &
+                               get_grid_point, &
+                init_albert => init_meiss, init_transformation, spline_transformation, &
+                               init_canonical_field_components
+    use psi_transform, only: grid_r_to_psi
 
-implicit none
+    implicit none
 
 ! For splining psi
-real(dp) :: psi_inner, psi_outer
-real(dp), dimension(:,:,:), allocatable :: psi_of_x
-real(dp), dimension(:), allocatable :: psi_grid
-logical :: dpsi_dr_positive
+    real(dp) :: psi_inner, psi_outer
+    real(dp), dimension(:, :, :), allocatable :: psi_of_x
+    real(dp), dimension(:), allocatable :: psi_grid
+    logical :: dpsi_dr_positive
 
 ! For splining field components over canonical coordinates
-real(dp), dimension(:,:,:), allocatable :: r_of_xc, &
-Aph_of_xc, hth_of_xc, hph_of_xc, Bmod_of_xc
+    real(dp), dimension(:, :, :), allocatable :: r_of_xc, &
+                                             Aph_of_xc, hth_of_xc, hph_of_xc, Bmod_of_xc
 
 ! Batch spline for r_of_xc transformation (1 component: r)
-type(BatchSplineData3D) :: spl_r_batch
+    type(BatchSplineData3D) :: spl_r_batch
 
 ! Batch spline for optimized field evaluation (4 components: Aphi, hth, hph, Bmod)
-type(BatchSplineData3D) :: spl_albert_batch
+    type(BatchSplineData3D) :: spl_albert_batch
 
-real(dp) :: Ath_norm
+    real(dp) :: Ath_norm
 
 contains
 
-subroutine evaluate_albert(f, r, th_c, ph_c, mode_secders)
-    type(field_can_t), intent(inout) :: f
-    real(dp), intent(in) :: r, th_c, ph_c
-    integer, intent(in) :: mode_secders
+    subroutine evaluate_albert(f, r, th_c, ph_c, mode_secders)
+        type(field_can_t), intent(inout) :: f
+        real(dp), intent(in) :: r, th_c, ph_c
+        integer, intent(in) :: mode_secders
 
-    real(dp) :: x(3)
+        real(dp) :: x(3)
 
-    n_field_evaluations = n_field_evaluations + 1
+        n_field_evaluations = n_field_evaluations + 1
 
-    x = [r, th_c, ph_c]
+        x = [r, th_c, ph_c]
 
-    f%Ath = Ath_norm*x(1)
-    f%dAth = [Ath_norm, 0d0, 0d0]
+        f%Ath = Ath_norm*x(1)
+        f%dAth = [Ath_norm, 0d0, 0d0]
 
-    if (mode_secders > 0) then
-        f%d2Ath = 0d0
-        call evaluate_albert_batch_der2(f, x)
-        return
-    end if
+        if (mode_secders > 0) then
+            f%d2Ath = 0d0
+            call evaluate_albert_batch_der2(f, x)
+            return
+        end if
 
-    call evaluate_albert_batch_der(f, x)
-end subroutine evaluate_albert
+        call evaluate_albert_batch_der(f, x)
+    end subroutine evaluate_albert
 
+    subroutine integ_to_ref_albert(xinteg, xref)
+        use field_can_meiss, only: integ_to_ref_meiss
 
-subroutine integ_to_ref_albert(xinteg, xref)
-    use field_can_meiss, only: integ_to_ref_meiss
+        real(dp), intent(in) :: xinteg(3)
+        real(dp), intent(out) :: xref(3)
+        real(dp) :: xmeiss(3), y_batch(1)
 
-    real(dp), intent(in) :: xinteg(3)
-    real(dp), intent(out) :: xref(3)
-    real(dp) :: xmeiss(3), y_batch(1)
+        call evaluate_batch_splines_3d(spl_r_batch, xinteg, y_batch)
+        xmeiss(1) = y_batch(1)  ! r component
+        xmeiss(2:3) = xinteg(2:3)
+        call integ_to_ref_meiss(xmeiss, xref)
+    end subroutine integ_to_ref_albert
 
-    call evaluate_batch_splines_3d(spl_r_batch, xinteg, y_batch)
-    xmeiss(1) = y_batch(1)  ! r component
-    xmeiss(2:3) = xinteg(2:3)
-    call integ_to_ref_meiss(xmeiss, xref)
-end subroutine integ_to_ref_albert
+    subroutine ref_to_integ_albert(xref, xinteg)
+        use field_can_meiss, only: ref_to_integ_meiss, spl_field_batch
 
+        real(dp), intent(in) :: xref(3)
+        real(dp), intent(out) :: xinteg(3)
 
-subroutine ref_to_integ_albert(xref, xinteg)
-    use field_can_meiss, only: ref_to_integ_meiss, spl_field_batch
+        real(dp) :: Ath, xmeiss(3), y_batch_local(5)
 
-    real(dp), intent(in) :: xref(3)
-    real(dp), intent(out) :: xinteg(3)
+        call ref_to_integ_meiss(xref, xmeiss)
+        call evaluate_batch_splines_3d(spl_field_batch, xmeiss, y_batch_local)
+        Ath = y_batch_local(1)  ! Extract Ath component
+        xinteg(1) = Ath/Ath_norm
+        xinteg(2:3) = xmeiss(2:3)
+    end subroutine ref_to_integ_albert
 
-    real(dp) :: Ath, xmeiss(3), y_batch_local(5)
-
-    call ref_to_integ_meiss(xref, xmeiss)
-    call evaluate_batch_splines_3d(spl_field_batch, xmeiss, y_batch_local)
-    Ath = y_batch_local(1)  ! Extract Ath component
-    xinteg(1) = Ath/Ath_norm
-    xinteg(2:3) = xmeiss(2:3)
-end subroutine ref_to_integ_albert
-
-
-subroutine get_albert_coordinates
+    subroutine get_albert_coordinates
 #ifdef SIMPLE_ENABLE_DEBUG_OUTPUT
-    print *, 'field_can_meiss.init_transformation'
+        print *, 'field_can_meiss.init_transformation'
 #endif
-    call init_transformation
+        call init_transformation
 
 #ifdef SIMPLE_ENABLE_DEBUG_OUTPUT
-    print *, 'field_can_meiss.spline_transformation'
+        print *, 'field_can_meiss.spline_transformation'
 #endif
-    call spline_transformation
+        call spline_transformation
 
 #ifdef SIMPLE_ENABLE_DEBUG_OUTPUT
-    print *, 'field_can_meiss.init_canonical_field_components'
+        print *, 'field_can_meiss.init_canonical_field_components'
 #endif
-    call init_canonical_field_components
+        call init_canonical_field_components
 
 #ifdef SIMPLE_ENABLE_DEBUG_OUTPUT
-    print *, 'field_can_albert.init_splines_with_psi'
+        print *, 'field_can_albert.init_splines_with_psi'
 #endif
-    call init_splines_with_psi
-end subroutine get_albert_coordinates
+        call init_splines_with_psi
+    end subroutine get_albert_coordinates
 
+    subroutine init_splines_with_psi
+        use psi_transform, only: grid_r_to_psi
+        use field_can_meiss, only: spl_field_batch
+        real(dp), dimension(:, :, :, :), allocatable :: y_batch
+   real(dp), dimension(:, :, :), allocatable :: Aphi_grid, hth_grid, hph_grid, Bmod_grid
+        real(dp) :: x_grid(3), y_batch_temp(5)
+        integer :: i_r, i_th, i_phi, dims(3)
 
-subroutine init_splines_with_psi
-    use psi_transform, only: grid_r_to_psi
-    use field_can_meiss, only: spl_field_batch
-    real(dp), dimension(:,:,:,:), allocatable :: y_batch
-    real(dp), dimension(:,:,:), allocatable :: Aphi_grid, hth_grid, hph_grid, Bmod_grid
-    real(dp) :: x_grid(3), y_batch_temp(5)
-    integer :: i_r, i_th, i_phi, dims(3)
+        allocate ( &
+            r_of_xc(n_r, n_th, n_phi), &
+            Aph_of_xc(n_r, n_th, n_phi), &
+            hth_of_xc(n_r, n_th, n_phi), &
+            hph_of_xc(n_r, n_th, n_phi), &
+            Bmod_of_xc(n_r, n_th, n_phi) &
+            )
 
-    allocate( &
-        r_of_xc(n_r, n_th, n_phi), &
-        Aph_of_xc(n_r, n_th, n_phi), &
-        hth_of_xc(n_r, n_th, n_phi), &
-        hph_of_xc(n_r, n_th, n_phi), &
-        Bmod_of_xc(n_r, n_th, n_phi) &
-    )
+        call init_psi_grid
 
-    call init_psi_grid
-
-    ! For Albert coordinates, we need to reconstruct the field components from Meiss
-    ! This requires grid evaluation - let's compute them explicitly    
+        ! For Albert coordinates, we need to reconstruct the field components from Meiss
+        ! This requires grid evaluation - let's compute them explicitly
     allocate(Aphi_grid(n_r,n_th,n_phi), hth_grid(n_r,n_th,n_phi), hph_grid(n_r,n_th,n_phi), Bmod_grid(n_r,n_th,n_phi))
-    
-    ! Evaluate Meiss batch spline on grid to get field components
-    do i_phi = 1, n_phi
-        do i_th = 1, n_th
-            do i_r = 1, n_r
-                x_grid = [xmin(1) + (i_r-1)*(xmax(1)-xmin(1))/(n_r-1), &
-                         xmin(2) + (i_th-1)*(xmax(2)-xmin(2))/(n_th-1), &
-                         xmin(3) + (i_phi-1)*(xmax(3)-xmin(3))/(n_phi-1)]
-                call evaluate_batch_splines_3d(spl_field_batch, x_grid, y_batch_temp)
-                Aphi_grid(i_r,i_th,i_phi) = y_batch_temp(2)  ! Aph component
-                hth_grid(i_r,i_th,i_phi) = y_batch_temp(3)   ! hth component  
-                hph_grid(i_r,i_th,i_phi) = y_batch_temp(4)   ! hph component
-                Bmod_grid(i_r,i_th,i_phi) = y_batch_temp(5)  ! Bmod component
+
+        ! Evaluate Meiss batch spline on grid to get field components
+        do i_phi = 1, n_phi
+            do i_th = 1, n_th
+                do i_r = 1, n_r
+                    x_grid = [xmin(1) + (i_r - 1)*(xmax(1) - xmin(1))/(n_r - 1), &
+                              xmin(2) + (i_th - 1)*(xmax(2) - xmin(2))/(n_th - 1), &
+                              xmin(3) + (i_phi - 1)*(xmax(3) - xmin(3))/(n_phi - 1)]
+                   call evaluate_batch_splines_3d(spl_field_batch, x_grid, y_batch_temp)
+                    Aphi_grid(i_r, i_th, i_phi) = y_batch_temp(2)  ! Aph component
+                    hth_grid(i_r, i_th, i_phi) = y_batch_temp(3)   ! hth component
+                    hph_grid(i_r, i_th, i_phi) = y_batch_temp(4)   ! hph component
+                    Bmod_grid(i_r, i_th, i_phi) = y_batch_temp(5)  ! Bmod component
+                end do
             end do
         end do
-    end do
 
-    ! Center Aphi around zero
-    Aphi_grid = Aphi_grid - 0.5d0*sum(Aphi_grid)/real(n_r*n_th*n_phi, dp)
+        ! Center Aphi around zero
+        Aphi_grid = Aphi_grid - 0.5d0*sum(Aphi_grid)/real(n_r*n_th*n_phi, dp)
 
-    call grid_r_to_psi(xmin(1), xmax(1), psi_inner, psi_outer, psi_of_x, &
-        Aphi_grid, hth_grid, hph_grid, Bmod_grid, r_of_xc, Aph_of_xc, &
-        hth_of_xc, hph_of_xc, Bmod_of_xc)
+        call grid_r_to_psi(xmin(1), xmax(1), psi_inner, psi_outer, psi_of_x, &
+                         Aphi_grid, hth_grid, hph_grid, Bmod_grid, r_of_xc, Aph_of_xc, &
+                           hth_of_xc, hph_of_xc, Bmod_of_xc)
 
-    ! Construct batch spline for r_of_xc (1 component: r)
-    block
-        real(dp), dimension(:,:,:,:), allocatable :: y_r_batch
-        dims = shape(r_of_xc)
-        allocate(y_r_batch(dims(1), dims(2), dims(3), 1))
-        y_r_batch(:,:,:,1) = r_of_xc
+        ! Construct batch spline for r_of_xc (1 component: r)
+        block
+            real(dp), dimension(:, :, :, :), allocatable :: y_r_batch
+            dims = shape(r_of_xc)
+            allocate (y_r_batch(dims(1), dims(2), dims(3), 1))
+            y_r_batch(:, :, :, 1) = r_of_xc
+            call construct_batch_splines_3d([psi_inner, xmin(2), xmin(3)], &
+                 [psi_outer, xmax(2), xmax(3)], y_r_batch, order, periodic, spl_r_batch)
+        end block
+
+        ! Construct batch spline for 4 Albert field components: [Aphi, hth, hph, Bmod]
+        dims = shape(Aph_of_xc)
+        allocate (y_batch(dims(1), dims(2), dims(3), 4))
+
+        y_batch(:, :, :, 1) = Aph_of_xc
+        y_batch(:, :, :, 2) = hth_of_xc
+        y_batch(:, :, :, 3) = hph_of_xc
+        y_batch(:, :, :, 4) = Bmod_of_xc
+
         call construct_batch_splines_3d([psi_inner, xmin(2), xmin(3)], &
-            [psi_outer, xmax(2), xmax(3)], y_r_batch, order, periodic, spl_r_batch)
-    end block
-    
-    ! Construct batch spline for 4 Albert field components: [Aphi, hth, hph, Bmod]
-    dims = shape(Aph_of_xc)
-    allocate(y_batch(dims(1), dims(2), dims(3), 4))
-    
-    y_batch(:,:,:,1) = Aph_of_xc
-    y_batch(:,:,:,2) = hth_of_xc
-    y_batch(:,:,:,3) = hph_of_xc
-    y_batch(:,:,:,4) = Bmod_of_xc
-    
-    call construct_batch_splines_3d([psi_inner, xmin(2), xmin(3)], &
-        [psi_outer, xmax(2), xmax(3)], y_batch, order, periodic, spl_albert_batch)
-end subroutine init_splines_with_psi
+              [psi_outer, xmax(2), xmax(3)], y_batch, order, periodic, spl_albert_batch)
+    end subroutine init_splines_with_psi
 
+    subroutine init_psi_grid
+        use field_can_meiss, only: spl_field_batch
+        real(dp) :: x(3), y_batch_local(5)
+        integer :: i_r, i_th, i_phi
 
-subroutine init_psi_grid
-    use field_can_meiss, only: spl_field_batch
-    real(dp) :: x(3), y_batch_local(5)
-    integer :: i_r, i_th, i_phi
+        allocate (psi_of_x(n_r, n_th, n_phi), psi_grid(n_r))
 
-    allocate(psi_of_x(n_r, n_th, n_phi), psi_grid(n_r))
-
-    ! Evaluate Meiss batch spline to get Ath (component 1) on grid
-    do i_phi = 1, n_phi
-        do i_th = 1, n_th
-            do i_r = 1, n_r
-                x = [xmin(1) + (i_r-1)*(xmax(1)-xmin(1))/(n_r-1), &
-                     xmin(2) + (i_th-1)*(xmax(2)-xmin(2))/(n_th-1), &
-                     xmin(3) + (i_phi-1)*(xmax(3)-xmin(3))/(n_phi-1)]
-                call evaluate_batch_splines_3d(spl_field_batch, x, y_batch_local)
-                psi_of_x(i_r, i_th, i_phi) = y_batch_local(1)  ! Ath component
+        ! Evaluate Meiss batch spline to get Ath (component 1) on grid
+        do i_phi = 1, n_phi
+            do i_th = 1, n_th
+                do i_r = 1, n_r
+                    x = [xmin(1) + (i_r - 1)*(xmax(1) - xmin(1))/(n_r - 1), &
+                         xmin(2) + (i_th - 1)*(xmax(2) - xmin(2))/(n_th - 1), &
+                         xmin(3) + (i_phi - 1)*(xmax(3) - xmin(3))/(n_phi - 1)]
+                    call evaluate_batch_splines_3d(spl_field_batch, x, y_batch_local)
+                    psi_of_x(i_r, i_th, i_phi) = y_batch_local(1)  ! Ath component
+                end do
             end do
         end do
-    end do
-    
-    Ath_norm = sign(maxval(abs(psi_of_x)), psi_of_x(n_r, n_th/2, n_phi/2))
-    psi_of_x = psi_of_x / Ath_norm
 
-    ! Here we use the "safe side" approach (new grid is fully within the old grid).
-    ! For the risky approach (old grid within the new grid) exchange
-    ! "minval" and "maxval".
-    if(psi_of_x(n_r, n_th/2, n_phi/2) > psi_of_x(1, n_th/2, n_phi/2)) then
-        dpsi_dr_positive = .true.
-        psi_inner = maxval(psi_of_x(1,:,:))
-        psi_outer = minval(psi_of_x(n_r,:,:))
-    else
-        dpsi_dr_positive = .false.
-        psi_inner = maxval(psi_of_x(n_r,:,:))
-        psi_outer = minval(psi_of_x(1,:,:))
-    endif
+        Ath_norm = sign(maxval(abs(psi_of_x)), psi_of_x(n_r, n_th/2, n_phi/2))
+        psi_of_x = psi_of_x/Ath_norm
 
-    do i_r = 1, n_r
-        psi_grid(i_r) = psi_inner + (psi_outer - psi_inner) * (i_r - 1) / (n_r - 1)
-    end do
-end subroutine init_psi_grid
+        ! Here we use the "safe side" approach (new grid is fully within the old grid).
+        ! For the risky approach (old grid within the new grid) exchange
+        ! "minval" and "maxval".
+        if (psi_of_x(n_r, n_th/2, n_phi/2) > psi_of_x(1, n_th/2, n_phi/2)) then
+            dpsi_dr_positive = .true.
+            psi_inner = maxval(psi_of_x(1, :, :))
+            psi_outer = minval(psi_of_x(n_r, :, :))
+        else
+            dpsi_dr_positive = .false.
+            psi_inner = maxval(psi_of_x(n_r, :, :))
+            psi_outer = minval(psi_of_x(1, :, :))
+        end if
 
+        do i_r = 1, n_r
+            psi_grid(i_r) = psi_inner + (psi_outer - psi_inner)*(i_r - 1)/(n_r - 1)
+        end do
+    end subroutine init_psi_grid
 
-subroutine magfie_albert(x,bmod,sqrtg,bder,hcovar,hctrvr,hcurl)
+    subroutine magfie_albert(x, bmod, sqrtg, bder, hcovar, hctrvr, hcurl)
 !  Computes magnetic field and derivatives with bmod in units of the magnetic code
 !
 !  Input parameters:
@@ -254,81 +248,79 @@ subroutine magfie_albert(x,bmod,sqrtg,bder,hcovar,hctrvr,hcurl)
 !                     hcovar          - covariant components of \bB/B
 !                     hctrvr          - contravariant components of \bB/B
 !                     hcurl           - contravariant components of curl (\bB/B)
-    real(dp), intent(in) :: x(3)
-    real(dp), intent(out) :: bmod, sqrtg
-    real(dp), dimension(3), intent(out) :: bder, hcovar, hctrvr, hcurl
+        real(dp), intent(in) :: x(3)
+        real(dp), intent(out) :: bmod, sqrtg
+        real(dp), dimension(3), intent(out) :: bder, hcovar, hctrvr, hcurl
 
-    type(field_can_t) :: f
-    real(dp) :: sqrtg_bmod
+        type(field_can_t) :: f
+        real(dp) :: sqrtg_bmod
 
-    call evaluate_albert(f, x(1), x(2), x(3), 0)
+        call evaluate_albert(f, x(1), x(2), x(3), 0)
 
-    bmod = f%Bmod
+        bmod = f%Bmod
 
-    sqrtg_bmod = f%hph*Ath_norm - f%hth*f%dAph(1)
-    sqrtg = sqrtg_bmod/bmod
-    bder = f%dBmod/bmod
+        sqrtg_bmod = f%hph*Ath_norm - f%hth*f%dAph(1)
+        sqrtg = sqrtg_bmod/bmod
+        bder = f%dBmod/bmod
 
-    hcovar(1) = 0.d0
-    hcovar(2) = f%hth
-    hcovar(3) = f%hph
+        hcovar(1) = 0.d0
+        hcovar(2) = f%hth
+        hcovar(3) = f%hph
 
-    hctrvr(1) = f%dAph(2)/sqrtg_bmod
-    hctrvr(2) = -f%dAph(1)/sqrtg_bmod
-    hctrvr(3) = Ath_norm/sqrtg_bmod
+        hctrvr(1) = f%dAph(2)/sqrtg_bmod
+        hctrvr(2) = -f%dAph(1)/sqrtg_bmod
+        hctrvr(3) = Ath_norm/sqrtg_bmod
 
-    hcurl(1) = (f%dhph(2) - f%dhth(3))/sqrtg
-    hcurl(2) = -f%dhph(1)/sqrtg
-    hcurl(3) = f%dhth(1)/sqrtg
-end subroutine magfie_albert
-
+        hcurl(1) = (f%dhph(2) - f%dhth(3))/sqrtg
+        hcurl(2) = -f%dhph(1)/sqrtg
+        hcurl(3) = f%dhth(1)/sqrtg
+    end subroutine magfie_albert
 
 ! Batch evaluation helper for first derivatives
-subroutine evaluate_albert_batch_der(f, x)
-    type(field_can_t), intent(inout) :: f
-    real(dp), intent(in) :: x(3)
-    
-    real(dp) :: y_batch(4), dy_batch(3, 4)
-    
-    call evaluate_batch_splines_3d_der(spl_albert_batch, x, y_batch, dy_batch)
-    
-    ! Unpack results: order is [Aphi, hth, hph, Bmod]
-    f%Aph = y_batch(1)
-    f%hth = y_batch(2)
-    f%hph = y_batch(3)
-    f%Bmod = y_batch(4)
-    
-    f%dAph = dy_batch(:, 1)
-    f%dhth = dy_batch(:, 2)
-    f%dhph = dy_batch(:, 3)
-    f%dBmod = dy_batch(:, 4)
-end subroutine evaluate_albert_batch_der
+    subroutine evaluate_albert_batch_der(f, x)
+        type(field_can_t), intent(inout) :: f
+        real(dp), intent(in) :: x(3)
 
+        real(dp) :: y_batch(4), dy_batch(3, 4)
+
+        call evaluate_batch_splines_3d_der(spl_albert_batch, x, y_batch, dy_batch)
+
+        ! Unpack results: order is [Aphi, hth, hph, Bmod]
+        f%Aph = y_batch(1)
+        f%hth = y_batch(2)
+        f%hph = y_batch(3)
+        f%Bmod = y_batch(4)
+
+        f%dAph = dy_batch(:, 1)
+        f%dhth = dy_batch(:, 2)
+        f%dhph = dy_batch(:, 3)
+        f%dBmod = dy_batch(:, 4)
+    end subroutine evaluate_albert_batch_der
 
 ! Batch evaluation helper for second derivatives
-subroutine evaluate_albert_batch_der2(f, x)
-    type(field_can_t), intent(inout) :: f
-    real(dp), intent(in) :: x(3)
-    
-    real(dp) :: y_batch(4), dy_batch(3, 4), d2y_batch(6, 4)
-    
-    call evaluate_batch_splines_3d_der2(spl_albert_batch, x, y_batch, dy_batch, d2y_batch)
-    
-    ! Unpack results: order is [Aphi, hth, hph, Bmod]
-    f%Aph = y_batch(1)
-    f%hth = y_batch(2)
-    f%hph = y_batch(3)
-    f%Bmod = y_batch(4)
-    
-    f%dAph = dy_batch(:, 1)
-    f%dhth = dy_batch(:, 2)
-    f%dhph = dy_batch(:, 3)
-    f%dBmod = dy_batch(:, 4)
-    
-    f%d2Aph = d2y_batch(:, 1)
-    f%d2hth = d2y_batch(:, 2)
-    f%d2hph = d2y_batch(:, 3)
-    f%d2Bmod = d2y_batch(:, 4)
-end subroutine evaluate_albert_batch_der2
+    subroutine evaluate_albert_batch_der2(f, x)
+        type(field_can_t), intent(inout) :: f
+        real(dp), intent(in) :: x(3)
+
+        real(dp) :: y_batch(4), dy_batch(3, 4), d2y_batch(6, 4)
+
+  call evaluate_batch_splines_3d_der2(spl_albert_batch, x, y_batch, dy_batch, d2y_batch)
+
+        ! Unpack results: order is [Aphi, hth, hph, Bmod]
+        f%Aph = y_batch(1)
+        f%hth = y_batch(2)
+        f%hph = y_batch(3)
+        f%Bmod = y_batch(4)
+
+        f%dAph = dy_batch(:, 1)
+        f%dhth = dy_batch(:, 2)
+        f%dhph = dy_batch(:, 3)
+        f%dBmod = dy_batch(:, 4)
+
+        f%d2Aph = d2y_batch(:, 1)
+        f%d2hth = d2y_batch(:, 2)
+        f%d2hph = d2y_batch(:, 3)
+        f%d2Bmod = d2y_batch(:, 4)
+    end subroutine evaluate_albert_batch_der2
 
 end module field_can_albert

--- a/src/get_canonical_coordinates.F90
+++ b/src/get_canonical_coordinates.F90
@@ -1,13 +1,13 @@
 module exchange_get_cancoord_mod
-   use, intrinsic :: iso_fortran_env, only: dp => real64
+    use, intrinsic :: iso_fortran_env, only: dp => real64
 
-   implicit none
-   private
+    implicit none
+    private
 
-   logical, public :: onlytheta
-   real(dp), public :: vartheta_c, varphi_c, sqg, aiota, Bcovar_vartheta, &
-                       Bcovar_varphi, A_theta, A_phi, theta, Bctrvr_vartheta, &
-                       Bctrvr_varphi
+    logical, public :: onlytheta
+    real(dp), public :: vartheta_c, varphi_c, sqg, aiota, Bcovar_vartheta, &
+                        Bcovar_varphi, A_theta, A_phi, theta, Bctrvr_vartheta, &
+                        Bctrvr_varphi
 
 !$omp threadprivate(onlytheta, vartheta_c, varphi_c, sqg, aiota)
 !$omp threadprivate(Bcovar_vartheta, Bcovar_varphi, A_theta, A_phi)
@@ -16,928 +16,928 @@ module exchange_get_cancoord_mod
 end module exchange_get_cancoord_mod
 
 module get_can_sub
-   use, intrinsic :: iso_fortran_env, only: dp => real64
-   use spl_three_to_five_sub
-   use stencil_utils
-   use field, only: magnetic_field_t, vmec_field_t, create_vmec_field, field_clone
-   use field_newton, only: newton_theta_from_canonical
-   use interpolate, only: BatchSplineData1D, BatchSplineData3D, &
-                          construct_batch_splines_1d, construct_batch_splines_3d, &
-                          evaluate_batch_splines_1d_der2, &
-                          evaluate_batch_splines_3d_der, &
-                          evaluate_batch_splines_3d_der2, &
-                          evaluate_batch_splines_3d_der2_rmix, &
-                          destroy_batch_splines_1d, destroy_batch_splines_3d
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use spl_three_to_five_sub
+    use stencil_utils
+    use field, only: magnetic_field_t, vmec_field_t, create_vmec_field, field_clone
+    use field_newton, only: newton_theta_from_canonical
+    use interpolate, only: BatchSplineData1D, BatchSplineData3D, &
+                           construct_batch_splines_1d, construct_batch_splines_3d, &
+                           evaluate_batch_splines_1d_der2, &
+                           evaluate_batch_splines_3d_der, &
+                           evaluate_batch_splines_3d_der2, &
+                           evaluate_batch_splines_3d_der2_rmix, &
+                           destroy_batch_splines_1d, destroy_batch_splines_3d
 
-   implicit none
-   private
+    implicit none
+    private
 
-   public :: get_canonical_coordinates, get_canonical_coordinates_with_field
-   public :: splint_can_coord
-   public :: can_to_vmec, vmec_to_can, vmec_to_cyl
-   public :: deallocate_can_coord
-   public :: reset_canflux_batch_splines
+    public :: get_canonical_coordinates, get_canonical_coordinates_with_field
+    public :: splint_can_coord
+    public :: can_to_vmec, vmec_to_can, vmec_to_cyl
+    public :: deallocate_can_coord
+    public :: reset_canflux_batch_splines
 
-   ! Constants
-   real(dp), parameter :: TWOPI = 2.0_dp*3.14159265358979_dp
+    ! Constants
+    real(dp), parameter :: TWOPI = 2.0_dp*3.14159265358979_dp
 
-   ! Module variable to store the field for use in subroutines
-   class(magnetic_field_t), allocatable :: current_field
+    ! Module variable to store the field for use in subroutines
+    class(magnetic_field_t), allocatable :: current_field
 !$omp threadprivate(current_field)
 
-   ! Batch spline for A_phi (vector potential)
-   type(BatchSplineData1D), save :: aphi_batch_spline
-   logical, save :: aphi_batch_spline_ready = .false.
+    ! Batch spline for A_phi (vector potential)
+    type(BatchSplineData1D), save :: aphi_batch_spline
+    logical, save :: aphi_batch_spline_ready = .false.
 
-   ! Batch spline for G_c (generating function)
-   type(BatchSplineData3D), save :: G_batch_spline
-   logical, save :: G_batch_spline_ready = .false.
+    ! Batch spline for G_c (generating function)
+    type(BatchSplineData3D), save :: G_batch_spline
+    logical, save :: G_batch_spline_ready = .false.
 
-   ! Batch splines for sqg_c, B_vartheta_c, B_varphi_c (separate NQ=1 splines)
-   type(BatchSplineData3D), save :: sqg_batch_spline
-   type(BatchSplineData3D), save :: Bt_batch_spline
-   type(BatchSplineData3D), save :: Bp_batch_spline
-   logical, save :: sqg_batch_spline_ready = .false.
-   logical, save :: Bt_batch_spline_ready = .false.
-   logical, save :: Bp_batch_spline_ready = .false.
+    ! Batch splines for sqg_c, B_vartheta_c, B_varphi_c (separate NQ=1 splines)
+    type(BatchSplineData3D), save :: sqg_batch_spline
+    type(BatchSplineData3D), save :: Bt_batch_spline
+    type(BatchSplineData3D), save :: Bp_batch_spline
+    logical, save :: sqg_batch_spline_ready = .false.
+    logical, save :: Bt_batch_spline_ready = .false.
+    logical, save :: Bp_batch_spline_ready = .false.
 
 contains
 
-   subroutine get_canonical_coordinates_with_field(field)
-      implicit none
+    subroutine get_canonical_coordinates_with_field(field)
+        implicit none
 
-      class(magnetic_field_t), intent(in) :: field
+        class(magnetic_field_t), intent(in) :: field
 
-      ! Store field in module variable for use in nested subroutines
-      call field_clone(field, current_field)
+        ! Store field in module variable for use in nested subroutines
+        call field_clone(field, current_field)
 
-      call reset_canflux_batch_splines
+        call reset_canflux_batch_splines
 
-      ! Call the actual implementation
-      call get_canonical_coordinates_impl
+        ! Call the actual implementation
+        call get_canonical_coordinates_impl
 
-   end subroutine get_canonical_coordinates_with_field
+    end subroutine get_canonical_coordinates_with_field
 
-   subroutine get_canonical_coordinates
-      ! Backward compatibility wrapper - uses VMEC field by default
-      type(vmec_field_t) :: vmec_field
+    subroutine get_canonical_coordinates
+        ! Backward compatibility wrapper - uses VMEC field by default
+        type(vmec_field_t) :: vmec_field
 
-      call create_vmec_field(vmec_field)
-      call get_canonical_coordinates_with_field(vmec_field)
-   end subroutine get_canonical_coordinates
+        call create_vmec_field(vmec_field)
+        call get_canonical_coordinates_with_field(vmec_field)
+    end subroutine get_canonical_coordinates
 
-   subroutine reset_canflux_batch_splines
-      if (aphi_batch_spline_ready) then
-         call destroy_batch_splines_1d(aphi_batch_spline)
-         aphi_batch_spline_ready = .false.
-      end if
-      if (G_batch_spline_ready) then
-         call destroy_batch_splines_3d(G_batch_spline)
-         G_batch_spline_ready = .false.
-      end if
-      if (sqg_batch_spline_ready) then
-         call destroy_batch_splines_3d(sqg_batch_spline)
-         sqg_batch_spline_ready = .false.
-      end if
-      if (Bt_batch_spline_ready) then
-         call destroy_batch_splines_3d(Bt_batch_spline)
-         Bt_batch_spline_ready = .false.
-      end if
-      if (Bp_batch_spline_ready) then
-         call destroy_batch_splines_3d(Bp_batch_spline)
-         Bp_batch_spline_ready = .false.
-      end if
-   end subroutine reset_canflux_batch_splines
+    subroutine reset_canflux_batch_splines
+        if (aphi_batch_spline_ready) then
+            call destroy_batch_splines_1d(aphi_batch_spline)
+            aphi_batch_spline_ready = .false.
+        end if
+        if (G_batch_spline_ready) then
+            call destroy_batch_splines_3d(G_batch_spline)
+            G_batch_spline_ready = .false.
+        end if
+        if (sqg_batch_spline_ready) then
+            call destroy_batch_splines_3d(sqg_batch_spline)
+            sqg_batch_spline_ready = .false.
+        end if
+        if (Bt_batch_spline_ready) then
+            call destroy_batch_splines_3d(Bt_batch_spline)
+            Bt_batch_spline_ready = .false.
+        end if
+        if (Bp_batch_spline_ready) then
+            call destroy_batch_splines_3d(Bp_batch_spline)
+            Bp_batch_spline_ready = .false.
+        end if
+    end subroutine reset_canflux_batch_splines
 
-   subroutine get_canonical_coordinates_impl
-      use canonical_coordinates_mod, only: ns_c, n_theta_c, n_phi_c, &
-                                           hs_c, h_theta_c, h_phi_c, &
-                                           ns_s_c, ns_tp_c, &
-                                           nh_stencil, G_c, sqg_c, &
-                                           B_vartheta_c, B_varphi_c
-      use vector_potentail_mod, only: ns, hs
-      use exchange_get_cancoord_mod, only: vartheta_c, varphi_c, sqg, aiota, &
-                                           Bcovar_vartheta, Bcovar_varphi, &
-                                           onlytheta
-      use new_vmec_stuff_mod, only: n_theta, n_phi, h_theta, h_phi, ns_s, ns_tp
-      use odeint_allroutines_sub, only: odeint_allroutines
+    subroutine get_canonical_coordinates_impl
+        use canonical_coordinates_mod, only: ns_c, n_theta_c, n_phi_c, &
+                                             hs_c, h_theta_c, h_phi_c, &
+                                             ns_s_c, ns_tp_c, &
+                                             nh_stencil, G_c, sqg_c, &
+                                             B_vartheta_c, B_varphi_c
+        use vector_potentail_mod, only: ns, hs
+        use exchange_get_cancoord_mod, only: vartheta_c, varphi_c, sqg, aiota, &
+                                             Bcovar_vartheta, Bcovar_varphi, &
+                                             onlytheta
+        use new_vmec_stuff_mod, only: n_theta, n_phi, h_theta, h_phi, ns_s, ns_tp
+        use odeint_allroutines_sub, only: odeint_allroutines
 
-      implicit none
+        implicit none
 
-      real(dp), parameter :: relerr = 1.0e-10_dp
-      integer :: i_theta, i_phi, i_sten, ndim, is_beg
-      integer, dimension(:), allocatable :: ipoi_t, ipoi_p
-      real(dp), dimension(:), allocatable :: y, dy
-      real(dp) :: dstencil_theta(-nh_stencil:nh_stencil), &
-                  dstencil_phi(-nh_stencil:nh_stencil)
+        real(dp), parameter :: relerr = 1.0e-10_dp
+        integer :: i_theta, i_phi, i_sten, ndim, is_beg
+        integer, dimension(:), allocatable :: ipoi_t, ipoi_p
+        real(dp), dimension(:), allocatable :: y, dy
+        real(dp) :: dstencil_theta(-nh_stencil:nh_stencil), &
+                    dstencil_phi(-nh_stencil:nh_stencil)
 
-      real(dp) :: r, r1, r2, G_beg, dG_c_dt, dG_c_dp
-      integer :: is
-      integer :: i_ctr
+        real(dp) :: r, r1, r2, G_beg, dG_c_dt, dG_c_dp
+        integer :: is
+        integer :: i_ctr
 
-      ns_c = ns
-      n_theta_c = n_theta
-      n_phi_c = n_phi
-      h_theta_c = h_theta
-      h_phi_c = h_phi
-      hs_c = hs
+        ns_c = ns
+        n_theta_c = n_theta
+        n_phi_c = n_phi
+        h_theta_c = h_theta
+        h_phi_c = h_phi
+        hs_c = hs
 
-      ! Initialize derivative stencils using stencil_utils module
-      call init_derivative_stencil(nh_stencil, h_theta_c, dstencil_theta)
-      call init_derivative_stencil(nh_stencil, h_phi_c, dstencil_phi)
+        ! Initialize derivative stencils using stencil_utils module
+        call init_derivative_stencil(nh_stencil, h_theta_c, dstencil_theta)
+        call init_derivative_stencil(nh_stencil, h_phi_c, dstencil_phi)
 
-      allocate (ipoi_t(1 - nh_stencil:n_theta_c + nh_stencil))
-      allocate (ipoi_p(1 - nh_stencil:n_phi_c + nh_stencil))
+        allocate (ipoi_t(1 - nh_stencil:n_theta_c + nh_stencil))
+        allocate (ipoi_p(1 - nh_stencil:n_phi_c + nh_stencil))
 
-      do i_theta = 1, n_theta_c
-         ipoi_t(i_theta) = i_theta
-      end do
+        do i_theta = 1, n_theta_c
+            ipoi_t(i_theta) = i_theta
+        end do
 
-      do i_phi = 1, n_phi_c
-         ipoi_p(i_phi) = i_phi
-      end do
+        do i_phi = 1, n_phi_c
+            ipoi_p(i_phi) = i_phi
+        end do
 
-      do i_sten = 1, nh_stencil
-         ipoi_t(1 - i_sten) = ipoi_t(n_theta - i_sten)
-         ipoi_t(n_theta_c + i_sten) = ipoi_t(1 + i_sten)
-         ipoi_p(1 - i_sten) = ipoi_p(n_phi_c - i_sten)
-         ipoi_p(n_phi_c + i_sten) = ipoi_p(1 + i_sten)
-      end do
+        do i_sten = 1, nh_stencil
+            ipoi_t(1 - i_sten) = ipoi_t(n_theta - i_sten)
+            ipoi_t(n_theta_c + i_sten) = ipoi_t(1 + i_sten)
+            ipoi_p(1 - i_sten) = ipoi_p(n_phi_c - i_sten)
+            ipoi_p(n_phi_c + i_sten) = ipoi_p(1 + i_sten)
+        end do
 
-      allocate (G_c(ns_c, n_theta_c, n_phi_c))
-      allocate (sqg_c(ns_c, n_theta_c, n_phi_c))
-      allocate (B_vartheta_c(ns_c, n_theta_c, n_phi_c))
-      allocate (B_varphi_c(ns_c, n_theta_c, n_phi_c))
+        allocate (G_c(ns_c, n_theta_c, n_phi_c))
+        allocate (sqg_c(ns_c, n_theta_c, n_phi_c))
+        allocate (B_vartheta_c(ns_c, n_theta_c, n_phi_c))
+        allocate (B_varphi_c(ns_c, n_theta_c, n_phi_c))
 
-      onlytheta = .false.
-      ndim = 1
-      is_beg = 1
-      G_beg = 1.0e-8_dp
+        onlytheta = .false.
+        ndim = 1
+        is_beg = 1
+        G_beg = 1.0e-8_dp
 
-      i_ctr = 0
+        i_ctr = 0
 !$omp parallel private(y, dy, i_theta, i_phi, is, r1, r2, r, dG_c_dt, dG_c_dp)
 !$omp critical
-      allocate (y(ndim), dy(ndim))
+        allocate (y(ndim), dy(ndim))
 !$omp end critical
 
 !$omp do
-      do i_theta = 1, n_theta_c
+        do i_theta = 1, n_theta_c
 #ifdef SIMPLE_ENABLE_DEBUG_OUTPUT
 !$omp critical
-         i_ctr = i_ctr + 1
-         call print_progress('integrate ODE: ', i_ctr, n_theta_c)
+            i_ctr = i_ctr + 1
+            call print_progress('integrate ODE: ', i_ctr, n_theta_c)
 !$omp end critical
 #endif
-         vartheta_c = h_theta_c*real(i_theta - 1, dp)
-         do i_phi = 1, n_phi_c
-            varphi_c = h_phi_c*real(i_phi - 1, dp)
+            vartheta_c = h_theta_c*real(i_theta - 1, dp)
+            do i_phi = 1, n_phi_c
+                varphi_c = h_phi_c*real(i_phi - 1, dp)
 
-            G_c(is_beg, i_theta, i_phi) = G_beg
-            y(1) = G_beg
+                G_c(is_beg, i_theta, i_phi) = G_beg
+                y(1) = G_beg
 
-            do is = is_beg - 1, 2, -1
-               r1 = hs_c*real(is, dp)
-               r2 = hs_c*real(is - 1, dp)
+                do is = is_beg - 1, 2, -1
+                    r1 = hs_c*real(is, dp)
+                    r2 = hs_c*real(is - 1, dp)
 
-               call odeint_allroutines(y, ndim, r1, r2, relerr, rhs_cancoord)
+                    call odeint_allroutines(y, ndim, r1, r2, relerr, rhs_cancoord)
 
-               G_c(is, i_theta, i_phi) = y(1)
+                    G_c(is, i_theta, i_phi) = y(1)
+                end do
+
+                y(1) = G_beg
+
+                do is = is_beg + 1, ns_c
+                    r1 = hs_c*real(is - 2, dp)
+                    r2 = hs_c*real(is - 1, dp)
+                    if (is == 2) r1 = 1.0e-8_dp
+
+                    call odeint_allroutines(y, ndim, r1, r2, relerr, rhs_cancoord)
+
+                    G_c(is, i_theta, i_phi) = y(1)
+                end do
             end do
-
-            y(1) = G_beg
-
-            do is = is_beg + 1, ns_c
-               r1 = hs_c*real(is - 2, dp)
-               r2 = hs_c*real(is - 1, dp)
-               if (is == 2) r1 = 1.0e-8_dp
-
-               call odeint_allroutines(y, ndim, r1, r2, relerr, rhs_cancoord)
-
-               G_c(is, i_theta, i_phi) = y(1)
-            end do
-         end do
-      end do
+        end do
 !$omp end do
 
-      i_ctr = 0
+        i_ctr = 0
 !$omp barrier
 !$omp do
-      do i_theta = 1, n_theta_c
+        do i_theta = 1, n_theta_c
 #ifdef SIMPLE_ENABLE_DEBUG_OUTPUT
 !$omp critical
-         i_ctr = i_ctr + 1
-         call print_progress('compute components: ', i_ctr, n_theta_c)
+            i_ctr = i_ctr + 1
+            call print_progress('compute components: ', i_ctr, n_theta_c)
 !$omp end critical
 #endif
-         vartheta_c = h_theta_c*real(i_theta - 1, dp)
-         do i_phi = 1, n_phi_c
-            varphi_c = h_phi_c*real(i_phi - 1, dp)
+            vartheta_c = h_theta_c*real(i_theta - 1, dp)
+            do i_phi = 1, n_phi_c
+                varphi_c = h_phi_c*real(i_phi - 1, dp)
 
-            do is = 2, ns_c
-               r = hs_c*real(is - 1, dp)
-               y(1) = G_c(is, i_theta, i_phi)
+                do is = 2, ns_c
+                    r = hs_c*real(is - 1, dp)
+                    y(1) = G_c(is, i_theta, i_phi)
 
-               call rhs_cancoord(r, y, dy)
+                    call rhs_cancoord(r, y, dy)
 
-               dG_c_dt = sum(dstencil_theta*G_c(is, &
-                                                ipoi_t(i_theta - &
-                                                       nh_stencil:i_theta + &
-                                                       nh_stencil), i_phi))
-               dG_c_dp = sum(dstencil_phi*G_c(is, i_theta, &
-                                              ipoi_p(i_phi - nh_stencil:i_phi + &
-                                                     nh_stencil)))
-               sqg_c(is, i_theta, i_phi) = sqg*(1.0_dp + aiota*dG_c_dt + dG_c_dp)
-               B_vartheta_c(is, i_theta, i_phi) = Bcovar_vartheta + &
-                                                  (aiota*Bcovar_vartheta + &
-                                                   Bcovar_varphi)*dG_c_dt
-               B_varphi_c(is, i_theta, i_phi) = Bcovar_varphi + &
-                                                (aiota*Bcovar_vartheta + &
-                                                 Bcovar_varphi)*dG_c_dp
+                    dG_c_dt = sum(dstencil_theta*G_c(is, &
+                                                     ipoi_t(i_theta - &
+                                                            nh_stencil:i_theta + &
+                                                            nh_stencil), i_phi))
+                    dG_c_dp = sum(dstencil_phi*G_c(is, i_theta, &
+                                                   ipoi_p(i_phi - nh_stencil:i_phi + &
+                                                          nh_stencil)))
+                    sqg_c(is, i_theta, i_phi) = sqg*(1.0_dp + aiota*dG_c_dt + dG_c_dp)
+                    B_vartheta_c(is, i_theta, i_phi) = Bcovar_vartheta + &
+                                                       (aiota*Bcovar_vartheta + &
+                                                        Bcovar_varphi)*dG_c_dt
+                    B_varphi_c(is, i_theta, i_phi) = Bcovar_varphi + &
+                                                     (aiota*Bcovar_vartheta + &
+                                                      Bcovar_varphi)*dG_c_dp
+                end do
+                ! Extrapolate on-axis point (is=1) with parabola
+                sqg_c(1, i_theta, i_phi) = 3.0_dp*(sqg_c(2, i_theta, i_phi) &
+                                                   - sqg_c(3, i_theta, i_phi)) + &
+                                           sqg_c(4, i_theta, i_phi)
+                B_vartheta_c(1, i_theta, i_phi) = 0.0_dp
+                B_varphi_c(1, i_theta, i_phi) = 3.0_dp*(B_varphi_c(2, i_theta, i_phi) &
+                                                        - B_varphi_c(3, i_theta, &
+                                                               i_phi)) + B_varphi_c(4, &
+                                                                         i_theta, i_phi)
             end do
-            ! Extrapolate on-axis point (is=1) with parabola
-            sqg_c(1, i_theta, i_phi) = 3.0_dp*(sqg_c(2, i_theta, i_phi) &
-                                               - sqg_c(3, i_theta, i_phi)) + &
-                                       sqg_c(4, i_theta, i_phi)
-            B_vartheta_c(1, i_theta, i_phi) = 0.0_dp
-            B_varphi_c(1, i_theta, i_phi) = 3.0_dp*(B_varphi_c(2, i_theta, i_phi) &
-                                                    - B_varphi_c(3, i_theta, &
-                                                                 i_phi)) + B_varphi_c(4, &
-                                                                                      i_theta, i_phi)
-         end do
-      end do
+        end do
 !$omp end do
 
 !$omp critical
-      deallocate (y, dy)
+        deallocate (y, dy)
 !$omp end critical
 !$omp end parallel
 
-      ns_s_c = ns_s
-      ns_tp_c = ns_tp
+        ns_s_c = ns_s
+        ns_tp_c = ns_tp
 
-      onlytheta = .true.
+        onlytheta = .true.
 
-      ! Build batch splines from computed grids
-      call build_canflux_aphi_batch_spline
-      call build_canflux_G_batch_spline
-      call build_canflux_sqg_Bt_Bp_batch_spline
+        ! Build batch splines from computed grids
+        call build_canflux_aphi_batch_spline
+        call build_canflux_G_batch_spline
+        call build_canflux_sqg_Bt_Bp_batch_spline
 
-      deallocate (ipoi_t, ipoi_p, sqg_c, B_vartheta_c, B_varphi_c, G_c)
+        deallocate (ipoi_t, ipoi_p, sqg_c, B_vartheta_c, B_varphi_c, G_c)
 
-   end subroutine get_canonical_coordinates_impl
+    end subroutine get_canonical_coordinates_impl
 
-   subroutine build_canflux_aphi_batch_spline
-      use vector_potentail_mod, only: ns, hs, sA_phi
-      use new_vmec_stuff_mod, only: ns_A
+    subroutine build_canflux_aphi_batch_spline
+        use vector_potentail_mod, only: ns, hs, sA_phi
+        use new_vmec_stuff_mod, only: ns_A
 
-      integer :: order
+        integer :: order
 
-      if (aphi_batch_spline_ready) then
-         call destroy_batch_splines_1d(aphi_batch_spline)
-         aphi_batch_spline_ready = .false.
-      end if
+        if (aphi_batch_spline_ready) then
+            call destroy_batch_splines_1d(aphi_batch_spline)
+            aphi_batch_spline_ready = .false.
+        end if
 
-      order = ns_A
-      if (order < 3 .or. order > 5) then
-         error stop "build_canflux_aphi_batch_spline: spline order must be 3..5"
-      end if
+        order = ns_A
+        if (order < 3 .or. order > 5) then
+            error stop "build_canflux_aphi_batch_spline: spline order must be 3..5"
+        end if
 
-      aphi_batch_spline%order = order
-      aphi_batch_spline%num_points = ns
-      aphi_batch_spline%periodic = .false.
-      aphi_batch_spline%x_min = 0.0_dp
-      aphi_batch_spline%h_step = hs
-      aphi_batch_spline%num_quantities = 1
+        aphi_batch_spline%order = order
+        aphi_batch_spline%num_points = ns
+        aphi_batch_spline%periodic = .false.
+        aphi_batch_spline%x_min = 0.0_dp
+        aphi_batch_spline%h_step = hs
+        aphi_batch_spline%num_quantities = 1
 
-      allocate (aphi_batch_spline%coeff(1, 0:order, ns))
-      aphi_batch_spline%coeff(1, 0:order, :) = sA_phi(1:order + 1, :)
+        allocate (aphi_batch_spline%coeff(1, 0:order, ns))
+        aphi_batch_spline%coeff(1, 0:order, :) = sA_phi(1:order + 1, :)
 
-      aphi_batch_spline_ready = .true.
-   end subroutine build_canflux_aphi_batch_spline
+        aphi_batch_spline_ready = .true.
+    end subroutine build_canflux_aphi_batch_spline
 
-   subroutine build_canflux_G_batch_spline
-      use canonical_coordinates_mod, only: ns_c, n_theta_c, n_phi_c, &
-                                           hs_c, h_theta_c, h_phi_c, &
-                                           ns_s_c, ns_tp_c, G_c
+    subroutine build_canflux_G_batch_spline
+        use canonical_coordinates_mod, only: ns_c, n_theta_c, n_phi_c, &
+                                             hs_c, h_theta_c, h_phi_c, &
+                                             ns_s_c, ns_tp_c, G_c
 
-      integer :: order(3)
-      real(dp) :: x_min(3), x_max(3)
-      logical :: periodic(3)
-      real(dp), allocatable :: y_batch(:, :, :, :)
+        integer :: order(3)
+        real(dp) :: x_min(3), x_max(3)
+        logical :: periodic(3)
+        real(dp), allocatable :: y_batch(:, :, :, :)
 
-      if (G_batch_spline_ready) then
-         call destroy_batch_splines_3d(G_batch_spline)
-         G_batch_spline_ready = .false.
-      end if
+        if (G_batch_spline_ready) then
+            call destroy_batch_splines_3d(G_batch_spline)
+            G_batch_spline_ready = .false.
+        end if
 
       order = [ns_s_c, ns_tp_c, ns_tp_c]
       if (minval(order) < 3 .or. maxval(order) > 5) then
          error stop "build_canflux_G_batch_spline: spline order must be 3..5"
       end if
 
-      x_min = [0.0_dp, 0.0_dp, 0.0_dp]
-      x_max(1) = hs_c*real(ns_c - 1, dp)
-      x_max(2) = h_theta_c*real(n_theta_c - 1, dp)
-      x_max(3) = h_phi_c*real(n_phi_c - 1, dp)
+        x_min = [0.0_dp, 0.0_dp, 0.0_dp]
+        x_max(1) = hs_c*real(ns_c - 1, dp)
+        x_max(2) = h_theta_c*real(n_theta_c - 1, dp)
+        x_max(3) = h_phi_c*real(n_phi_c - 1, dp)
 
-      periodic = [.false., .true., .true.]
+        periodic = [.false., .true., .true.]
 
-      allocate (y_batch(ns_c, n_theta_c, n_phi_c, 1))
-      y_batch(:, :, :, 1) = G_c
+        allocate (y_batch(ns_c, n_theta_c, n_phi_c, 1))
+        y_batch(:, :, :, 1) = G_c
 
-      call construct_batch_splines_3d(x_min, x_max, y_batch, order, periodic, &
-                                      G_batch_spline)
-      G_batch_spline_ready = .true.
-      deallocate (y_batch)
-   end subroutine build_canflux_G_batch_spline
+        call construct_batch_splines_3d(x_min, x_max, y_batch, order, periodic, &
+                                        G_batch_spline)
+        G_batch_spline_ready = .true.
+        deallocate (y_batch)
+    end subroutine build_canflux_G_batch_spline
 
-   subroutine build_canflux_sqg_Bt_Bp_batch_spline
-      use canonical_coordinates_mod, only: ns_c, n_theta_c, n_phi_c, &
-                                           hs_c, h_theta_c, h_phi_c, &
-                                           ns_s_c, ns_tp_c, &
-                                           sqg_c, B_vartheta_c, B_varphi_c
+    subroutine build_canflux_sqg_Bt_Bp_batch_spline
+        use canonical_coordinates_mod, only: ns_c, n_theta_c, n_phi_c, &
+                                             hs_c, h_theta_c, h_phi_c, &
+                                             ns_s_c, ns_tp_c, &
+                                             sqg_c, B_vartheta_c, B_varphi_c
 
-      integer :: order(3)
-      real(dp) :: x_min(3), x_max(3)
-      logical :: periodic(3)
-      real(dp), allocatable :: y_batch(:, :, :, :)
+        integer :: order(3)
+        real(dp) :: x_min(3), x_max(3)
+        logical :: periodic(3)
+        real(dp), allocatable :: y_batch(:, :, :, :)
 
-      if (sqg_batch_spline_ready) then
-         call destroy_batch_splines_3d(sqg_batch_spline)
-         sqg_batch_spline_ready = .false.
-      end if
-      if (Bt_batch_spline_ready) then
-         call destroy_batch_splines_3d(Bt_batch_spline)
-         Bt_batch_spline_ready = .false.
-      end if
-      if (Bp_batch_spline_ready) then
-         call destroy_batch_splines_3d(Bp_batch_spline)
-         Bp_batch_spline_ready = .false.
-      end if
+        if (sqg_batch_spline_ready) then
+            call destroy_batch_splines_3d(sqg_batch_spline)
+            sqg_batch_spline_ready = .false.
+        end if
+        if (Bt_batch_spline_ready) then
+            call destroy_batch_splines_3d(Bt_batch_spline)
+            Bt_batch_spline_ready = .false.
+        end if
+        if (Bp_batch_spline_ready) then
+            call destroy_batch_splines_3d(Bp_batch_spline)
+            Bp_batch_spline_ready = .false.
+        end if
 
       order = [ns_s_c, ns_tp_c, ns_tp_c]
       if (minval(order) < 3 .or. maxval(order) > 5) then
          error stop "build_canflux_sqg_Bt_Bp_batch_spline: spline order must be 3..5"
       end if
 
-      x_min = [0.0_dp, 0.0_dp, 0.0_dp]
-      x_max(1) = hs_c*real(ns_c - 1, dp)
-      x_max(2) = h_theta_c*real(n_theta_c - 1, dp)
-      x_max(3) = h_phi_c*real(n_phi_c - 1, dp)
+        x_min = [0.0_dp, 0.0_dp, 0.0_dp]
+        x_max(1) = hs_c*real(ns_c - 1, dp)
+        x_max(2) = h_theta_c*real(n_theta_c - 1, dp)
+        x_max(3) = h_phi_c*real(n_phi_c - 1, dp)
 
-      periodic = [.false., .true., .true.]
+        periodic = [.false., .true., .true.]
 
-      allocate (y_batch(ns_c, n_theta_c, n_phi_c, 1))
+        allocate (y_batch(ns_c, n_theta_c, n_phi_c, 1))
 
-      y_batch(:, :, :, 1) = sqg_c
-      call construct_batch_splines_3d(x_min, x_max, y_batch, order, periodic, &
-                                      sqg_batch_spline)
-      sqg_batch_spline_ready = .true.
+        y_batch(:, :, :, 1) = sqg_c
+        call construct_batch_splines_3d(x_min, x_max, y_batch, order, periodic, &
+                                        sqg_batch_spline)
+        sqg_batch_spline_ready = .true.
 
-      y_batch(:, :, :, 1) = B_vartheta_c
-      call construct_batch_splines_3d(x_min, x_max, y_batch, order, periodic, &
-                                      Bt_batch_spline)
-      Bt_batch_spline_ready = .true.
+        y_batch(:, :, :, 1) = B_vartheta_c
+        call construct_batch_splines_3d(x_min, x_max, y_batch, order, periodic, &
+                                        Bt_batch_spline)
+        Bt_batch_spline_ready = .true.
 
-      y_batch(:, :, :, 1) = B_varphi_c
-      call construct_batch_splines_3d(x_min, x_max, y_batch, order, periodic, &
-                                      Bp_batch_spline)
-      Bp_batch_spline_ready = .true.
+        y_batch(:, :, :, 1) = B_varphi_c
+        call construct_batch_splines_3d(x_min, x_max, y_batch, order, periodic, &
+                                        Bp_batch_spline)
+        Bp_batch_spline_ready = .true.
 
-      deallocate (y_batch)
-   end subroutine build_canflux_sqg_Bt_Bp_batch_spline
+        deallocate (y_batch)
+    end subroutine build_canflux_sqg_Bt_Bp_batch_spline
 
-   subroutine rhs_cancoord(r, y, dy)
-      use exchange_get_cancoord_mod, only: vartheta_c, varphi_c, sqg, aiota, &
-                                           Bcovar_vartheta, Bcovar_varphi, &
-                                           theta, onlytheta
-      use spline_vmec_sub
-      use vmec_field_eval
+    subroutine rhs_cancoord(r, y, dy)
+        use exchange_get_cancoord_mod, only: vartheta_c, varphi_c, sqg, aiota, &
+                                             Bcovar_vartheta, Bcovar_varphi, &
+                                             theta, onlytheta
+        use spline_vmec_sub
+        use vmec_field_eval
 
-      implicit none
+        implicit none
 
-      real(dp), intent(in) :: r
-      real(dp), intent(in) :: y(:)
-      real(dp), intent(out) :: dy(:)
+        real(dp), intent(in) :: r
+        real(dp), intent(in) :: y(:)
+        real(dp), intent(out) :: dy(:)
 
-      real(dp), parameter :: epserr = 1.0e-14_dp
-      integer :: iter
-      real(dp) :: s, varphi, A_theta, A_phi, dA_theta_ds, dA_phi_ds, &
-                  alam, dl_ds, dl_dt, dl_dp, Bctrvr_vartheta, Bctrvr_varphi, Bcovar_r
-      logical :: converged
+        real(dp), parameter :: epserr = 1.0e-14_dp
+        integer :: iter
+        real(dp) :: s, varphi, A_theta, A_phi, dA_theta_ds, dA_phi_ds, &
+                    alam, dl_ds, dl_dt, dl_dp, Bctrvr_vartheta, Bctrvr_varphi, Bcovar_r
+        logical :: converged
 
-      real(dp) :: vartheta, daiota_ds, deltheta
+        real(dp) :: vartheta, daiota_ds, deltheta
 
-      s = r**2
+        s = r**2
 
-      if (allocated(current_field)) then
-         call vmec_iota_interpolate_with_field(current_field, s, aiota, daiota_ds)
-      else
-         call vmec_iota_interpolate(s, aiota, daiota_ds)
-      end if
+        if (allocated(current_field)) then
+            call vmec_iota_interpolate_with_field(current_field, s, aiota, daiota_ds)
+        else
+            call vmec_iota_interpolate(s, aiota, daiota_ds)
+        end if
 
-      vartheta = vartheta_c + aiota*y(1)
-      varphi = varphi_c + y(1)
+        vartheta = vartheta_c + aiota*y(1)
+        varphi = varphi_c + y(1)
 
-      ! Newton iteration to find field-specific theta from canonical theta
-      if (allocated(current_field)) then
-         theta = vartheta
-         call newton_theta_from_canonical(current_field, s, vartheta, varphi, &
-                                          theta, converged)
-         if (.not. converged) then
-            print *, 'WARNING: Newton iteration failed in rhs_cancoord'
-         end if
-      else
-         theta = vartheta
-         do iter = 1, 100
-            call vmec_lambda_interpolate(s, theta, varphi, alam, dl_dt)
-            deltheta = (vartheta - theta - alam)/(1.0_dp + dl_dt)
-            theta = theta + deltheta
-            if (abs(deltheta) < epserr) exit
-         end do
-      end if
+        ! Newton iteration to find field-specific theta from canonical theta
+        if (allocated(current_field)) then
+            theta = vartheta
+            call newton_theta_from_canonical(current_field, s, vartheta, varphi, &
+                                             theta, converged)
+            if (.not. converged) then
+                print *, 'WARNING: Newton iteration failed in rhs_cancoord'
+            end if
+        else
+            theta = vartheta
+            do iter = 1, 100
+                call vmec_lambda_interpolate(s, theta, varphi, alam, dl_dt)
+                deltheta = (vartheta - theta - alam)/(1.0_dp + dl_dt)
+                theta = theta + deltheta
+                if (abs(deltheta) < epserr) exit
+            end do
+        end if
 
-      if (onlytheta) return
+        if (onlytheta) return
 
-      if (allocated(current_field)) then
-         call vmec_field_evaluate_with_field(current_field, s, theta, varphi, &
-                                             A_theta, A_phi, dA_theta_ds, &
-                                             dA_phi_ds, aiota, &
-                                             sqg, alam, dl_ds, dl_dt, dl_dp, &
-                                             Bctrvr_vartheta, Bctrvr_varphi, &
-                                             Bcovar_r, Bcovar_vartheta, &
-                                             Bcovar_varphi)
-      else
-         call vmec_field_evaluate(s, theta, varphi, A_theta, A_phi, &
-                                  dA_theta_ds, dA_phi_ds, aiota, &
-                                  sqg, alam, dl_ds, dl_dt, dl_dp, Bctrvr_vartheta, &
-                                  Bctrvr_varphi, &
-                                  Bcovar_r, Bcovar_vartheta, Bcovar_varphi)
-      end if
+        if (allocated(current_field)) then
+            call vmec_field_evaluate_with_field(current_field, s, theta, varphi, &
+                                                A_theta, A_phi, dA_theta_ds, &
+                                                dA_phi_ds, aiota, &
+                                                sqg, alam, dl_ds, dl_dt, dl_dp, &
+                                                Bctrvr_vartheta, Bctrvr_varphi, &
+                                                Bcovar_r, Bcovar_vartheta, &
+                                                Bcovar_varphi)
+        else
+            call vmec_field_evaluate(s, theta, varphi, A_theta, A_phi, &
+                                     dA_theta_ds, dA_phi_ds, aiota, &
+                                     sqg, alam, dl_ds, dl_dt, dl_dp, Bctrvr_vartheta, &
+                                     Bctrvr_varphi, &
+                                     Bcovar_r, Bcovar_vartheta, Bcovar_varphi)
+        end if
 
-      dy(1) = -(Bcovar_r + daiota_ds*Bcovar_vartheta*y(1))/ &
-              (aiota*Bcovar_vartheta + Bcovar_varphi)
-      dy(1) = 2.0_dp*r*dy(1)
+        dy(1) = -(Bcovar_r + daiota_ds*Bcovar_vartheta*y(1))/ &
+                (aiota*Bcovar_vartheta + Bcovar_varphi)
+        dy(1) = 2.0_dp*r*dy(1)
 
-   end subroutine rhs_cancoord
+    end subroutine rhs_cancoord
 
-   subroutine print_progress(message, progress, total)
-      character(*), intent(in) :: message
-      integer, intent(in) :: progress, total
+    subroutine print_progress(message, progress, total)
+        character(*), intent(in) :: message
+        integer, intent(in) :: progress, total
 
 #ifndef SIMPLE_ENABLE_DEBUG_OUTPUT
-      return
+        return
 #endif
 
-      write (*, '(A, I4, A, I4)', advance='no') message, progress, ' of ', total
+        write (*, '(A, I4, A, I4)', advance='no') message, progress, ' of ', total
 
-      if (progress < total) then
-         write (*, '(A)', advance="no") char(13)
-      else
-         write (*, *)
-      end if
-   end subroutine print_progress
+        if (progress < total) then
+            write (*, '(A)', advance="no") char(13)
+        else
+            write (*, *)
+        end if
+    end subroutine print_progress
 
-   subroutine splint_can_coord(fullset, mode_secders, r, vartheta_c, varphi_c, &
-                               A_theta, A_phi, dA_theta_dr, dA_phi_dr, &
-                               d2A_phi_dr2, d3A_phi_dr3, &
-                               sqg_c, dsqg_c_dr, dsqg_c_dt, dsqg_c_dp, &
-                               B_vartheta_c, dB_vartheta_c_dr, &
-                               dB_vartheta_c_dt, dB_vartheta_c_dp, &
-                               B_varphi_c, dB_varphi_c_dr, &
-                               dB_varphi_c_dt, dB_varphi_c_dp, &
-                               d2sqg_rr, d2sqg_rt, d2sqg_rp, &
-                               d2sqg_tt, d2sqg_tp, d2sqg_pp, &
-                               d2bth_rr, d2bth_rt, d2bth_rp, &
-                               d2bth_tt, d2bth_tp, d2bth_pp, &
-                               d2bph_rr, d2bph_rt, d2bph_rp, &
-                               d2bph_tt, d2bph_tp, d2bph_pp, G_c)
+    subroutine splint_can_coord(fullset, mode_secders, r, vartheta_c, varphi_c, &
+                                A_theta, A_phi, dA_theta_dr, dA_phi_dr, &
+                                d2A_phi_dr2, d3A_phi_dr3, &
+                                sqg_c, dsqg_c_dr, dsqg_c_dt, dsqg_c_dp, &
+                                B_vartheta_c, dB_vartheta_c_dr, &
+                                dB_vartheta_c_dt, dB_vartheta_c_dp, &
+                                B_varphi_c, dB_varphi_c_dr, &
+                                dB_varphi_c_dt, dB_varphi_c_dp, &
+                                d2sqg_rr, d2sqg_rt, d2sqg_rp, &
+                                d2sqg_tt, d2sqg_tp, d2sqg_pp, &
+                                d2bth_rr, d2bth_rt, d2bth_rp, &
+                                d2bth_tt, d2bth_tp, d2bth_pp, &
+                                d2bph_rr, d2bph_rt, d2bph_rp, &
+                                d2bph_tt, d2bph_tp, d2bph_pp, G_c)
 
-      use vector_potentail_mod, only: torflux
-      use new_vmec_stuff_mod, only: nper
-      use chamb_mod, only: rnegflag
-      use diag_mod, only: dodiag, icounter
+        use vector_potentail_mod, only: torflux
+        use new_vmec_stuff_mod, only: nper
+        use chamb_mod, only: rnegflag
+        use diag_mod, only: dodiag, icounter
 
-      implicit none
+        implicit none
 
-      logical, intent(in) :: fullset
-      integer, intent(in) :: mode_secders
-      real(dp), intent(in) :: r
-      real(dp), intent(in) :: vartheta_c, varphi_c
+        logical, intent(in) :: fullset
+        integer, intent(in) :: mode_secders
+        real(dp), intent(in) :: r
+        real(dp), intent(in) :: vartheta_c, varphi_c
 
-      real(dp), intent(out) :: A_phi, A_theta, dA_phi_dr, dA_theta_dr
-      real(dp), intent(out) :: d2A_phi_dr2, d3A_phi_dr3
-      real(dp), intent(out) :: sqg_c, dsqg_c_dr, dsqg_c_dt, dsqg_c_dp
-      real(dp), intent(out) :: B_vartheta_c, dB_vartheta_c_dr
-      real(dp), intent(out) :: dB_vartheta_c_dt, dB_vartheta_c_dp
-      real(dp), intent(out) :: B_varphi_c, dB_varphi_c_dr
-      real(dp), intent(out) :: dB_varphi_c_dt, dB_varphi_c_dp
-      real(dp), intent(out) :: d2sqg_rr, d2sqg_rt, d2sqg_rp
-      real(dp), intent(out) :: d2sqg_tt, d2sqg_tp, d2sqg_pp
-      real(dp), intent(out) :: d2bth_rr, d2bth_rt, d2bth_rp
-      real(dp), intent(out) :: d2bth_tt, d2bth_tp, d2bth_pp
-      real(dp), intent(out) :: d2bph_rr, d2bph_rt, d2bph_rp
-      real(dp), intent(out) :: d2bph_tt, d2bph_tp, d2bph_pp
-      real(dp), intent(out) :: G_c
+        real(dp), intent(out) :: A_phi, A_theta, dA_phi_dr, dA_theta_dr
+        real(dp), intent(out) :: d2A_phi_dr2, d3A_phi_dr3
+        real(dp), intent(out) :: sqg_c, dsqg_c_dr, dsqg_c_dt, dsqg_c_dp
+        real(dp), intent(out) :: B_vartheta_c, dB_vartheta_c_dr
+        real(dp), intent(out) :: dB_vartheta_c_dt, dB_vartheta_c_dp
+        real(dp), intent(out) :: B_varphi_c, dB_varphi_c_dr
+        real(dp), intent(out) :: dB_varphi_c_dt, dB_varphi_c_dp
+        real(dp), intent(out) :: d2sqg_rr, d2sqg_rt, d2sqg_rp
+        real(dp), intent(out) :: d2sqg_tt, d2sqg_tp, d2sqg_pp
+        real(dp), intent(out) :: d2bth_rr, d2bth_rt, d2bth_rp
+        real(dp), intent(out) :: d2bth_tt, d2bth_tp, d2bth_pp
+        real(dp), intent(out) :: d2bph_rr, d2bph_rt, d2bph_rp
+        real(dp), intent(out) :: d2bph_tt, d2bph_tp, d2bph_pp
+        real(dp), intent(out) :: G_c
 
-      real(dp) :: r_eval
-      real(dp) :: rho_tor, drhods, drhods2, d2rhods2m
-      real(dp) :: x_eval(3)
-      real(dp) :: yq(1), dyq(3, 1), d2yq(6, 1)
-      real(dp) :: d2yq_rmix(3, 1)
-      real(dp) :: y_G(1), dy_G(3, 1)
-      real(dp) :: y1d(1), dy1d(1), d2y1d(1)
-      real(dp) :: theta_wrapped, phi_wrapped
-      real(dp) :: qua, dqua_dr, dqua_dt, dqua_dp
-      real(dp) :: d2qua_dr2, d2qua_drdt, d2qua_drdp
-      real(dp) :: d2qua_dt2, d2qua_dtdp, d2qua_dp2
+        real(dp) :: r_eval
+        real(dp) :: rho_tor, drhods, drhods2, d2rhods2m
+        real(dp) :: x_eval(3)
+        real(dp) :: yq(1), dyq(3, 1), d2yq(6, 1)
+        real(dp) :: d2yq_rmix(3, 1)
+        real(dp) :: y_G(1), dy_G(3, 1)
+        real(dp) :: y1d(1), dy1d(1), d2y1d(1)
+        real(dp) :: theta_wrapped, phi_wrapped
+        real(dp) :: qua, dqua_dr, dqua_dt, dqua_dp
+        real(dp) :: d2qua_dr2, d2qua_drdt, d2qua_drdp
+        real(dp) :: d2qua_dt2, d2qua_dtdp, d2qua_dp2
 
-      if (dodiag) then
+        if (dodiag) then
 !$omp atomic
-         icounter = icounter + 1
-      end if
-      r_eval = r
-      if (r_eval <= 0.0_dp) then
-         rnegflag = .true.
-         r_eval = abs(r_eval)
-      end if
+            icounter = icounter + 1
+        end if
+        r_eval = r
+        if (r_eval <= 0.0_dp) then
+            rnegflag = .true.
+            r_eval = abs(r_eval)
+        end if
 
-      A_theta = torflux*r_eval
-      dA_theta_dr = torflux
+        A_theta = torflux*r_eval
+        dA_theta_dr = torflux
 
-      ! Interpolate A_phi using batch spline (1D)
-      if (.not. aphi_batch_spline_ready) then
-         error stop "splint_can_coord: Aphi batch spline not initialized"
-      end if
+        ! Interpolate A_phi using batch spline (1D)
+        if (.not. aphi_batch_spline_ready) then
+            error stop "splint_can_coord: Aphi batch spline not initialized"
+        end if
 
-      call evaluate_batch_splines_1d_der2(aphi_batch_spline, r_eval, &
-                                          y1d, dy1d, d2y1d)
-      d3A_phi_dr3 = 0.0_dp
-      A_phi = y1d(1)
-      dA_phi_dr = dy1d(1)
-      d2A_phi_dr2 = d2y1d(1)
+        call evaluate_batch_splines_1d_der2(aphi_batch_spline, r_eval, &
+                                            y1d, dy1d, d2y1d)
+        d3A_phi_dr3 = 0.0_dp
+        A_phi = y1d(1)
+        dA_phi_dr = dy1d(1)
+        d2A_phi_dr2 = d2y1d(1)
 
-      ! Prepare coordinates for 3D interpolation
-      rho_tor = sqrt(r_eval)
-      theta_wrapped = modulo(vartheta_c, TWOPI)
-      phi_wrapped = modulo(varphi_c, TWOPI/real(nper, dp))
+        ! Prepare coordinates for 3D interpolation
+        rho_tor = sqrt(r_eval)
+        theta_wrapped = modulo(vartheta_c, TWOPI)
+        phi_wrapped = modulo(varphi_c, TWOPI/real(nper, dp))
 
-      x_eval(1) = rho_tor
-      x_eval(2) = theta_wrapped
-      x_eval(3) = phi_wrapped
+        x_eval(1) = rho_tor
+        x_eval(2) = theta_wrapped
+        x_eval(3) = phi_wrapped
 
-      ! Chain rule coefficients for rho -> s conversion
-      ! rho = sqrt(s), drho/ds = 0.5/rho, d2rho/ds2 = -0.25/rho^3
-      drhods = 0.5_dp/rho_tor
-      drhods2 = drhods**2
-      d2rhods2m = drhods2/rho_tor  ! -d2rho/ds2 (negated for chain rule)
+        ! Chain rule coefficients for rho -> s conversion
+        ! rho = sqrt(s), drho/ds = 0.5/rho, d2rho/ds2 = -0.25/rho^3
+        drhods = 0.5_dp/rho_tor
+        drhods2 = drhods**2
+        d2rhods2m = drhods2/rho_tor  ! -d2rho/ds2 (negated for chain rule)
 
-      ! Interpolate G if needed
-      if (fullset) then
-         if (.not. G_batch_spline_ready) then
-            error stop "splint_can_coord: G batch spline not initialized"
-         end if
-         call evaluate_batch_splines_3d_der(G_batch_spline, x_eval, y_G, dy_G)
-         G_c = y_G(1)
-      else
-         G_c = 0.0_dp
-      end if
+        ! Interpolate G if needed
+        if (fullset) then
+            if (.not. G_batch_spline_ready) then
+                error stop "splint_can_coord: G batch spline not initialized"
+            end if
+            call evaluate_batch_splines_3d_der(G_batch_spline, x_eval, y_G, dy_G)
+            G_c = y_G(1)
+        else
+            G_c = 0.0_dp
+        end if
 
-      ! Interpolate sqg, B_vartheta, B_varphi (separate NQ=1 splines)
-      if (.not. (sqg_batch_spline_ready .and. Bt_batch_spline_ready .and. &
-                 Bp_batch_spline_ready)) then
-         error stop "splint_can_coord: sqg/Bt/Bp batch splines not initialized"
-      end if
+        ! Interpolate sqg, B_vartheta, B_varphi (separate NQ=1 splines)
+        if (.not. (sqg_batch_spline_ready .and. Bt_batch_spline_ready .and. &
+                   Bp_batch_spline_ready)) then
+            error stop "splint_can_coord: sqg/Bt/Bp batch splines not initialized"
+        end if
 
-      if (mode_secders == 2 .or. mode_secders == 3) then
-         if (mode_secders == 2) then
-            call evaluate_batch_splines_3d_der2(sqg_batch_spline, x_eval, yq, &
-                                                dyq, d2yq)
-         else
-            call evaluate_batch_splines_3d_der2_rmix(sqg_batch_spline, x_eval, yq, &
-                                                     dyq, d2yq_rmix)
-            d2yq(1:3, 1) = d2yq_rmix(:, 1)
-            d2yq(4:6, 1) = 0.0_dp
-         end if
+        if (mode_secders == 2 .or. mode_secders == 3) then
+            if (mode_secders == 2) then
+                call evaluate_batch_splines_3d_der2(sqg_batch_spline, x_eval, yq, &
+                                                    dyq, d2yq)
+            else
+                call evaluate_batch_splines_3d_der2_rmix(sqg_batch_spline, x_eval, yq, &
+                                                         dyq, d2yq_rmix)
+                d2yq(1:3, 1) = d2yq_rmix(:, 1)
+                d2yq(4:6, 1) = 0.0_dp
+            end if
 
-         qua = yq(1)
-         dqua_dr = dyq(1, 1)
-         dqua_dt = dyq(2, 1)
-         dqua_dp = dyq(3, 1)
-         d2qua_dr2 = d2yq(1, 1)
-         d2qua_drdt = d2yq(2, 1)
-         d2qua_drdp = d2yq(3, 1)
-         d2qua_dt2 = d2yq(4, 1)
-         d2qua_dtdp = d2yq(5, 1)
-         d2qua_dp2 = d2yq(6, 1)
+            qua = yq(1)
+            dqua_dr = dyq(1, 1)
+            dqua_dt = dyq(2, 1)
+            dqua_dp = dyq(3, 1)
+            d2qua_dr2 = d2yq(1, 1)
+            d2qua_drdt = d2yq(2, 1)
+            d2qua_drdp = d2yq(3, 1)
+            d2qua_dt2 = d2yq(4, 1)
+            d2qua_dtdp = d2yq(5, 1)
+            d2qua_dp2 = d2yq(6, 1)
 
-         d2qua_dr2 = d2qua_dr2*drhods2 - dqua_dr*d2rhods2m
-         dqua_dr = dqua_dr*drhods
-         d2qua_drdt = d2qua_drdt*drhods
-         d2qua_drdp = d2qua_drdp*drhods
+            d2qua_dr2 = d2qua_dr2*drhods2 - dqua_dr*d2rhods2m
+            dqua_dr = dqua_dr*drhods
+            d2qua_drdt = d2qua_drdt*drhods
+            d2qua_drdp = d2qua_drdp*drhods
 
-         sqg_c = qua
-         dsqg_c_dr = dqua_dr
-         dsqg_c_dt = dqua_dt
-         dsqg_c_dp = dqua_dp
-         d2sqg_rr = d2qua_dr2
-         d2sqg_rt = d2qua_drdt
-         d2sqg_rp = d2qua_drdp
-         d2sqg_tt = d2qua_dt2
-         d2sqg_tp = d2qua_dtdp
-         d2sqg_pp = d2qua_dp2
+            sqg_c = qua
+            dsqg_c_dr = dqua_dr
+            dsqg_c_dt = dqua_dt
+            dsqg_c_dp = dqua_dp
+            d2sqg_rr = d2qua_dr2
+            d2sqg_rt = d2qua_drdt
+            d2sqg_rp = d2qua_drdp
+            d2sqg_tt = d2qua_dt2
+            d2sqg_tp = d2qua_dtdp
+            d2sqg_pp = d2qua_dp2
 
-         if (mode_secders == 2) then
-            call evaluate_batch_splines_3d_der2(Bt_batch_spline, x_eval, yq, &
-                                                dyq, d2yq)
-         else
-            call evaluate_batch_splines_3d_der2_rmix(Bt_batch_spline, x_eval, yq, &
-                                                     dyq, d2yq_rmix)
-            d2yq(1:3, 1) = d2yq_rmix(:, 1)
-            d2yq(4:6, 1) = 0.0_dp
-         end if
+            if (mode_secders == 2) then
+                call evaluate_batch_splines_3d_der2(Bt_batch_spline, x_eval, yq, &
+                                                    dyq, d2yq)
+            else
+                call evaluate_batch_splines_3d_der2_rmix(Bt_batch_spline, x_eval, yq, &
+                                                         dyq, d2yq_rmix)
+                d2yq(1:3, 1) = d2yq_rmix(:, 1)
+                d2yq(4:6, 1) = 0.0_dp
+            end if
 
-         qua = yq(1)
-         dqua_dr = dyq(1, 1)
-         dqua_dt = dyq(2, 1)
-         dqua_dp = dyq(3, 1)
-         d2qua_dr2 = d2yq(1, 1)
-         d2qua_drdt = d2yq(2, 1)
-         d2qua_drdp = d2yq(3, 1)
-         d2qua_dt2 = d2yq(4, 1)
-         d2qua_dtdp = d2yq(5, 1)
-         d2qua_dp2 = d2yq(6, 1)
+            qua = yq(1)
+            dqua_dr = dyq(1, 1)
+            dqua_dt = dyq(2, 1)
+            dqua_dp = dyq(3, 1)
+            d2qua_dr2 = d2yq(1, 1)
+            d2qua_drdt = d2yq(2, 1)
+            d2qua_drdp = d2yq(3, 1)
+            d2qua_dt2 = d2yq(4, 1)
+            d2qua_dtdp = d2yq(5, 1)
+            d2qua_dp2 = d2yq(6, 1)
 
-         d2qua_dr2 = d2qua_dr2*drhods2 - dqua_dr*d2rhods2m
-         dqua_dr = dqua_dr*drhods
-         d2qua_drdt = d2qua_drdt*drhods
-         d2qua_drdp = d2qua_drdp*drhods
+            d2qua_dr2 = d2qua_dr2*drhods2 - dqua_dr*d2rhods2m
+            dqua_dr = dqua_dr*drhods
+            d2qua_drdt = d2qua_drdt*drhods
+            d2qua_drdp = d2qua_drdp*drhods
 
-         B_vartheta_c = qua
-         dB_vartheta_c_dr = dqua_dr
-         dB_vartheta_c_dt = dqua_dt
-         dB_vartheta_c_dp = dqua_dp
-         d2bth_rr = d2qua_dr2
-         d2bth_rt = d2qua_drdt
-         d2bth_rp = d2qua_drdp
-         d2bth_tt = d2qua_dt2
-         d2bth_tp = d2qua_dtdp
-         d2bth_pp = d2qua_dp2
+            B_vartheta_c = qua
+            dB_vartheta_c_dr = dqua_dr
+            dB_vartheta_c_dt = dqua_dt
+            dB_vartheta_c_dp = dqua_dp
+            d2bth_rr = d2qua_dr2
+            d2bth_rt = d2qua_drdt
+            d2bth_rp = d2qua_drdp
+            d2bth_tt = d2qua_dt2
+            d2bth_tp = d2qua_dtdp
+            d2bth_pp = d2qua_dp2
 
-         if (mode_secders == 2) then
-            call evaluate_batch_splines_3d_der2(Bp_batch_spline, x_eval, yq, &
-                                                dyq, d2yq)
-         else
-            call evaluate_batch_splines_3d_der2_rmix(Bp_batch_spline, x_eval, yq, &
-                                                     dyq, d2yq_rmix)
-            d2yq(1:3, 1) = d2yq_rmix(:, 1)
-            d2yq(4:6, 1) = 0.0_dp
-         end if
+            if (mode_secders == 2) then
+                call evaluate_batch_splines_3d_der2(Bp_batch_spline, x_eval, yq, &
+                                                    dyq, d2yq)
+            else
+                call evaluate_batch_splines_3d_der2_rmix(Bp_batch_spline, x_eval, yq, &
+                                                         dyq, d2yq_rmix)
+                d2yq(1:3, 1) = d2yq_rmix(:, 1)
+                d2yq(4:6, 1) = 0.0_dp
+            end if
 
-         qua = yq(1)
-         dqua_dr = dyq(1, 1)
-         dqua_dt = dyq(2, 1)
-         dqua_dp = dyq(3, 1)
-         d2qua_dr2 = d2yq(1, 1)
-         d2qua_drdt = d2yq(2, 1)
-         d2qua_drdp = d2yq(3, 1)
-         d2qua_dt2 = d2yq(4, 1)
-         d2qua_dtdp = d2yq(5, 1)
-         d2qua_dp2 = d2yq(6, 1)
+            qua = yq(1)
+            dqua_dr = dyq(1, 1)
+            dqua_dt = dyq(2, 1)
+            dqua_dp = dyq(3, 1)
+            d2qua_dr2 = d2yq(1, 1)
+            d2qua_drdt = d2yq(2, 1)
+            d2qua_drdp = d2yq(3, 1)
+            d2qua_dt2 = d2yq(4, 1)
+            d2qua_dtdp = d2yq(5, 1)
+            d2qua_dp2 = d2yq(6, 1)
 
-         d2qua_dr2 = d2qua_dr2*drhods2 - dqua_dr*d2rhods2m
-         dqua_dr = dqua_dr*drhods
-         d2qua_drdt = d2qua_drdt*drhods
-         d2qua_drdp = d2qua_drdp*drhods
+            d2qua_dr2 = d2qua_dr2*drhods2 - dqua_dr*d2rhods2m
+            dqua_dr = dqua_dr*drhods
+            d2qua_drdt = d2qua_drdt*drhods
+            d2qua_drdp = d2qua_drdp*drhods
 
-         B_varphi_c = qua
-         dB_varphi_c_dr = dqua_dr
-         dB_varphi_c_dt = dqua_dt
-         dB_varphi_c_dp = dqua_dp
-         d2bph_rr = d2qua_dr2
-         d2bph_rt = d2qua_drdt
-         d2bph_rp = d2qua_drdp
-         d2bph_tt = d2qua_dt2
-         d2bph_tp = d2qua_dtdp
-         d2bph_pp = d2qua_dp2
+            B_varphi_c = qua
+            dB_varphi_c_dr = dqua_dr
+            dB_varphi_c_dt = dqua_dt
+            dB_varphi_c_dp = dqua_dp
+            d2bph_rr = d2qua_dr2
+            d2bph_rt = d2qua_drdt
+            d2bph_rp = d2qua_drdp
+            d2bph_tt = d2qua_dt2
+            d2bph_tp = d2qua_dtdp
+            d2bph_pp = d2qua_dp2
 
-      else
-         call evaluate_batch_splines_3d_der(sqg_batch_spline, x_eval, yq, dyq)
-         sqg_c = yq(1)
-         dsqg_c_dr = dyq(1, 1)*drhods
-         dsqg_c_dt = dyq(2, 1)
-         dsqg_c_dp = dyq(3, 1)
+        else
+            call evaluate_batch_splines_3d_der(sqg_batch_spline, x_eval, yq, dyq)
+            sqg_c = yq(1)
+            dsqg_c_dr = dyq(1, 1)*drhods
+            dsqg_c_dt = dyq(2, 1)
+            dsqg_c_dp = dyq(3, 1)
 
-         call evaluate_batch_splines_3d_der(Bt_batch_spline, x_eval, yq, dyq)
-         B_vartheta_c = yq(1)
-         dB_vartheta_c_dr = dyq(1, 1)*drhods
-         dB_vartheta_c_dt = dyq(2, 1)
-         dB_vartheta_c_dp = dyq(3, 1)
+            call evaluate_batch_splines_3d_der(Bt_batch_spline, x_eval, yq, dyq)
+            B_vartheta_c = yq(1)
+            dB_vartheta_c_dr = dyq(1, 1)*drhods
+            dB_vartheta_c_dt = dyq(2, 1)
+            dB_vartheta_c_dp = dyq(3, 1)
 
-         call evaluate_batch_splines_3d_der(Bp_batch_spline, x_eval, yq, dyq)
-         B_varphi_c = yq(1)
-         dB_varphi_c_dr = dyq(1, 1)*drhods
-         dB_varphi_c_dt = dyq(2, 1)
-         dB_varphi_c_dp = dyq(3, 1)
+            call evaluate_batch_splines_3d_der(Bp_batch_spline, x_eval, yq, dyq)
+            B_varphi_c = yq(1)
+            dB_varphi_c_dr = dyq(1, 1)*drhods
+            dB_varphi_c_dt = dyq(2, 1)
+            dB_varphi_c_dp = dyq(3, 1)
 
-         d2sqg_rr = 0.0_dp
-         d2sqg_rt = 0.0_dp
-         d2sqg_rp = 0.0_dp
-         d2sqg_tt = 0.0_dp
-         d2sqg_tp = 0.0_dp
-         d2sqg_pp = 0.0_dp
-         d2bth_rr = 0.0_dp
-         d2bth_rt = 0.0_dp
-         d2bth_rp = 0.0_dp
-         d2bth_tt = 0.0_dp
-         d2bth_tp = 0.0_dp
-         d2bth_pp = 0.0_dp
-         d2bph_rr = 0.0_dp
-         d2bph_rt = 0.0_dp
-         d2bph_rp = 0.0_dp
-         d2bph_tt = 0.0_dp
-         d2bph_tp = 0.0_dp
-         d2bph_pp = 0.0_dp
+            d2sqg_rr = 0.0_dp
+            d2sqg_rt = 0.0_dp
+            d2sqg_rp = 0.0_dp
+            d2sqg_tt = 0.0_dp
+            d2sqg_tp = 0.0_dp
+            d2sqg_pp = 0.0_dp
+            d2bth_rr = 0.0_dp
+            d2bth_rt = 0.0_dp
+            d2bth_rp = 0.0_dp
+            d2bth_tt = 0.0_dp
+            d2bth_tp = 0.0_dp
+            d2bth_pp = 0.0_dp
+            d2bph_rr = 0.0_dp
+            d2bph_rt = 0.0_dp
+            d2bph_rp = 0.0_dp
+            d2bph_tt = 0.0_dp
+            d2bph_tp = 0.0_dp
+            d2bph_pp = 0.0_dp
 
-         if (mode_secders == 1) then
-            call evaluate_batch_splines_3d_der2(sqg_batch_spline, x_eval, yq, dyq, &
-                                                d2yq)
-            d2sqg_rr = d2yq(1, 1)*drhods2 - dyq(1, 1)*d2rhods2m
+            if (mode_secders == 1) then
+                call evaluate_batch_splines_3d_der2(sqg_batch_spline, x_eval, yq, dyq, &
+                                                    d2yq)
+                d2sqg_rr = d2yq(1, 1)*drhods2 - dyq(1, 1)*d2rhods2m
 
-            call evaluate_batch_splines_3d_der2(Bt_batch_spline, x_eval, yq, dyq, &
-                                                d2yq)
-            d2bth_rr = d2yq(1, 1)*drhods2 - dyq(1, 1)*d2rhods2m
+                call evaluate_batch_splines_3d_der2(Bt_batch_spline, x_eval, yq, dyq, &
+                                                    d2yq)
+                d2bth_rr = d2yq(1, 1)*drhods2 - dyq(1, 1)*d2rhods2m
 
-            call evaluate_batch_splines_3d_der2(Bp_batch_spline, x_eval, yq, dyq, &
-                                                d2yq)
-            d2bph_rr = d2yq(1, 1)*drhods2 - dyq(1, 1)*d2rhods2m
-         end if
-      end if
+                call evaluate_batch_splines_3d_der2(Bp_batch_spline, x_eval, yq, dyq, &
+                                                    d2yq)
+                d2bph_rr = d2yq(1, 1)*drhods2 - dyq(1, 1)*d2rhods2m
+            end if
+        end if
 
-   end subroutine splint_can_coord
+    end subroutine splint_can_coord
 
-   subroutine can_to_vmec(r, vartheta_c_in, varphi_c_in, theta_vmec, varphi_vmec)
-      use exchange_get_cancoord_mod, only: vartheta_c, varphi_c, theta
+    subroutine can_to_vmec(r, vartheta_c_in, varphi_c_in, theta_vmec, varphi_vmec)
+        use exchange_get_cancoord_mod, only: vartheta_c, varphi_c, theta
 
-      implicit none
+        implicit none
 
-      real(dp), intent(in) :: r, vartheta_c_in, varphi_c_in
-      real(dp), intent(out) :: theta_vmec, varphi_vmec
+        real(dp), intent(in) :: r, vartheta_c_in, varphi_c_in
+        real(dp), intent(out) :: theta_vmec, varphi_vmec
 
-      logical :: fullset
-      integer :: mode_secders
-      real(dp) :: r_local
-      real(dp) :: A_phi, A_theta, dA_phi_dr, dA_theta_dr, d2A_phi_dr2, d3A_phi_dr3
-      real(dp) :: sqg_c, dsqg_c_dr, dsqg_c_dt, dsqg_c_dp
-      real(dp) :: B_vartheta_c, dB_vartheta_c_dr, dB_vartheta_c_dt, dB_vartheta_c_dp
-      real(dp) :: B_varphi_c, dB_varphi_c_dr, dB_varphi_c_dt, dB_varphi_c_dp
-      real(dp) :: G_c
-      real(dp) :: d2sqg_rr, d2sqg_rt, d2sqg_rp, d2sqg_tt, d2sqg_tp, d2sqg_pp
-      real(dp) :: d2bth_rr, d2bth_rt, d2bth_rp, d2bth_tt, d2bth_tp, d2bth_pp
-      real(dp) :: d2bph_rr, d2bph_rt, d2bph_rp, d2bph_tt, d2bph_tp, d2bph_pp
-      real(dp), dimension(1) :: y, dy
+        logical :: fullset
+        integer :: mode_secders
+        real(dp) :: r_local
+        real(dp) :: A_phi, A_theta, dA_phi_dr, dA_theta_dr, d2A_phi_dr2, d3A_phi_dr3
+        real(dp) :: sqg_c, dsqg_c_dr, dsqg_c_dt, dsqg_c_dp
+        real(dp) :: B_vartheta_c, dB_vartheta_c_dr, dB_vartheta_c_dt, dB_vartheta_c_dp
+        real(dp) :: B_varphi_c, dB_varphi_c_dr, dB_varphi_c_dt, dB_varphi_c_dp
+        real(dp) :: G_c
+        real(dp) :: d2sqg_rr, d2sqg_rt, d2sqg_rp, d2sqg_tt, d2sqg_tp, d2sqg_pp
+        real(dp) :: d2bth_rr, d2bth_rt, d2bth_rp, d2bth_tt, d2bth_tp, d2bth_pp
+        real(dp) :: d2bph_rr, d2bph_rt, d2bph_rp, d2bph_tt, d2bph_tp, d2bph_pp
+        real(dp), dimension(1) :: y, dy
 
-      fullset = .true.
-      mode_secders = 0
-      r_local = r
+        fullset = .true.
+        mode_secders = 0
+        r_local = r
 
-      call splint_can_coord(fullset, mode_secders, r_local, vartheta_c_in, &
-                            varphi_c_in, A_theta, A_phi, dA_theta_dr, dA_phi_dr, &
-                            d2A_phi_dr2, d3A_phi_dr3, &
-                            sqg_c, dsqg_c_dr, dsqg_c_dt, dsqg_c_dp, &
-                            B_vartheta_c, dB_vartheta_c_dr, dB_vartheta_c_dt, &
-                            dB_vartheta_c_dp, &
-                            B_varphi_c, dB_varphi_c_dr, dB_varphi_c_dt, &
-                            dB_varphi_c_dp, &
-                            d2sqg_rr, d2sqg_rt, d2sqg_rp, d2sqg_tt, d2sqg_tp, &
-                            d2sqg_pp, &
-                            d2bth_rr, d2bth_rt, d2bth_rp, d2bth_tt, d2bth_tp, &
-                            d2bth_pp, &
-                            d2bph_rr, d2bph_rt, d2bph_rp, d2bph_tt, d2bph_tp, &
-                            d2bph_pp, G_c)
+        call splint_can_coord(fullset, mode_secders, r_local, vartheta_c_in, &
+                              varphi_c_in, A_theta, A_phi, dA_theta_dr, dA_phi_dr, &
+                              d2A_phi_dr2, d3A_phi_dr3, &
+                              sqg_c, dsqg_c_dr, dsqg_c_dt, dsqg_c_dp, &
+                              B_vartheta_c, dB_vartheta_c_dr, dB_vartheta_c_dt, &
+                              dB_vartheta_c_dp, &
+                              B_varphi_c, dB_varphi_c_dr, dB_varphi_c_dt, &
+                              dB_varphi_c_dp, &
+                              d2sqg_rr, d2sqg_rt, d2sqg_rp, d2sqg_tt, d2sqg_tp, &
+                              d2sqg_pp, &
+                              d2bth_rr, d2bth_rt, d2bth_rp, d2bth_tt, d2bth_tp, &
+                              d2bth_pp, &
+                              d2bph_rr, d2bph_rt, d2bph_rp, d2bph_tt, d2bph_tp, &
+                              d2bph_pp, G_c)
 
-      vartheta_c = vartheta_c_in
-      varphi_c = varphi_c_in
-      y(1) = G_c
+        vartheta_c = vartheta_c_in
+        varphi_c = varphi_c_in
+        y(1) = G_c
 
-      ! Transform from r (toroidal flux) to rho_tor for ODE integration
-      call rhs_cancoord(sqrt(r_local), y, dy)
+        ! Transform from r (toroidal flux) to rho_tor for ODE integration
+        call rhs_cancoord(sqrt(r_local), y, dy)
 
-      theta_vmec = theta
-      varphi_vmec = varphi_c_in + G_c
+        theta_vmec = theta
+        varphi_vmec = varphi_c_in + G_c
 
-   end subroutine can_to_vmec
+    end subroutine can_to_vmec
 
-   subroutine deallocate_can_coord
-      call reset_canflux_batch_splines
-   end subroutine deallocate_can_coord
+    subroutine deallocate_can_coord
+        call reset_canflux_batch_splines
+    end subroutine deallocate_can_coord
 
-   subroutine vmec_to_can(r, theta, varphi, vartheta_c, varphi_c)
-      ! Input : r,theta,varphi      - VMEC coordinates
-      ! Output: vartheta_c,varphi_c - canonical coordinates
+    subroutine vmec_to_can(r, theta, varphi, vartheta_c, varphi_c)
+        ! Input : r,theta,varphi      - VMEC coordinates
+        ! Output: vartheta_c,varphi_c - canonical coordinates
 
-      use spline_vmec_sub
-      use new_vmec_stuff_mod, only: nper
-      use vector_potentail_mod, only: torflux
-      use chamb_mod, only: rnegflag
-      use vmec_field_eval
+        use spline_vmec_sub
+        use new_vmec_stuff_mod, only: nper
+        use vector_potentail_mod, only: torflux
+        use chamb_mod, only: rnegflag
+        use vmec_field_eval
 
-      implicit none
+        implicit none
 
-      real(dp), parameter :: epserr = 1.0e-14_dp
-      integer, parameter :: niter = 100
-      integer :: iter
-      real(dp), intent(in) :: r, theta, varphi
-      real(dp), intent(out) :: vartheta_c, varphi_c
-      real(dp) :: delthe, delphi, alam, dl_dt, vartheta
-      real(dp) :: rho_tor, x_eval(3), y_G(1), dy_G(3, 1)
-      real(dp) :: G_c, dG_c_dt, dG_c_dp, aiota
-      real(dp) :: ts, ps, dts_dtc, dts_dpc, dps_dtc, dps_dpc, det
-      real(dp) :: y1d(1), dy1d(1), d2y1d(1), dA_phi_dr, dA_theta_dr
-      real(dp) :: r_local
+        real(dp), parameter :: epserr = 1.0e-14_dp
+        integer, parameter :: niter = 100
+        integer :: iter
+        real(dp), intent(in) :: r, theta, varphi
+        real(dp), intent(out) :: vartheta_c, varphi_c
+        real(dp) :: delthe, delphi, alam, dl_dt, vartheta
+        real(dp) :: rho_tor, x_eval(3), y_G(1), dy_G(3, 1)
+        real(dp) :: G_c, dG_c_dt, dG_c_dp, aiota
+        real(dp) :: ts, ps, dts_dtc, dts_dpc, dps_dtc, dps_dpc, det
+        real(dp) :: y1d(1), dy1d(1), d2y1d(1), dA_phi_dr, dA_theta_dr
+        real(dp) :: r_local
 
-      r_local = r
-      if (r_local <= 0.0_dp) then
-         rnegflag = .true.
-         r_local = abs(r_local)
-      end if
+        r_local = r
+        if (r_local <= 0.0_dp) then
+            rnegflag = .true.
+            r_local = abs(r_local)
+        end if
 
-      if (allocated(current_field)) then
-         call vmec_lambda_interpolate_with_field(current_field, r_local, theta, &
-                                                 varphi, alam, dl_dt)
-      else
-         call vmec_lambda_interpolate(r_local, theta, varphi, alam, dl_dt)
-      end if
+        if (allocated(current_field)) then
+            call vmec_lambda_interpolate_with_field(current_field, r_local, theta, &
+                                                    varphi, alam, dl_dt)
+        else
+            call vmec_lambda_interpolate(r_local, theta, varphi, alam, dl_dt)
+        end if
 
-      vartheta = theta + alam
+        vartheta = theta + alam
 
-      vartheta_c = vartheta
-      varphi_c = varphi
+        vartheta_c = vartheta
+        varphi_c = varphi
 
-      ! Get iota from A_phi interpolation
-      dA_theta_dr = torflux
-      call evaluate_batch_splines_1d_der2(aphi_batch_spline, r_local, y1d, &
-                                          dy1d, d2y1d)
-      dA_phi_dr = dy1d(1)
-      aiota = -dA_phi_dr/dA_theta_dr
+        ! Get iota from A_phi interpolation
+        dA_theta_dr = torflux
+        call evaluate_batch_splines_1d_der2(aphi_batch_spline, r_local, y1d, &
+                                            dy1d, d2y1d)
+        dA_phi_dr = dy1d(1)
+        aiota = -dA_phi_dr/dA_theta_dr
 
-      do iter = 1, niter
-         rho_tor = sqrt(r_local)
-         x_eval(1) = rho_tor
-         x_eval(2) = modulo(vartheta_c, TWOPI)
-         x_eval(3) = modulo(varphi_c, TWOPI/real(nper, dp))
+        do iter = 1, niter
+            rho_tor = sqrt(r_local)
+            x_eval(1) = rho_tor
+            x_eval(2) = modulo(vartheta_c, TWOPI)
+            x_eval(3) = modulo(varphi_c, TWOPI/real(nper, dp))
 
-         call evaluate_batch_splines_3d_der(G_batch_spline, x_eval, y_G, dy_G)
-         G_c = y_G(1)
-         dG_c_dt = dy_G(2, 1)
-         dG_c_dp = dy_G(3, 1)
+            call evaluate_batch_splines_3d_der(G_batch_spline, x_eval, y_G, dy_G)
+            G_c = y_G(1)
+            dG_c_dt = dy_G(2, 1)
+            dG_c_dp = dy_G(3, 1)
 
-         ts = vartheta_c + aiota*G_c - vartheta
-         ps = varphi_c + G_c - varphi
-         dts_dtc = 1.0_dp + aiota*dG_c_dt
-         dts_dpc = aiota*dG_c_dp
-         dps_dtc = dG_c_dt
-         dps_dpc = 1.0_dp + dG_c_dp
-         det = 1.0_dp + aiota*dG_c_dt + dG_c_dp
+            ts = vartheta_c + aiota*G_c - vartheta
+            ps = varphi_c + G_c - varphi
+            dts_dtc = 1.0_dp + aiota*dG_c_dt
+            dts_dpc = aiota*dG_c_dp
+            dps_dtc = dG_c_dt
+            dps_dpc = 1.0_dp + dG_c_dp
+            det = 1.0_dp + aiota*dG_c_dt + dG_c_dp
 
-         delthe = (ps*dts_dpc - ts*dps_dpc)/det
-         delphi = (ts*dps_dtc - ps*dts_dtc)/det
+            delthe = (ps*dts_dpc - ts*dps_dpc)/det
+            delphi = (ts*dps_dtc - ps*dts_dtc)/det
 
-         vartheta_c = vartheta_c + delthe
-         varphi_c = varphi_c + delphi
-         if (abs(delthe) + abs(delphi) < epserr) exit
-      end do
+            vartheta_c = vartheta_c + delthe
+            varphi_c = varphi_c + delphi
+            if (abs(delthe) + abs(delphi) < epserr) exit
+        end do
 
-   end subroutine vmec_to_can
+    end subroutine vmec_to_can
 
-   subroutine vmec_to_cyl(s, theta, varphi, Rcyl, Zcyl)
-      use spline_vmec_sub
-      use vmec_field_eval
+    subroutine vmec_to_cyl(s, theta, varphi, Rcyl, Zcyl)
+        use spline_vmec_sub
+        use vmec_field_eval
 
-      real(dp), intent(in) :: s, theta, varphi
-      real(dp), intent(out) :: Rcyl, Zcyl
+        real(dp), intent(in) :: s, theta, varphi
+        real(dp), intent(out) :: Rcyl, Zcyl
 
-      real(dp) :: A_phi, A_theta, dA_phi_ds, dA_theta_ds, aiota, &
-                  R, Z, alam, dR_ds, dR_dt, dR_dp, dZ_ds, dZ_dt, dZ_dp, dl_ds, &
-                  dl_dt, dl_dp
+        real(dp) :: A_phi, A_theta, dA_phi_ds, dA_theta_ds, aiota, &
+                    R, Z, alam, dR_ds, dR_dt, dR_dp, dZ_ds, dZ_dt, dZ_dp, dl_ds, &
+                    dl_dt, dl_dp
 
-      if (allocated(current_field)) then
-         call vmec_data_interpolate_with_field(current_field, s, theta, varphi, &
-                                               A_phi, A_theta, dA_phi_ds, &
-                                               dA_theta_ds, aiota, &
-                                               R, Z, alam, dR_ds, dR_dt, dR_dp, &
-                                               dZ_ds, dZ_dt, dZ_dp, &
-                                               dl_ds, dl_dt, dl_dp)
-      else
-         call vmec_data_interpolate(s, theta, varphi, A_phi, A_theta, &
-                                    dA_phi_ds, dA_theta_ds, aiota, &
-                                    R, Z, alam, dR_ds, dR_dt, dR_dp, dZ_ds, &
-                                    dZ_dt, dZ_dp, &
-                                    dl_ds, dl_dt, dl_dp)
-      end if
+        if (allocated(current_field)) then
+            call vmec_data_interpolate_with_field(current_field, s, theta, varphi, &
+                                                  A_phi, A_theta, dA_phi_ds, &
+                                                  dA_theta_ds, aiota, &
+                                                  R, Z, alam, dR_ds, dR_dt, dR_dp, &
+                                                  dZ_ds, dZ_dt, dZ_dp, &
+                                                  dl_ds, dl_dt, dl_dp)
+        else
+            call vmec_data_interpolate(s, theta, varphi, A_phi, A_theta, &
+                                       dA_phi_ds, dA_theta_ds, aiota, &
+                                       R, Z, alam, dR_ds, dR_dt, dR_dp, dZ_ds, &
+                                       dZ_dt, dZ_dp, &
+                                       dl_ds, dl_dt, dl_dp)
+        end if
 
-      Rcyl = R
-      Zcyl = Z
-   end subroutine vmec_to_cyl
+        Rcyl = R
+        Zcyl = Z
+    end subroutine vmec_to_cyl
 
 end module get_can_sub

--- a/src/orbit_symplectic_base.f90
+++ b/src/orbit_symplectic_base.f90
@@ -1,234 +1,232 @@
 module orbit_symplectic_base
 use field_can_mod, only: eval_field => evaluate, field_can_t, get_val, get_derivatives, &
-  get_derivatives2
+                             get_derivatives2
 
-implicit none
+    implicit none
 
 ! Define real(dp) kind parameter
-integer, parameter :: dp = kind(1.0d0)
+    integer, parameter :: dp = kind(1.0d0)
 
-logical, parameter :: extrap_field = .True.  ! do extrapolation after final iteration
+    logical, parameter :: extrap_field = .True.  ! do extrapolation after final iteration
 
-  ! Integration methods
-integer, parameter :: RK45 = 0, EXPL_IMPL_EULER = 1, IMPL_EXPL_EULER = 2, &
-  MIDPOINT = 3, GAUSS1 = 4, GAUSS2 = 5, GAUSS3 = 6, GAUSS4 = 7, LOBATTO3 = 15
+    ! Integration methods
+    integer, parameter :: RK45 = 0, EXPL_IMPL_EULER = 1, IMPL_EXPL_EULER = 2, &
+             MIDPOINT = 3, GAUSS1 = 4, GAUSS2 = 5, GAUSS3 = 6, GAUSS4 = 7, LOBATTO3 = 15
 
-type :: symplectic_integrator_t
-  real(dp) :: atol
-  real(dp) :: rtol
+    type :: symplectic_integrator_t
+        real(dp) :: atol
+        real(dp) :: rtol
 
-  ! Current phase-space coordinates z and old pth
-  real(dp), dimension(4) :: z  ! z = (r, th, ph, pphi)
-  real(dp) :: pthold
+        ! Current phase-space coordinates z and old pth
+        real(dp), dimension(4) :: z  ! z = (r, th, ph, pphi)
+        real(dp) :: pthold
 
-  ! Timestep and variables from z0
-  integer :: ntau
-  real(dp) :: dt
-  real(dp) :: pabs
-end type symplectic_integrator_t
+        ! Timestep and variables from z0
+        integer :: ntau
+        real(dp) :: dt
+        real(dp) :: pabs
+    end type symplectic_integrator_t
 
-  !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-  !
-  ! Composition method with 2s internal stages according to Hairer, 2002 V.3.1
-  !
-integer, parameter :: S_MAX = 32
-type :: multistage_integrator_t
-  integer :: s
-  real(dp) :: alpha(S_MAX), beta(S_MAX)
-  type(symplectic_integrator_t) stages(2*S_MAX)
-end type multistage_integrator_t
+    !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+    !
+    ! Composition method with 2s internal stages according to Hairer, 2002 V.3.1
+    !
+    integer, parameter :: S_MAX = 32
+    type :: multistage_integrator_t
+        integer :: s
+        real(dp) :: alpha(S_MAX), beta(S_MAX)
+        type(symplectic_integrator_t) stages(2*S_MAX)
+    end type multistage_integrator_t
 
-abstract interface
-  subroutine orbit_timestep_sympl_i(si, f, ierr)
-    import :: symplectic_integrator_t, field_can_t
-    type(symplectic_integrator_t), intent(inout) :: si
-    type(field_can_t), intent(inout) :: f
-    integer, intent(out) :: ierr
-  end subroutine orbit_timestep_sympl_i
-end interface
+    abstract interface
+        subroutine orbit_timestep_sympl_i(si, f, ierr)
+            import :: symplectic_integrator_t, field_can_t
+            type(symplectic_integrator_t), intent(inout) :: si
+            type(field_can_t), intent(inout) :: f
+            integer, intent(out) :: ierr
+        end subroutine orbit_timestep_sympl_i
+    end interface
 
-abstract interface
-  subroutine orbit_timestep_quasi_i(ierr)
-    integer, intent(out) :: ierr
-  end subroutine orbit_timestep_quasi_i
-end interface
+    abstract interface
+        subroutine orbit_timestep_quasi_i(ierr)
+            integer, intent(out) :: ierr
+        end subroutine orbit_timestep_quasi_i
+    end interface
 
 contains
 
-subroutine coeff_rk_gauss(n, a, b, c)
-  integer, intent(in) :: n
-  real(dp), intent(inout) :: a(n,n), b(n), c(n)
+    subroutine coeff_rk_gauss(n, a, b, c)
+        integer, intent(in) :: n
+        real(dp), intent(inout) :: a(n, n), b(n), c(n)
 
-  if (n == 1) then
-    a(1,1) = 0.5d0
-    b(1) = 1.0d0
-    c(1) = 0.5d0
-  elseif (n == 2) then
-    a(1,1) =  0.25d0
-    a(1,2) = -0.038675134594812d0
-    a(2,1) =  0.538675134594812d0
-    a(2,2) =  0.25d0
+        if (n == 1) then
+            a(1, 1) = 0.5d0
+            b(1) = 1.0d0
+            c(1) = 0.5d0
+        elseif (n == 2) then
+            a(1, 1) = 0.25d0
+            a(1, 2) = -0.038675134594812d0
+            a(2, 1) = 0.538675134594812d0
+            a(2, 2) = 0.25d0
 
-    b(1) = 0.5d0
-    b(2) = 0.5d0
+            b(1) = 0.5d0
+            b(2) = 0.5d0
 
-    c(1) = 0.211324865405187d0
-    c(2) = 0.788675134594812d0
-  elseif (n == 3) then
-    a(1,1) =  0.1388888888888889d0
-    a(1,2) = -0.03597666752493894d0
-    a(1,3) =  0.009789444015308318d0
-    a(2,1) =  0.3002631949808646d0
-    a(2,2) =  0.2222222222222222d0
-    a(2,3) = -0.022485417203086805d0
-    a(3,1) = 0.26798833376246944d0
-    a(3,2) = 0.48042111196938336d0
-    a(3,3) = 0.1388888888888889d0
+            c(1) = 0.211324865405187d0
+            c(2) = 0.788675134594812d0
+        elseif (n == 3) then
+            a(1, 1) = 0.1388888888888889d0
+            a(1, 2) = -0.03597666752493894d0
+            a(1, 3) = 0.009789444015308318d0
+            a(2, 1) = 0.3002631949808646d0
+            a(2, 2) = 0.2222222222222222d0
+            a(2, 3) = -0.022485417203086805d0
+            a(3, 1) = 0.26798833376246944d0
+            a(3, 2) = 0.48042111196938336d0
+            a(3, 3) = 0.1388888888888889d0
 
-    b(1) = 0.2777777777777778d0
-    b(2) = 0.4444444444444444d0
-    b(3) = 0.2777777777777778d0
+            b(1) = 0.2777777777777778d0
+            b(2) = 0.4444444444444444d0
+            b(3) = 0.2777777777777778d0
 
-    c(1) = 0.1127016653792583d0
-    c(2) = 0.5d0
-    c(3) = 0.8872983346207417d0
-  elseif (n == 4) then  ! with help of coefficients from GeometricIntegrators.jl of Michael Kraus
-    a(1,1) = 0.086963711284363462428182d0
-    a(1,2) = -0.026604180084998794303397d0
-    a(1,3) = 0.012627462689404725035280d0
-    a(1,4) = -0.003555149685795683332096d0
+            c(1) = 0.1127016653792583d0
+            c(2) = 0.5d0
+            c(3) = 0.8872983346207417d0
+        elseif (n == 4) then  ! with help of coefficients from GeometricIntegrators.jl of Michael Kraus
+            a(1, 1) = 0.086963711284363462428182d0
+            a(1, 2) = -0.026604180084998794303397d0
+            a(1, 3) = 0.012627462689404725035280d0
+            a(1, 4) = -0.003555149685795683332096d0
 
-    a(2,1) = 0.188118117499868064967927d0
-    a(2,2) = 0.163036288715636523694030d0
-    a(2,3) = -0.027880428602470894855481d0
-    a(2,4) = 0.006735500594538155853808d0
+            a(2, 1) = 0.188118117499868064967927d0
+            a(2, 2) = 0.163036288715636523694030d0
+            a(2, 3) = -0.027880428602470894855481d0
+            a(2, 4) = 0.006735500594538155853808d0
 
-    a(3,1) = 0.167191921974188778543535d0
-    a(3,2) = 0.353953006033743966529670d0
-    a(3,3) = 0.163036288715636523694030d0
-    a(3,4) = -0.014190694931141143581010d0
+            a(3, 1) = 0.167191921974188778543535d0
+            a(3, 2) = 0.353953006033743966529670d0
+            a(3, 3) = 0.163036288715636523694030d0
+            a(3, 4) = -0.014190694931141143581010d0
 
-    a(4,1) = 0.177482572254522602550608d0
-    a(4,2) = 0.313445114741868369190314d0
-    a(4,3) = 0.352676757516271865977586d0
-    a(4,4) = 0.086963711284363462428182d0
+            a(4, 1) = 0.177482572254522602550608d0
+            a(4, 2) = 0.313445114741868369190314d0
+            a(4, 3) = 0.352676757516271865977586d0
+            a(4, 4) = 0.086963711284363462428182d0
 
-    b(1) = 0.173927422568726924856364d0
-    b(2) = 0.326072577431273047388061d0
-    b(3) = 0.326072577431273047388061d0
-    b(4) = 0.173927422568726924856364d0
+            b(1) = 0.173927422568726924856364d0
+            b(2) = 0.326072577431273047388061d0
+            b(3) = 0.326072577431273047388061d0
+            b(4) = 0.173927422568726924856364d0
 
-    c(1) = 0.069431844202973713731097d0
-    c(2) = 0.330009478207571871344328d0
-    c(3) = 0.669990521792428128655672d0
-    c(4) = 0.930568155797026341780054d0
-  else
-    ! not implemented
-    a = 0d0
-    b = 0d0
-    c = 0d0
-  endif
-end subroutine coeff_rk_gauss
+            c(1) = 0.069431844202973713731097d0
+            c(2) = 0.330009478207571871344328d0
+            c(3) = 0.669990521792428128655672d0
+            c(4) = 0.930568155797026341780054d0
+        else
+            ! not implemented
+            a = 0d0
+            b = 0d0
+            c = 0d0
+        end if
+    end subroutine coeff_rk_gauss
 
+    subroutine coeff_rk_lobatto(n, a, ahat, b, c)
+        integer, intent(in) :: n
+        real(dp), intent(inout) :: a(n, n), ahat(n, n), b(n), c(n)
 
-subroutine coeff_rk_lobatto(n, a, ahat, b, c)
-  integer, intent(in) :: n
-  real(dp), intent(inout) :: a(n,n), ahat(n,n), b(n), c(n)
+        if (n == 3) then
+            a(1, 1) = 0d0
+            a(1, 2) = 0d0
+            a(1, 3) = 0d0
 
-  if (n == 3) then
-    a(1,1) =  0d0
-    a(1,2) =  0d0
-    a(1,3) =  0d0
+            a(2, 1) = 0.20833333333333334d0
+            a(2, 2) = 0.33333333333333333d0
+            a(2, 3) = -0.041666666666666664d0
 
-    a(2,1) =  0.20833333333333334d0
-    a(2,2) =  0.33333333333333333d0
-    a(2,3) = -0.041666666666666664d0
+            a(3, 1) = 0.16666666666666667d0
+            a(3, 2) = 0.66666666666666667d0
+            a(3, 3) = 0.16666666666666667d0
 
-    a(3,1) =  0.16666666666666667d0
-    a(3,2) =  0.66666666666666667d0
-    a(3,3) =  0.16666666666666667d0
+            ahat(1, 1) = 0.16666666666666667d0
+            ahat(1, 2) = -0.16666666666666667d0
+            ahat(1, 3) = 0d0
 
-    ahat(1,1) =  0.16666666666666667d0
-    ahat(1,2) = -0.16666666666666667d0
-    ahat(1,3) =  0d0
+            ahat(2, 1) = 0.16666666666666667d0
+            ahat(2, 2) = 0.33333333333333333d0
+            ahat(2, 3) = 0d0
 
-    ahat(2,1) =  0.16666666666666667d0
-    ahat(2,2) =  0.33333333333333333d0
-    ahat(2,3) =  0d0
+            ahat(3, 1) = 0.16666666666666667d0
+            ahat(3, 2) = 0.83333333333333333d0
+            ahat(3, 3) = 0d0
 
-    ahat(3,1) =  0.16666666666666667d0
-    ahat(3,2) =  0.83333333333333333d0
-    ahat(3,3) =  0d0
+            b(1) = 0.16666666666666667d0
+            b(2) = 0.66666666666666667d0
+            b(3) = 0.16666666666666667d0
 
-    b(1) =  0.16666666666666667d0
-    b(2) =  0.66666666666666667d0
-    b(3) =  0.16666666666666667d0
+            c(1) = 0d0
+            c(2) = 0.5d0
+            c(3) = 1.0d0
 
-    c(1) = 0d0
-    c(2) = 0.5d0
-    c(3) = 1.0d0
+        else
+            ! not implemented
+            a = 0d0
+            b = 0d0
+            c = 0d0
+        end if
+    end subroutine coeff_rk_lobatto
 
-  else
-    ! not implemented
-    a = 0d0
-    b = 0d0
-    c = 0d0
-  endif
-end subroutine coeff_rk_lobatto
+    !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+    !
+    ! Lobatto (IIIA)-(IIIB) Runge-Kutta method with s internal stages (n=4*s variables)
+    !
+    subroutine f_rk_lobatto(si, fs, s, x, fvec, jactype)
+        !
+        type(symplectic_integrator_t), intent(inout) :: si
+        integer, intent(in) :: s
+        type(field_can_t), intent(inout) :: fs(:)
+        real(dp), intent(in) :: x(4*s)  ! = (rend, thend, phend, pphend)
+        real(dp), intent(out) :: fvec(4*s)
+        integer, intent(in) :: jactype  ! 0 = no second derivatives, 2 = second derivatives
 
+        real(dp) :: a(s, s), ahat(s, s), b(s), c(s), Hprime(s)
+        integer :: k, l  ! counters
 
-  !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-  !
-  ! Lobatto (IIIA)-(IIIB) Runge-Kutta method with s internal stages (n=4*s variables)
-  !
-subroutine f_rk_lobatto(si, fs, s, x, fvec, jactype)
-  !
-  type(symplectic_integrator_t), intent(inout) :: si
-  integer, intent(in) :: s
-  type(field_can_t), intent(inout) :: fs(:)
-  real(dp), intent(in) :: x(4*s)  ! = (rend, thend, phend, pphend)
-  real(dp), intent(out) :: fvec(4*s)
-  integer, intent(in) :: jactype  ! 0 = no second derivatives, 2 = second derivatives
+        call coeff_rk_lobatto(s, a, ahat, b, c)
 
-  real(dp) :: a(s,s), ahat(s,s), b(s), c(s), Hprime(s)
-  integer :: k,l  ! counters
+        call eval_field(fs(1), x(1), si%z(2), si%z(3), jactype)
+        call get_derivatives(fs(1), x(2))
 
-  call coeff_rk_lobatto(s, a, ahat, b, c)
+        do k = 2, s
+         call eval_field(fs(k), x(4*k - 3 - 2), x(4*k - 2 - 2), x(4*k - 1 - 2), jactype)
+            call get_derivatives(fs(k), x(4*k - 2))
+        end do
 
-  call eval_field(fs(1), x(1), si%z(2), si%z(3), jactype)
-  call get_derivatives(fs(1), x(2))
+        Hprime = fs%dH(1)/fs%dpth(1)
 
-  do k = 2, s
-    call eval_field(fs(k), x(4*k-3-2), x(4*k-2-2), x(4*k-1-2), jactype)
-    call get_derivatives(fs(k), x(4*k-2))
-  end do
+        fvec(1) = fs(1)%pth - si%pthold
+        fvec(2) = x(2) - si%z(4)
 
-  Hprime = fs%dH(1)/fs%dpth(1)
+        do l = 1, s
+fvec(1) = fvec(1) + si%dt*ahat(1, l)*(fs(l)%dH(2) - Hprime(l)*fs(l)%dpth(2))        ! pthdot
+fvec(2) = fvec(2) + si%dt*ahat(1, l)*(fs(l)%dH(3) - Hprime(l)*fs(l)%dpth(3))        ! pphdot
+        end do
 
-  fvec(1) = fs(1)%pth - si%pthold
-  fvec(2) = x(2) - si%z(4)
+        do k = 2, s
+            fvec(4*k - 3 - 2) = fs(k)%pth - si%pthold
+            fvec(4*k - 2 - 2) = x(4*k - 2 - 2) - si%z(2)
+            fvec(4*k - 1 - 2) = x(4*k - 1 - 2) - si%z(3)
+            fvec(4*k - 2) = x(4*k - 2) - si%z(4)
+        end do
 
-  do l = 1, s
-      fvec(1) = fvec(1) + si%dt*ahat(1,l)*(fs(l)%dH(2) - Hprime(l)*fs(l)%dpth(2))        ! pthdot
-      fvec(2) = fvec(2) + si%dt*ahat(1,l)*(fs(l)%dH(3) - Hprime(l)*fs(l)%dpth(3))        ! pphdot
-  end do
-
-  do k = 2, s
-    fvec(4*k-3-2) = fs(k)%pth - si%pthold
-    fvec(4*k-2-2) = x(4*k-2-2)  - si%z(2)
-    fvec(4*k-1-2) = x(4*k-1-2)  - si%z(3)
-    fvec(4*k-2)   = x(4*k-2)    - si%z(4)
-  end do
-
-  do l = 1, s
-    do k = 2, s
+        do l = 1, s
+            do k = 2, s
       fvec(4*k-3-2) = fvec(4*k-3-2) + si%dt*ahat(k,l)*(fs(l)%dH(2) - Hprime(l)*fs(l)%dpth(2))        ! pthdot
       fvec(4*k-2-2) = fvec(4*k-2-2) - si%dt*a(k,l)*Hprime(l)                                         ! thdot
       fvec(4*k-1-2) = fvec(4*k-1-2) - si%dt*a(k,l)*(fs(l)%vpar  - Hprime(l)*fs(l)%hth)/fs(l)%hph     ! phdot
       fvec(4*k-2)   = fvec(4*k-2)   + si%dt*ahat(k,l)*(fs(l)%dH(3) - Hprime(l)*fs(l)%dpth(3))        ! pphdot
-    end do
-  end do
+            end do
+        end do
 
-end subroutine f_rk_lobatto
+    end subroutine f_rk_lobatto
 
 end module orbit_symplectic_base

--- a/src/samplers.f90
+++ b/src/samplers.f90
@@ -1,292 +1,288 @@
 module samplers
-  use, intrinsic :: iso_fortran_env, only: dp => real64
-  use util
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use util
 
-  implicit none
+    implicit none
 
-  character(len=*), parameter :: START_FILE = 'start.dat'
-  character(len=*), parameter :: START_FILE_ANTS = 'start_ants.dat'
-  character(len=*), parameter :: START_FILE_BATCH = 'batch.dat'
+    character(len=*), parameter :: START_FILE = 'start.dat'
+    character(len=*), parameter :: START_FILE_ANTS = 'start_ants.dat'
+    character(len=*), parameter :: START_FILE_BATCH = 'batch.dat'
 
-  ! Interface ################################
-  INTERFACE sample
-       MODULE PROCEDURE sample_read
-       MODULE PROCEDURE sample_surface_fieldline
-       MODULE PROCEDURE sample_grid
-       MODULE PROCEDURE sample_volume_single
-       MODULE PROCEDURE sample_random_batch
-       MODULE PROCEDURE sample_points_ants
-  END INTERFACE sample
+    ! Interface ################################
+    INTERFACE sample
+        MODULE PROCEDURE sample_read
+        MODULE PROCEDURE sample_surface_fieldline
+        MODULE PROCEDURE sample_grid
+        MODULE PROCEDURE sample_volume_single
+        MODULE PROCEDURE sample_random_batch
+        MODULE PROCEDURE sample_points_ants
+    END INTERFACE sample
 
+contains
+    ! Functions #################################
+    subroutine init_starting_surf
+        use alpha_lifetime_sub, only: integrate_mfl_can
+        use params, only: dphi, nper, npoiper, phibeg, thetabeg, volstart, &
+                          xstart, sbeg, bmin, bmax, bmod00
 
-  contains
-  ! Functions #################################
-  subroutine init_starting_surf
-    use alpha_lifetime_sub, only : integrate_mfl_can
-    use params, only: dphi, nper, npoiper, phibeg, thetabeg, volstart, &
-        xstart, sbeg, bmin, bmax, bmod00
+        integer :: ierr = 0
+        real(dp), dimension(npoiper*nper) :: bstart
 
-    integer :: ierr=0
-    real(dp), dimension(npoiper*nper) :: bstart
+        xstart = 0.d0
+        bstart = 0.d0
+        volstart = 0.d0
 
+        ! For VMEC-backed runs the driver calls this while VMEC magfie is active,
+        ! so xstart can be copied directly to reference-coordinate zstart. The
+        ! volstart integral gives volume-weighted sampling on this one surface.
+        call integrate_mfl_can( &
+            npoiper*nper, dphi, sbeg(1), phibeg, thetabeg, &
+            xstart, bstart, volstart, bmod00, ierr)
 
-    xstart=0.d0
-    bstart=0.d0
-    volstart=0.d0
+        if (ierr .ne. 0) then
+            print *, 'starting field line has points outside the chamber'
+            stop
+        end if
 
-    ! For VMEC-backed runs the driver calls this while VMEC magfie is active,
-    ! so xstart can be copied directly to reference-coordinate zstart. The
-    ! volstart integral gives volume-weighted sampling on this one surface.
-    call integrate_mfl_can( &
-      npoiper*nper,dphi,sbeg(1),phibeg,thetabeg, &
-      xstart,bstart,volstart,bmod00,ierr)
+        ! maximum value of B module:
+        bmax = maxval(bstart)
+        bmin = minval(bstart)
 
-    if(ierr.ne.0) then
-      print *,'starting field line has points outside the chamber'
-      stop
-    endif
+        print *, 'bmod00 = ', bmod00, 'bmin = ', bmin, 'bmax = ', bmax
+    end subroutine init_starting_surf
 
-  ! maximum value of B module:
-    bmax=maxval(bstart)
-    bmin=minval(bstart)
+    subroutine load_starting_points(zstart, filename)
+        real(dp), dimension(:, :), intent(inout) :: zstart
+        character(len=*), intent(in) :: filename
+        integer :: ipart
 
-    print *, 'bmod00 = ', bmod00, 'bmin = ', bmin, 'bmax = ', bmax
-  end subroutine init_starting_surf
+        open (1, file=filename, recl=1024)
+        do ipart = 1, size(zstart, 2)
+            read (1, *) zstart(:, ipart)
+        end do
+        close (1)
+    end subroutine load_starting_points
 
-  subroutine load_starting_points(zstart, filename)
-    real(dp), dimension(:,:), intent(inout) :: zstart
-    character(len=*), intent(in) :: filename
-    integer :: ipart
+    subroutine save_starting_points(zstart)
+        real(dp), dimension(:, :), intent(in) :: zstart
+        integer :: ipart
 
-    open(1,file=filename,recl=1024)
-    do ipart=1,size(zstart,2)
-      read(1,*) zstart(:,ipart)
-    enddo
-    close(1)
-  end subroutine load_starting_points
+        open (1, file=START_FILE, recl=1024)
+        do ipart = 1, size(zstart, 2)
+            write (1, *) zstart(:, ipart)
+        end do
+        close (1)
+    end subroutine save_starting_points
 
-  subroutine save_starting_points(zstart)
-    real(dp), dimension(:,:), intent(in) :: zstart
-    integer :: ipart
+    subroutine sample_read(zstart, filename)
+        real(dp), dimension(:, :), intent(inout) :: zstart
+        character(len=*), intent(in) :: filename
 
-    open(1,file=START_FILE,recl=1024)
-    do ipart=1,size(zstart,2)
-      write(1,*) zstart(:,ipart)
-    enddo
-    close(1)
-  end subroutine save_starting_points
+        call load_starting_points(zstart, filename)
+    end subroutine
 
-  subroutine sample_read(zstart, filename)
-      real(dp), dimension(:,:), intent(inout) :: zstart
-      character(len=*), intent(in) :: filename
+    ! Samplers ################################
+    subroutine sample_volume_single(zstart, s_inner, s_outer)
+        use params, only: isw_field_type, num_surf
+        use field_can_mod, only: integ_to_ref
 
-      call load_starting_points(zstart, filename)
-  end subroutine
+        real(dp), intent(in) :: s_inner
+        real(dp), intent(in) :: s_outer
+        real(dp), parameter :: s_min = 0.01d0
+        real(dp) :: tmp_rand, s_lo, s_hi
+        real(dp) :: r, vartheta, varphi
+        real(dp), dimension(:, :), intent(inout) :: zstart
+        integer :: ipart
 
+        ! If user wants to do volume with 0 or 1 surfaces,
+        !   we "add" the constraints, therefore having 2 surfaces.
+        if (2 /= num_surf) then
+            num_surf = 2
+        end if
 
-  ! Samplers ################################
-  subroutine sample_volume_single(zstart, s_inner, s_outer)
-    use params, only: isw_field_type, num_surf
-    use field_can_mod, only : integ_to_ref
+        ! Clamp lower bound to s_min to avoid axis singularity
+        s_lo = max(s_inner, s_min)
+        s_hi = max(s_outer, s_min)
 
-    real(dp), intent(in) :: s_inner
-    real(dp), intent(in) :: s_outer
-    real(dp), parameter :: s_min = 0.01d0
-    real(dp) :: tmp_rand, s_lo, s_hi
-    real(dp) :: r,vartheta,varphi
-    real(dp), dimension(:,:), intent(inout) :: zstart
-    integer :: ipart
+        do ipart = 1, size(zstart, 2)
+            call random_number(tmp_rand)
+            r = tmp_rand*(s_hi - s_lo) + s_lo
 
-    ! If user wants to do volume with 0 or 1 surfaces,
-    !   we "add" the constraints, therefore having 2 surfaces.
-    if (2 /= num_surf) then
-      num_surf = 2
-    endif
+            call random_number(tmp_rand)
+            vartheta = twopi*tmp_rand
+            call random_number(tmp_rand)
+            varphi = twopi*tmp_rand
+            ! we store starting points in reference coordinates:
+            call integ_to_ref([r, vartheta, varphi], zstart(1:3, ipart))
+            ! normalized velocity module z(4) = v / v_0:
+            zstart(4, ipart) = 1.d0
+            ! starting pitch z(5)=v_\parallel / v:
+            call random_number(tmp_rand)
+            zstart(5, ipart) = 2.d0*(tmp_rand - 0.5d0)
+        end do
 
-    ! Clamp lower bound to s_min to avoid axis singularity
-    s_lo = max(s_inner, s_min)
-    s_hi = max(s_outer, s_min)
+        call save_starting_points(zstart)
 
-    do ipart=1,size(zstart,2)
-      call random_number(tmp_rand)
-      r = tmp_rand * (s_hi - s_lo) + s_lo
+    end subroutine sample_volume_single
 
-      call random_number(tmp_rand)
-      vartheta=twopi*tmp_rand
-      call random_number(tmp_rand)
-      varphi=twopi*tmp_rand
-      ! we store starting points in reference coordinates:
-      call integ_to_ref([r, vartheta, varphi], zstart(1:3,ipart))
-      ! normalized velocity module z(4) = v / v_0:
-      zstart(4,ipart)=1.d0
-      ! starting pitch z(5)=v_\parallel / v:
-      call random_number(tmp_rand)
-      zstart(5,ipart)=2.d0*(tmp_rand-0.5d0)
-    enddo
+    subroutine sample_surface_fieldline(zstart)
+        real(dp), dimension(:, :), intent(inout) :: zstart
 
-    call save_starting_points(zstart)
+        call sample_surface_fieldline_impl(zstart, .false.)
+    end subroutine sample_surface_fieldline
 
-  end subroutine sample_volume_single
+    subroutine sample_surface_fieldline_from_integ(zstart)
+        real(dp), dimension(:, :), intent(inout) :: zstart
 
-  subroutine sample_surface_fieldline(zstart)
-    real(dp), dimension(:,:), intent(inout) :: zstart
+        call sample_surface_fieldline_impl(zstart, .true.)
+    end subroutine sample_surface_fieldline_from_integ
 
-    call sample_surface_fieldline_impl(zstart, .false.)
-  end subroutine sample_surface_fieldline
+    subroutine sample_surface_fieldline_impl(zstart, xstart_is_integ_coords)
+        use params, only: volstart, ibins, xstart, npoiper, nper
+        use binsrc_sub, only: binsrc
+        use field_can_mod, only: integ_to_ref
 
-  subroutine sample_surface_fieldline_from_integ(zstart)
-    real(dp), dimension(:,:), intent(inout) :: zstart
+        real(dp), dimension(:, :), intent(inout) :: zstart
+        logical, intent(in) :: xstart_is_integ_coords
 
-    call sample_surface_fieldline_impl(zstart, .true.)
-  end subroutine sample_surface_fieldline_from_integ
+        real(dp) :: xi
+        integer :: ipart, i
 
-  subroutine sample_surface_fieldline_impl(zstart, xstart_is_integ_coords)
-    use params, only: volstart, ibins, xstart, npoiper, nper
-    use binsrc_sub, only: binsrc
-    use field_can_mod, only: integ_to_ref
+        do ipart = 1, size(zstart, 2)
+            call random_number(xi)
+            call binsrc(volstart, 1, npoiper*nper, xi, i)
+            ibins = i
+            if (xstart_is_integ_coords) then
+                call integ_to_ref(xstart(:, i), zstart(1:3, ipart))
+            else
+                zstart(1:3, ipart) = xstart(:, i)
+            end if
+            zstart(4, ipart) = 1.d0  ! normalized velocity module z(4) = v / v_0
+            call random_number(xi)
+            zstart(5, ipart) = 2.d0*(xi - 0.5d0)  ! starting pitch z(5)=v_\parallel / v
+        end do
 
-    real(dp), dimension(:,:), intent(inout) :: zstart
-    logical, intent(in) :: xstart_is_integ_coords
+        call save_starting_points(zstart)
 
-    real(dp) :: xi
-    integer :: ipart, i
+    end subroutine sample_surface_fieldline_impl
 
-    do ipart=1,size(zstart,2)
-      call random_number(xi)
-      call binsrc(volstart,1,npoiper*nper,xi,i)
-      ibins=i
-      if (xstart_is_integ_coords) then
-        call integ_to_ref(xstart(:,i), zstart(1:3,ipart))
-      else
-        zstart(1:3,ipart)=xstart(:,i)
-      end if
-      zstart(4,ipart)=1.d0  ! normalized velocity module z(4) = v / v_0
-      call random_number(xi)
-      zstart(5,ipart)=2.d0*(xi-0.5d0)  ! starting pitch z(5)=v_\parallel / v
-    enddo
+    subroutine sample_grid(zstart, grid_density, xstart_is_integ_coords)
+        use params, only: ntestpart, zstart_dim1, zend, times_lost, &
+                          trap_par, perp_inv, iclass, sbeg
+        use util, only: pi
+        use field_can_mod, only: integ_to_ref
 
-    call save_starting_points(zstart)
+        real(dp), dimension(:, :), allocatable, intent(inout) :: zstart
+        real(dp), intent(in) :: grid_density
+        logical, intent(in), optional :: xstart_is_integ_coords
+        real(dp) :: xi, xsize_real
+        real(dp) :: xinteg(3)
+        integer :: ngrid, ipart, jpart, lidx
+        logical :: convert_surface_starts
 
-  end subroutine sample_surface_fieldline_impl
+        convert_surface_starts = .false.
+        if (present(xstart_is_integ_coords)) then
+            convert_surface_starts = xstart_is_integ_coords
+        end if
 
-  subroutine sample_grid(zstart, grid_density, xstart_is_integ_coords)
-    use params, only: ntestpart, zstart_dim1, zend, times_lost, &
-        trap_par, perp_inv, iclass, sbeg
-    use util, only: pi
-    use field_can_mod, only: integ_to_ref
+        xsize_real = (2*pi)*grid_density !angle density
+        ngrid = int((1/grid_density) - 1)
+        ntestpart = ngrid**2 !number of total angle points
 
-    real(dp), dimension(:,:), allocatable, intent(inout) :: zstart
-    real(dp), intent(in) :: grid_density
-    logical, intent(in), optional :: xstart_is_integ_coords
-    real(dp) :: xi, xsize_real
-    real(dp) :: xinteg(3)
-    integer :: ngrid, ipart, jpart, lidx
-    logical :: convert_surface_starts
-
-    convert_surface_starts = .false.
-    if (present(xstart_is_integ_coords)) then
-      convert_surface_starts = xstart_is_integ_coords
-    end if
-
-    xsize_real = (2*pi) * grid_density !angle density
-    ngrid = int((1 / grid_density) - 1)
-    ntestpart = ngrid ** 2 !number of total angle points
-
-    ! Resize particle coord. arrays and result memory.
-    if (allocated(zstart)) deallocate(zstart)
-    if (allocated(zend)) deallocate(zend)
-    allocate(zstart(zstart_dim1,ntestpart), zend(zstart_dim1,ntestpart))
-    if (allocated(times_lost)) deallocate(times_lost)
-    if (allocated(trap_par)) deallocate(trap_par)
-    if (allocated(perp_inv)) deallocate(perp_inv)
-    if (allocated(iclass)) deallocate(iclass)
+        ! Resize particle coord. arrays and result memory.
+        if (allocated(zstart)) deallocate (zstart)
+        if (allocated(zend)) deallocate (zend)
+        allocate (zstart(zstart_dim1, ntestpart), zend(zstart_dim1, ntestpart))
+        if (allocated(times_lost)) deallocate (times_lost)
+        if (allocated(trap_par)) deallocate (trap_par)
+        if (allocated(perp_inv)) deallocate (perp_inv)
+        if (allocated(iclass)) deallocate (iclass)
     allocate(times_lost(ntestpart), trap_par(ntestpart), perp_inv(ntestpart), iclass(3,ntestpart))
 
-    do ipart=1,ngrid
-      do jpart=1,ngrid
-        lidx = (jpart-1)*ngrid+ipart
-        xinteg = [sbeg(1), xsize_real*ipart, xsize_real*jpart]
-        if (convert_surface_starts) then
-          call integ_to_ref(xinteg, zstart(1:3,lidx))
+        do ipart = 1, ngrid
+            do jpart = 1, ngrid
+                lidx = (jpart - 1)*ngrid + ipart
+                xinteg = [sbeg(1), xsize_real*ipart, xsize_real*jpart]
+                if (convert_surface_starts) then
+                    call integ_to_ref(xinteg, zstart(1:3, lidx))
+                else
+                    zstart(1:3, lidx) = xinteg
+                end if
+                zstart(4, lidx) = 1.d0  ! normalized velocity module z(4) = v / v_0
+                call random_number(xi)
+                zstart(5, lidx) = 2.d0*(xi - 0.5d0)  ! starting pitch z(5)=v_\parallel / v
+            end do
+        end do
+
+        call save_starting_points(zstart)
+
+    end subroutine sample_grid
+
+    subroutine sample_random_batch(zstart, reuse_existing)
+        ! Get random batch from preexisting zstart, allows reuse.
+        use params, only: batch_size, ntestpart, zstart_dim1, idx
+
+        integer :: ran_begin, ran_end, ipart
+        real :: temp_ran
+        real(dp), dimension(:, :), intent(inout) :: zstart
+        real(dp), dimension(zstart_dim1, batch_size) :: zstart_batch
+        logical, intent(in) :: reuse_existing
+
+        if (reuse_existing .eqv. .True.) then
+            call load_starting_points(zstart_batch, START_FILE_BATCH)
         else
-          zstart(1:3,lidx) = xinteg
+            call load_starting_points(zstart_batch, START_FILE)
+            call random_number(temp_ran)
+            ran_begin = INT(temp_ran)
+            ran_end = ran_begin + batch_size
+            if ((ran_end) .gt. (ntestpart)) then
+                ran_begin = ran_begin - (ran_end - ntestpart)
+            end if
+            do ipart = 0, batch_size
+                zstart(:, ipart) = zstart_batch(:, (ipart + ran_begin))
+            end do
         end if
-        zstart(4,lidx) = 1.d0  ! normalized velocity module z(4) = v / v_0
-        call random_number(xi)
-        zstart(5,lidx)=2.d0*(xi-0.5d0)  ! starting pitch z(5)=v_\parallel / v
-      end do
-    enddo
 
-    call save_starting_points(zstart)
+        do ipart = idx(0), idx(ntestpart)
+            read (1, *) zstart(:, ipart)
+        end do
 
-  end subroutine sample_grid
+    end subroutine sample_random_batch
 
-  subroutine sample_random_batch(zstart, reuse_existing)
-  ! Get random batch from preexisting zstart, allows reuse.
-    use params, only: batch_size, ntestpart, zstart_dim1, idx
+    subroutine sample_points_ants(use_special_ants_file)
+        use parse_ants, only: process_line
+        use get_can_sub, only: vmec_to_can
+        use params, only: ntestpart, zstart ! ANTS sampler uses global zstart
 
-    integer :: ran_begin, ran_end, ipart
-    real :: temp_ran
-    real(dp), dimension(:,:), intent(inout) :: zstart
-    real(dp), dimension(zstart_dim1,batch_size) :: zstart_batch
-    logical, intent(in) :: reuse_existing
+        logical, intent(in) :: use_special_ants_file
 
-    if (reuse_existing .eqv. .True.) then
-      call load_starting_points(zstart_batch, START_FILE_BATCH)
-    else
-      call load_starting_points(zstart_batch, START_FILE)
-      call random_number(temp_ran)
-      ran_begin = INT(temp_ran)
-      ran_end = ran_begin+batch_size
-      if ((ran_end).gt.(ntestpart)) then
-        ran_begin = ran_begin - (ran_end-ntestpart)
-      endif
-      do ipart=0,batch_size
-        zstart(:,ipart) = zstart_batch(:,(ipart+ran_begin))
-      enddo
-    endif
+        integer, parameter :: maxlen = 4096
+        character(len=maxlen) :: line
+        real(8) :: v_par, v_perp, u, v, s
+        real(8) :: th, ph
+        integer :: ipart
 
-    do ipart=idx(0),idx(ntestpart)
-      read(1,*) zstart(:,ipart)
-    enddo
+        do ipart = 1, ntestpart
+            if (use_special_ants_file) then
+                open (1, file=START_FILE_ANTS, recl=1024)
+                read (1, '(A)') line
+                close (1)
+            else
+                open (1, file=START_FILE, recl=1024)
+                read (1, '(A)') line
+                close (1)
+            end if
 
-  end subroutine sample_random_batch
-
-  subroutine sample_points_ants(use_special_ants_file)
-    use parse_ants, only : process_line
-    use get_can_sub, only : vmec_to_can
-    use params, only: ntestpart, zstart ! ANTS sampler uses global zstart
-
-    logical, intent(in) :: use_special_ants_file
-
-    integer, parameter :: maxlen = 4096
-    character(len=maxlen) :: line
-    real(8) :: v_par, v_perp, u, v, s
-    real(8) :: th, ph
-    integer :: ipart
-
-    do ipart=1,ntestpart
-      if (use_special_ants_file) then
-        open (1, file=START_FILE_ANTS, recl=1024)
-        read(1, '(A)') line
-        close(1)
-      else
-        open(1, file=START_FILE, recl=1024)
-        read(1, '(A)') line
-        close(1)
-      endif
-
-      call process_line(line, v_par, v_perp, u, v, s)
-      ! In the test case, u runs from 0 to 1 and v from 0 to 4
-      th = 2d0*pi*u
-      ph = 2d0*pi*v/4d0
-      zstart(1, ipart) = s
-      zstart(2, ipart) = th
-      zstart(3, ipart) = ph
-      zstart(4, ipart) = 1.d0
-      zstart(5, ipart) = v_par / sqrt(v_par**2 + v_perp**2)
-    enddo
-  end subroutine sample_points_ants
-
+            call process_line(line, v_par, v_perp, u, v, s)
+            ! In the test case, u runs from 0 to 1 and v from 0 to 4
+            th = 2d0*pi*u
+            ph = 2d0*pi*v/4d0
+            zstart(1, ipart) = s
+            zstart(2, ipart) = th
+            zstart(3, ipart) = ph
+            zstart(4, ipart) = 1.d0
+            zstart(5, ipart) = v_par/sqrt(v_par**2 + v_perp**2)
+        end do
+    end subroutine sample_points_ants
 
 end module samplers

--- a/test/tests/export_boozer_chartmap_tool.f90
+++ b/test/tests/export_boozer_chartmap_tool.f90
@@ -9,13 +9,13 @@ program export_boozer_chartmap_tool
     use velo_mod, only: isw_field_type
     use boozer_coordinates_mod, only: use_B_r
     use boozer_sub, only: get_boozer_coordinates, vmec_to_boozer, &
-        export_boozer_chartmap
+                          export_boozer_chartmap
     use spline_vmec_sub, only: spline_vmec_data
     use vmecin_sub, only: stevvo
 
     implicit none
 
-    real(dp), parameter :: twopi = 8.0_dp * atan(1.0_dp)
+    real(dp), parameter :: twopi = 8.0_dp*atan(1.0_dp)
     character(len=1024) :: wout_file, chartmap_file, start_vmec, start_boozer
     integer :: nargs, ipart, npart, ios, u_in, u_out
     real(dp) :: s, theta_v, phi_v, v, lam, theta_b, phi_b
@@ -25,7 +25,7 @@ program export_boozer_chartmap_tool
     nargs = command_argument_count()
     if (nargs /= 4) then
         print *, 'Usage: export_boozer_chartmap_tool.x <wout.nc> <chartmap.nc>', &
-                 ' <start_vmec.dat> <start_boozer.dat>'
+            ' <start_vmec.dat> <start_boozer.dat>'
         error stop
     end if
 
@@ -45,7 +45,7 @@ program export_boozer_chartmap_tool
 
     call spline_vmec_data
     call stevvo(RT0, R0i, L1i, cbfi, bz0i, bf0)
-    fper = twopi / real(L1i, dp)
+    fper = twopi/real(L1i, dp)
 
     ! Compute Boozer coordinates
     use_B_r = .false.
@@ -56,26 +56,26 @@ program export_boozer_chartmap_tool
 
     ! Count particles in start_vmec
     npart = 0
-    open(newunit=u_in, file=trim(start_vmec), status='old', iostat=ios)
+    open (newunit=u_in, file=trim(start_vmec), status='old', iostat=ios)
     if (ios /= 0) then
         print *, 'Cannot open ', trim(start_vmec)
         error stop
     end if
     do
-        read(u_in, *, iostat=ios)
+        read (u_in, *, iostat=ios)
         if (ios /= 0) exit
         npart = npart + 1
     end do
-    close(u_in)
+    close (u_in)
 
     print *, 'Converting', npart, ' particles from VMEC to Boozer coords'
 
     ! Convert start.dat coordinates
-    open(newunit=u_in, file=trim(start_vmec), status='old')
-    open(newunit=u_out, file=trim(start_boozer), status='replace', recl=1024)
+    open (newunit=u_in, file=trim(start_vmec), status='old')
+    open (newunit=u_out, file=trim(start_boozer), status='replace', recl=1024)
 
     do ipart = 1, npart
-        read(u_in, *) s, theta_v, phi_v, v, lam
+        read (u_in, *) s, theta_v, phi_v, v, lam
 
         ! Transform VMEC angles to Boozer angles
         call vmec_to_boozer(s, theta_v, phi_v, theta_b, phi_b)
@@ -83,11 +83,11 @@ program export_boozer_chartmap_tool
         ! In chartmap reference coords: x(1) = rho = sqrt(s)
         rho = sqrt(max(s, 0.0_dp))
 
-        write(u_out, *) rho, theta_b, phi_b, v, lam
+        write (u_out, *) rho, theta_b, phi_b, v, lam
     end do
 
-    close(u_in)
-    close(u_out)
+    close (u_in)
+    close (u_out)
 
     print *, 'Written ', trim(start_boozer)
 

--- a/test/tests/field_can/test_albert_transform_diagnostic.f90
+++ b/test/tests/field_can/test_albert_transform_diagnostic.f90
@@ -17,10 +17,10 @@ program test_albert_transform_diagnostic
     use field, only: vmec_field_t, create_vmec_field
     use simple, only: init_vmec
     use field_can_meiss, only: init_meiss, get_meiss_coordinates, cleanup_meiss, &
-        spl_field_batch, xmin, xmax, n_r, n_th, n_phi, twopi
+                               spl_field_batch, xmin, xmax, n_r, n_th, n_phi, twopi
     use field_can_albert, only: get_albert_coordinates, psi_inner, psi_outer, &
-        psi_of_x, Ath_norm, r_of_xc, spl_r_batch, &
-        integ_to_ref_albert, ref_to_integ_albert
+                                psi_of_x, Ath_norm, r_of_xc, spl_r_batch, &
+                                integ_to_ref_albert, ref_to_integ_albert
     use interpolate, only: evaluate_batch_splines_3d
 
     implicit none
@@ -69,14 +69,13 @@ contains
 
         psi_range_full = psi_max_outer - psi_min_inner
         psi_range_safe = psi_outer - psi_inner
-        coverage = psi_range_safe / psi_range_full * 100d0
+        coverage = psi_range_safe/psi_range_full*100d0
 
         print *, '  Safe psi range: [', psi_inner, ',', psi_outer, ']'
         print *, '  Full psi range: [', psi_min_inner, ',', psi_max_outer, ']'
         print *, '  Coverage:', coverage, '%'
         print *, ''
     end subroutine diagnose_psi_range
-
 
     subroutine diagnose_transform_steps()
         !> Trace through transform steps to identify error accumulation.
@@ -94,7 +93,7 @@ contains
         x_ref = [0.5d0, 3.14159d0, 0.5d0]
 
         print *, '  Starting point (ref coords): s=', x_ref(1), &
-                 ' th=', x_ref(2), ' ph=', x_ref(3)
+            ' th=', x_ref(2), ' ph=', x_ref(3)
 
         ! Step 1: ref -> meiss (should be exact)
         call ref_to_integ_meiss(x_ref, x_meiss)
@@ -103,7 +102,7 @@ contains
 
         ! Step 2: Evaluate Ath spline at meiss coords
         call evaluate_batch_splines_3d(spl_field_batch, x_meiss, y_ath)
-        psi_forward = y_ath(1) / Ath_norm
+        psi_forward = y_ath(1)/Ath_norm
         print *, '  Step 2 - Ath spline evaluation:'
         print *, '    Ath =', y_ath(1), ' psi = Ath/Ath_norm =', psi_forward
 
@@ -134,7 +133,6 @@ contains
         print *, '    Total roundtrip error in s:', err_total
         print *, ''
     end subroutine diagnose_transform_steps
-
 
     subroutine diagnose_grid_resolution_effect()
         !> Test how grid resolution affects transform accuracy.

--- a/test/tests/field_can/test_coord_transform_roundtrip.f90
+++ b/test/tests/field_can/test_coord_transform_roundtrip.f90
@@ -115,7 +115,6 @@ contains
         call cleanup_meiss()
     end subroutine test_meiss_roundtrip
 
-
     subroutine test_meiss_s_r_conversion(n_failed)
         !> Verify the s <-> r = sqrt(s) scaling is applied correctly.
         integer, intent(inout) :: n_failed
@@ -159,7 +158,6 @@ contains
             print *, '    PASSED: s=0.81 -> r=0.9 conversion correct'
         end if
     end subroutine test_meiss_s_r_conversion
-
 
     subroutine test_albert_roundtrip(n_failed)
         !> Albert coordinates use spline interpolation for the psi <-> r mapping:

--- a/test/tests/field_can/test_field_can_albert.f90
+++ b/test/tests/field_can/test_field_can_albert.f90
@@ -1,25 +1,25 @@
 program test_field_can_albert
 
-use, intrinsic :: iso_fortran_env, only: dp => real64
+    use, intrinsic :: iso_fortran_env, only: dp => real64
 
-use simple, only: tracer_t
-use simple_main, only: init_field
-use magfie_sub, only: ALBERT
-use velo_mod, only: isw_field_type
-use field, only: vmec_field_t, create_vmec_field
-use field_can_albert, only: init_albert
+    use simple, only: tracer_t
+    use simple_main, only: init_field
+    use magfie_sub, only: ALBERT
+    use velo_mod, only: isw_field_type
+    use field, only: vmec_field_t, create_vmec_field
+    use field_can_albert, only: init_albert
 
-implicit none
+    implicit none
 
-real(dp), parameter :: twopi = atan(1.d0)*8.d0
+    real(dp), parameter :: twopi = atan(1.d0)*8.d0
 
-type(tracer_t) :: norb
-type(vmec_field_t) :: magfie
+    type(tracer_t) :: norb
+    type(vmec_field_t) :: magfie
 
-isw_field_type = ALBERT
-call create_vmec_field(magfie)
+    isw_field_type = ALBERT
+    call create_vmec_field(magfie)
 
-print *, 'init_field'
-call init_field(norb, 'wout.nc', 5, 5, 3, 0)
+    print *, 'init_field'
+    call init_field(norb, 'wout.nc', 5, 5, 3, 0)
 
 end program test_field_can_albert

--- a/test/tests/field_can/test_field_can_albert_diagnostic.f90
+++ b/test/tests/field_can/test_field_can_albert_diagnostic.f90
@@ -9,7 +9,7 @@ program test_field_can_albert_diagnostic
     use velo_mod, only: isw_field_type
     use field, only: vmec_field_t, create_vmec_field
     use field_can_albert, only: init_albert, psi_inner, psi_outer, &
-        psi_of_x, Ath_norm, dpsi_dr_positive
+                                psi_of_x, Ath_norm, dpsi_dr_positive
     use field_can_meiss, only: spl_field_batch, xmin, xmax, n_r, n_th, n_phi
     use interpolate, only: evaluate_batch_splines_3d
     use params, only: coord_input
@@ -28,7 +28,7 @@ program test_field_can_albert_diagnostic
 
     print *, 'Test: Albert coordinate field initialization'
 
-    inquire(file='wout.nc', exist=file_exists)
+    inquire (file='wout.nc', exist=file_exists)
     if (.not. file_exists) then
         print *, 'FAILED: Required VMEC file (wout.nc) not found'
         error stop 1
@@ -65,12 +65,12 @@ program test_field_can_albert_diagnostic
     print *, 'Test 4: psi_of_x monotonicity'
     if (dpsi_dr_positive) then
         if (psi_of_x(n_r, n_th/2, n_phi/2) <= psi_of_x(1, n_th/2, n_phi/2)) then
-            print *, '  FAILED: psi_of_x should increase with r when dpsi_dr_positive=.true.'
+       print *, '  FAILED: psi_of_x should increase with r when dpsi_dr_positive=.true.'
             n_failed = n_failed + 1
         end if
     else
         if (psi_of_x(n_r, n_th/2, n_phi/2) >= psi_of_x(1, n_th/2, n_phi/2)) then
-            print *, '  FAILED: psi_of_x should decrease with r when dpsi_dr_positive=.false.'
+      print *, '  FAILED: psi_of_x should decrease with r when dpsi_dr_positive=.false.'
             n_failed = n_failed + 1
         end if
     end if
@@ -82,9 +82,9 @@ program test_field_can_albert_diagnostic
     do i_phi = 1, n_phi, max(1, n_phi/4)
         do i_th = 1, n_th, max(1, n_th/4)
             do i_r = 1, n_r, max(1, n_r/4)
-                x(1) = xmin(1) + (i_r-1)*(xmax(1)-xmin(1))/(n_r-1)
-                x(2) = xmin(2) + (i_th-1)*(xmax(2)-xmin(2))/(n_th-1)
-                x(3) = xmin(3) + (i_phi-1)*(xmax(3)-xmin(3))/(n_phi-1)
+                x(1) = xmin(1) + (i_r - 1)*(xmax(1) - xmin(1))/(n_r - 1)
+                x(2) = xmin(2) + (i_th - 1)*(xmax(2) - xmin(2))/(n_th - 1)
+                x(3) = xmin(3) + (i_phi - 1)*(xmax(3) - xmin(3))/(n_phi - 1)
                 call evaluate_batch_splines_3d(spl_field_batch, x, y_batch)
                 ! y_batch(5) is Bmod
                 Bmod_min = min(Bmod_min, y_batch(5))

--- a/test/tests/field_can/test_field_can_meiss.f90
+++ b/test/tests/field_can/test_field_can_meiss.f90
@@ -1,141 +1,138 @@
 program test_field_can_meiss
 
-use, intrinsic :: iso_fortran_env, only: dp => real64
-use params, only: read_config
-use simple, only: tracer_t
-use simple_main, only: init_field
-use velo_mod, only: isw_field_type
-use field, only: vmec_field_t, create_vmec_field
-use field_can_mod, only: eval_field => evaluate, field_can_t, field_can_init
-use magfie_sub, only: MEISS
-use field_can_meiss, only: init_meiss, init_transformation, &
-    spline_transformation, init_canonical_field_components, &
-    xmin, h_r, h_phi, h_th, ah_cov_on_slice, n_r, n_phi, n_th, lam_phi, chi_gauge
-use new_vmec_stuff_mod, only : old_axis_healing, old_axis_healing_boundary
-implicit none
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use params, only: read_config
+    use simple, only: tracer_t
+    use simple_main, only: init_field
+    use velo_mod, only: isw_field_type
+    use field, only: vmec_field_t, create_vmec_field
+    use field_can_mod, only: eval_field => evaluate, field_can_t, field_can_init
+    use magfie_sub, only: MEISS
+    use field_can_meiss, only: init_meiss, init_transformation, &
+                               spline_transformation, init_canonical_field_components, &
+           xmin, h_r, h_phi, h_th, ah_cov_on_slice, n_r, n_phi, n_th, lam_phi, chi_gauge
+    use new_vmec_stuff_mod, only: old_axis_healing, old_axis_healing_boundary
+    implicit none
 
-real(dp), parameter :: twopi = atan(1.d0)*8.d0
+    real(dp), parameter :: twopi = atan(1.d0)*8.d0
 
-type(tracer_t) :: norb
-type(vmec_field_t) :: magfie
+    type(tracer_t) :: norb
+    type(vmec_field_t) :: magfie
 
-isw_field_type = MEISS
-call create_vmec_field(magfie)
+    isw_field_type = MEISS
+    call create_vmec_field(magfie)
 
-print *, 'init_field'
-call init_field(norb, 'wout.nc', 5, 5, 3, 0)
-call init_meiss(magfie, 128, 4, 4, 0.01d0, 1.0d0, 0.0d0, twopi)
+    print *, 'init_field'
+    call init_field(norb, 'wout.nc', 5, 5, 3, 0)
+    call init_meiss(magfie, 128, 4, 4, 0.01d0, 1.0d0, 0.0d0, twopi)
 
-print *, 'test_covar_components'
-call test_covar_components
+    print *, 'test_covar_components'
+    call test_covar_components
 
-print *, 'field_can_meiss.write_transformation'
-call write_transformation('lam_chi.out')
+    print *, 'field_can_meiss.write_transformation'
+    call write_transformation('lam_chi.out')
 
-print *, 'test_evaluate_vmec'
-call test_evaluate_vmec
+    print *, 'test_evaluate_vmec'
+    call test_evaluate_vmec
 
-print *, 'test_evaluate_meiss'
-call test_evaluate_meiss
+    print *, 'test_evaluate_meiss'
+    call test_evaluate_meiss
 
 contains
 
-subroutine test_covar_components
-    real(dp) :: r, phi, th
-    real(dp) :: Ar, Ap, hr, hp
-    integer :: i_r, i_phi, i_th
-    integer :: funit
+    subroutine test_covar_components
+        real(dp) :: r, phi, th
+        real(dp) :: Ar, Ap, hr, hp
+        integer :: i_r, i_phi, i_th
+        integer :: funit
 
-    open(newunit=funit, file='covar_components.out')
-    write(funit, *) '#', ' r', ' phi', ' th', ' Arcov', ' Apcov', ' Atcov', &
-                    ' hrcov', ' hpcov', ' htcov', ' Bmod'
-    do i_phi = 1, n_phi
-        phi = xmin(3) + h_phi*(i_phi-1)
-        do i_th = 1, n_th
-            th = xmin(2) + h_th*(i_th-1)
+        open (newunit=funit, file='covar_components.out')
+        write (funit, *) '#', ' r', ' phi', ' th', ' Arcov', ' Apcov', ' Atcov', &
+            ' hrcov', ' hpcov', ' htcov', ' Bmod'
+        do i_phi = 1, n_phi
+            phi = xmin(3) + h_phi*(i_phi - 1)
+            do i_th = 1, n_th
+                th = xmin(2) + h_th*(i_th - 1)
                 do i_r = 1, n_r
-                    r = xmin(1) + h_r*(i_r-1)
+                    r = xmin(1) + h_r*(i_r - 1)
                     call ah_cov_on_slice(r, phi, i_th, Ar, Ap, hr, hp)
-                    write(funit, *) r, phi, th, Ar, Ap, 0d0, hr, hp, 0d0, 0d0
+                    write (funit, *) r, phi, th, Ar, Ap, 0d0, hr, hp, 0d0, 0d0
                 end do
-        end do
-    end do
-    close(funit)
-end subroutine test_covar_components
-
-
-subroutine write_transformation(filename)
-    character(*), intent(in) :: filename
-
-    integer :: funit
-    integer :: i_r, i_th, i_phi
-    real(dp) :: r, th, phi
-
-    open(newunit=funit, file=filename, status='unknown')
-    write(funit, *) '#', ' r', ' phi', ' th', ' lam_phi', ' chi_gauge'
-
-    do i_th=1,n_th
-        th = xmin(2) + h_th*(i_th-1)
-        do i_phi=1,n_phi
-            phi = xmin(3) + h_phi*(i_phi-1)
-            do i_r=1,n_r
-                r = xmin(1) + h_r*(i_r-1)
-                write(funit, *) r, phi, th, lam_phi(i_r, i_th, i_phi), &
-                    chi_gauge(i_r, i_th, i_phi)
-            enddo
-        enddo
-    enddo
-
-    close(funit)
-end subroutine write_transformation
-
-
-subroutine test_evaluate_vmec
-    real(dp) :: r, phi, th
-    real(dp) :: Acov(3), hcov(3), Bmod
-    integer :: i_r, i_phi, i_th
-    integer :: funit
-
-    open(newunit=funit, file='field_vmec.out')
-    write(funit, *) '#', ' r', ' phi', ' th', ' Arcov', ' Apcov', ' Atcov', &
-                    ' hrcov', ' hpcov', ' htcov', ' Bmod'
-    do i_th = 1, n_th
-        th = xmin(2) + h_th*(i_th-1)
-        do i_phi = 1, n_phi
-            phi = xmin(3) + h_phi*(i_phi-1)
-            do i_r = 1, n_r
-                r = xmin(1) + h_r*(i_r-1)
-                call magfie%evaluate([r, th, phi], Acov, hcov, Bmod)
-                write(funit, *) r, phi, th, Acov(1), Acov(3), Acov(2), &
-                    hcov(1), hcov(3), hcov(2), Bmod
             end do
         end do
-    end do
-    close(funit)
-end subroutine test_evaluate_vmec
+        close (funit)
+    end subroutine test_covar_components
 
+    subroutine write_transformation(filename)
+        character(*), intent(in) :: filename
 
-subroutine test_evaluate_meiss
-    real(dp) :: r, phi, th
-    type(field_can_t) :: f
-    integer :: i_r, i_phi, i_th
-    integer :: funit
+        integer :: funit
+        integer :: i_r, i_th, i_phi
+        real(dp) :: r, th, phi
 
-    open(newunit=funit, file='field_can_meiss.out')
-    write(funit, *) '#', ' r', ' phi', ' th', ' Arcov', ' Apcov', ' Atcov', &
-                    ' hrcov', ' hpcov', ' htcov', ' Bmod'
-    do i_th = 1, n_th
-        th = xmin(3) + h_th*(i_th-1)
-        do i_phi = 1, n_phi
-            phi = xmin(2) + h_phi*(i_phi-1)
-            do i_r = 1, n_r
-                r = xmin(1) + h_r*(i_r-1)
-                call eval_field(f, r, th, phi, 0)
-                write(funit, *) r, phi, th, 0d0, f%Aph, f%Ath, 0d0, f%hph, f%hth, f%Bmod
+        open (newunit=funit, file=filename, status='unknown')
+        write (funit, *) '#', ' r', ' phi', ' th', ' lam_phi', ' chi_gauge'
+
+        do i_th = 1, n_th
+            th = xmin(2) + h_th*(i_th - 1)
+            do i_phi = 1, n_phi
+                phi = xmin(3) + h_phi*(i_phi - 1)
+                do i_r = 1, n_r
+                    r = xmin(1) + h_r*(i_r - 1)
+                    write (funit, *) r, phi, th, lam_phi(i_r, i_th, i_phi), &
+                        chi_gauge(i_r, i_th, i_phi)
+                end do
             end do
         end do
-    end do
-    close(funit)
-end subroutine test_evaluate_meiss
+
+        close (funit)
+    end subroutine write_transformation
+
+    subroutine test_evaluate_vmec
+        real(dp) :: r, phi, th
+        real(dp) :: Acov(3), hcov(3), Bmod
+        integer :: i_r, i_phi, i_th
+        integer :: funit
+
+        open (newunit=funit, file='field_vmec.out')
+        write (funit, *) '#', ' r', ' phi', ' th', ' Arcov', ' Apcov', ' Atcov', &
+            ' hrcov', ' hpcov', ' htcov', ' Bmod'
+        do i_th = 1, n_th
+            th = xmin(2) + h_th*(i_th - 1)
+            do i_phi = 1, n_phi
+                phi = xmin(3) + h_phi*(i_phi - 1)
+                do i_r = 1, n_r
+                    r = xmin(1) + h_r*(i_r - 1)
+                    call magfie%evaluate([r, th, phi], Acov, hcov, Bmod)
+                    write (funit, *) r, phi, th, Acov(1), Acov(3), Acov(2), &
+                        hcov(1), hcov(3), hcov(2), Bmod
+                end do
+            end do
+        end do
+        close (funit)
+    end subroutine test_evaluate_vmec
+
+    subroutine test_evaluate_meiss
+        real(dp) :: r, phi, th
+        type(field_can_t) :: f
+        integer :: i_r, i_phi, i_th
+        integer :: funit
+
+        open (newunit=funit, file='field_can_meiss.out')
+        write (funit, *) '#', ' r', ' phi', ' th', ' Arcov', ' Apcov', ' Atcov', &
+            ' hrcov', ' hpcov', ' htcov', ' Bmod'
+        do i_th = 1, n_th
+            th = xmin(3) + h_th*(i_th - 1)
+            do i_phi = 1, n_phi
+                phi = xmin(2) + h_phi*(i_phi - 1)
+                do i_r = 1, n_r
+                    r = xmin(1) + h_r*(i_r - 1)
+                    call eval_field(f, r, th, phi, 0)
+               write (funit, *) r, phi, th, 0d0, f%Aph, f%Ath, 0d0, f%hph, f%hth, f%Bmod
+                end do
+            end do
+        end do
+        close (funit)
+    end subroutine test_evaluate_meiss
 
 end program test_field_can_meiss

--- a/test/tests/magfie/test_magfie_coils.f90
+++ b/test/tests/magfie/test_magfie_coils.f90
@@ -30,8 +30,8 @@ program test_magfie_coils
     n_failed = 0
     isw_field_type = VMEC
 
-    inquire(file='wout.nc', exist=wout_exists)
-    inquire(file='coils.simple', exist=coils_exists)
+    inquire (file='wout.nc', exist=wout_exists)
+    inquire (file='coils.simple', exist=coils_exists)
     if (.not. wout_exists) then
         print *, 'FAILED: Required VMEC file (wout.nc) not found'
         error stop 1
@@ -83,7 +83,7 @@ program test_magfie_coils
 
     ! Test 4: Splined and raw should agree within 1%
     print *, 'Test 4: Splined vs raw Biot-Savart agreement'
-    if (abs(Bmod_spl - Bmod_raw) / Bmod_raw > 0.01_dp) then
+    if (abs(Bmod_spl - Bmod_raw)/Bmod_raw > 0.01_dp) then
         print *, '  FAILED: Bmod_spl and Bmod_raw differ by more than 1%'
         print *, '    Bmod_spl = ', Bmod_spl, ' Bmod_raw = ', Bmod_raw
         n_failed = n_failed + 1
@@ -130,7 +130,6 @@ contains
         call cyl_to_cart(x_cyl, x_cart)
         call field%evaluate(x_cart, Acov, hcov, Bmod)
     end subroutine evaluate_raw_at_ref
-
 
     subroutine test_magfie(n_failed)
         integer, intent(inout) :: n_failed

--- a/test/tests/magfie/test_orbit_refcoords_rk45.f90
+++ b/test/tests/magfie/test_orbit_refcoords_rk45.f90
@@ -50,7 +50,7 @@ program test_orbit_refcoords_rk45
     real(dp) :: dev_s, dev_th, dev_phi
     real(dp) :: mu_drift_vmec, mu_drift_refcoords
 
-    real(dp) :: traj_vmec(5, n_steps+1), traj_refcoords(5, n_steps+1)
+    real(dp) :: traj_vmec(5, n_steps + 1), traj_refcoords(5, n_steps + 1)
     real(dp) :: time_arr(n_steps+1), mu_vmec_arr(n_steps+1), mu_refcoords_arr(n_steps+1)
 
     n_failed = 0
@@ -90,9 +90,9 @@ program test_orbit_refcoords_rk45
             print *, 'magfie_vmec: particle left domain at step ', i
             exit
         end if
-        traj_vmec(:, i+1) = z_vmec
-        time_arr(i+1) = i * dtaumin
-        mu_vmec_arr(i+1) = compute_mu_at_point(z_vmec)
+        traj_vmec(:, i + 1) = z_vmec
+        time_arr(i + 1) = i*dtaumin
+        mu_vmec_arr(i + 1) = compute_mu_at_point(z_vmec)
     end do
     mu_vmec_final = compute_mu_at_point(z_vmec)
     mu_drift_vmec = abs(mu_vmec_final - mu0_vmec)/mu0_vmec
@@ -116,8 +116,8 @@ program test_orbit_refcoords_rk45
             print *, 'magfie_refcoords: particle left domain at step ', i
             exit
         end if
-        traj_refcoords(:, i+1) = z_refcoords
-        mu_refcoords_arr(i+1) = compute_mu_at_point(z_refcoords)
+        traj_refcoords(:, i + 1) = z_refcoords
+        mu_refcoords_arr(i + 1) = compute_mu_at_point(z_refcoords)
     end do
     mu_refcoords_final = compute_mu_at_point(z_refcoords)
     mu_drift_refcoords = abs(mu_refcoords_final - mu0_refcoords)/mu0_refcoords
@@ -146,7 +146,7 @@ program test_orbit_refcoords_rk45
     print *
 
     call write_orbits_netcdf(traj_vmec, traj_refcoords, time_arr, &
-                             mu_vmec_arr, mu_refcoords_arr, n_steps+1)
+                             mu_vmec_arr, mu_refcoords_arr, n_steps + 1)
     print *, 'Wrote orbit comparison to orbit_refcoords_comparison.nc'
     print *
 
@@ -196,7 +196,6 @@ contains
         rmu = 1.0d8
     end subroutine set_physics_parameters
 
-
     subroutine set_initial_conditions(z, bmod)
         real(dp), intent(out) :: z(5), bmod
 
@@ -213,7 +212,6 @@ contains
         call magfie(z(1:3), bmod, sqrtg, bder, hcov, hctr, hcurl)
     end subroutine set_initial_conditions
 
-
     function compute_mu(z, bmod) result(mu)
         real(dp), intent(in) :: z(5), bmod
         real(dp) :: mu
@@ -226,7 +224,6 @@ contains
         mu = 0.5_dp*p**2*coala/bmod
     end function compute_mu
 
-
     function compute_mu_at_point(z) result(mu)
         real(dp), intent(in) :: z(5)
         real(dp) :: mu
@@ -236,7 +233,6 @@ contains
         call magfie(z(1:3), bmod, sqrtg, bder, hcov, hctr, hcurl)
         mu = compute_mu(z, bmod)
     end function compute_mu_at_point
-
 
     subroutine check_nc(status, location)
         integer, intent(in) :: status
@@ -248,7 +244,6 @@ contains
             error stop 'NetCDF operation failed'
         end if
     end subroutine check_nc
-
 
     subroutine write_orbits_netcdf(traj_vmec, traj_refcoords, time_arr, &
                                    mu_vmec, mu_refcoords, n_points)
@@ -264,10 +259,9 @@ contains
         call nc_create_file(ncid, dimid_time, n_points)
         call nc_define_variables(ncid, dimid_time, varids_vmec, varids_ref)
         call nc_write_data(ncid, varids_vmec, varids_ref, traj_vmec, &
-                          traj_refcoords, time_arr, mu_vmec, mu_refcoords)
+                           traj_refcoords, time_arr, mu_vmec, mu_refcoords)
         call check_nc(nf90_close(ncid), 'nf90_close')
     end subroutine write_orbits_netcdf
-
 
     subroutine nc_create_file(ncid, dimid_time, n_points)
         integer, intent(out) :: ncid, dimid_time
@@ -275,20 +269,19 @@ contains
         integer :: status, varid_time
 
         status = nf90_create('orbit_refcoords_comparison.nc', &
-                            nf90_netcdf4, ncid)
+                             nf90_netcdf4, ncid)
         call check_nc(status, 'nf90_create')
         status = nf90_def_dim(ncid, 'time', n_points, dimid_time)
         call check_nc(status, 'nf90_def_dim')
         status = nf90_def_var(ncid, 'time', nf90_double, &
-                             [dimid_time], varid_time)
+                              [dimid_time], varid_time)
         call check_nc(status, 'nf90_def_var time')
         status = nf90_put_att(ncid, varid_time, 'units', 'normalized')
         call check_nc(status, 'nf90_put_att units')
         status = nf90_put_att(ncid, nf90_global, 'description', &
-            'RK45 orbit comparison: magfie_vmec vs magfie_refcoords')
+                              'RK45 orbit comparison: magfie_vmec vs magfie_refcoords')
         call check_nc(status, 'nf90_put_att description')
     end subroutine nc_create_file
-
 
     subroutine nc_define_variables(ncid, dimid, varids_vmec, varids_ref)
         integer, intent(in) :: ncid, dimid
@@ -299,36 +292,34 @@ contains
         call check_nc(nf90_enddef(ncid), 'nf90_enddef')
     end subroutine nc_define_variables
 
-
     subroutine nc_def_trajectory_vars(ncid, dimid, suffix, varids)
         integer, intent(in) :: ncid, dimid
         character(len=*), intent(in) :: suffix
         integer, intent(out) :: varids(6)
         character(len=64) :: varname
 
-        varname = 's_' // trim(suffix)
+        varname = 's_'//trim(suffix)
         call check_nc(nf90_def_var(ncid, varname, nf90_double, &
                                    [dimid], varids(1)), varname)
-        varname = 'theta_' // trim(suffix)
+        varname = 'theta_'//trim(suffix)
         call check_nc(nf90_def_var(ncid, varname, nf90_double, &
                                    [dimid], varids(2)), varname)
-        varname = 'phi_' // trim(suffix)
+        varname = 'phi_'//trim(suffix)
         call check_nc(nf90_def_var(ncid, varname, nf90_double, &
                                    [dimid], varids(3)), varname)
-        varname = 'p_' // trim(suffix)
+        varname = 'p_'//trim(suffix)
         call check_nc(nf90_def_var(ncid, varname, nf90_double, &
                                    [dimid], varids(4)), varname)
-        varname = 'lambda_' // trim(suffix)
+        varname = 'lambda_'//trim(suffix)
         call check_nc(nf90_def_var(ncid, varname, nf90_double, &
                                    [dimid], varids(5)), varname)
-        varname = 'mu_' // trim(suffix)
+        varname = 'mu_'//trim(suffix)
         call check_nc(nf90_def_var(ncid, varname, nf90_double, &
                                    [dimid], varids(6)), varname)
     end subroutine nc_def_trajectory_vars
 
-
     subroutine nc_write_data(ncid, varids_vmec, varids_ref, traj_vmec, &
-                            traj_ref, time_arr, mu_vmec, mu_ref)
+                             traj_ref, time_arr, mu_vmec, mu_ref)
         integer, intent(in) :: ncid, varids_vmec(6), varids_ref(6)
         real(dp), intent(in) :: traj_vmec(:, :), traj_ref(:, :)
         real(dp), intent(in) :: time_arr(:), mu_vmec(:), mu_ref(:)
@@ -340,7 +331,6 @@ contains
         call nc_write_trajectory(ncid, varids_vmec, traj_vmec, mu_vmec)
         call nc_write_trajectory(ncid, varids_ref, traj_ref, mu_ref)
     end subroutine nc_write_data
-
 
     subroutine nc_write_trajectory(ncid, varids, traj, mu)
         integer, intent(in) :: ncid, varids(6)

--- a/test/tests/test_array_utils.f90
+++ b/test/tests/test_array_utils.f90
@@ -1,184 +1,184 @@
 program test_array_utils
-  use, intrinsic :: iso_fortran_env, only: dp => real64
-  use array_utils, only: init_derivative_factors
-  implicit none
-  
-  integer :: i, errors
-  
-  errors = 0
-  
-  ! Test basic functionality
-  call test_basic_values(errors)
-  
-  ! Test edge cases
-  call test_edge_cases(errors)
-  
-  ! Test large arrays
-  call test_large_arrays(errors)
-  
-  ! Test numerical accuracy
-  call test_numerical_accuracy(errors)
-  
-  if (errors == 0) then
-    print *, "All array_utils tests passed!"
-  else
-    print *, "ERROR: ", errors, " test(s) failed!"
-    stop 1
-  end if
-  
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use array_utils, only: init_derivative_factors
+    implicit none
+
+    integer :: i, errors
+
+    errors = 0
+
+    ! Test basic functionality
+    call test_basic_values(errors)
+
+    ! Test edge cases
+    call test_edge_cases(errors)
+
+    ! Test large arrays
+    call test_large_arrays(errors)
+
+    ! Test numerical accuracy
+    call test_numerical_accuracy(errors)
+
+    if (errors == 0) then
+        print *, "All array_utils tests passed!"
+    else
+        print *, "ERROR: ", errors, " test(s) failed!"
+        stop 1
+    end if
+
 contains
 
-  subroutine test_basic_values(errors)
-    integer, intent(inout) :: errors
-    double precision :: derf1(10), derf2(10), derf3(10)
-    double precision :: expected1(10), expected2(10), expected3(10)
-    integer :: k
-    
-    print *, "Testing basic derivative factor values..."
-    
-    ! Initialize expected values
-    do k = 1, 10
-      expected1(k) = dble(k-1)
-      expected2(k) = dble((k-1)*(k-2))
-      expected3(k) = dble((k-1)*(k-2)*(k-3))
-    end do
-    
-    ! Call the function
-    call init_derivative_factors(10, derf1, derf2, derf3)
-    
-    ! Check results
-    do k = 1, 10
-      if (abs(derf1(k) - expected1(k)) > 1.0d-15) then
-        print *, "ERROR: derf1(", k, ") = ", derf1(k), " expected ", expected1(k)
-        errors = errors + 1
-      end if
-      if (abs(derf2(k) - expected2(k)) > 1.0d-15) then
-        print *, "ERROR: derf2(", k, ") = ", derf2(k), " expected ", expected2(k)
-        errors = errors + 1
-      end if
-      if (abs(derf3(k) - expected3(k)) > 1.0d-15) then
-        print *, "ERROR: derf3(", k, ") = ", derf3(k), " expected ", expected3(k)
-        errors = errors + 1
-      end if
-    end do
-    
-    if (errors == 0) then
-      print *, "  Basic values test PASSED"
-    end if
-    
-  end subroutine test_basic_values
-  
-  subroutine test_edge_cases(errors)
-    integer, intent(inout) :: errors
-    double precision :: derf1(5), derf2(5), derf3(5)
-    
-    print *, "Testing edge cases..."
-    
-    ! Test with small array
-    call init_derivative_factors(5, derf1, derf2, derf3)
-    
-    ! Check specific edge values
-    ! For k=1: derf1 = 0, derf2 = 0, derf3 = 0
+    subroutine test_basic_values(errors)
+        integer, intent(inout) :: errors
+        double precision :: derf1(10), derf2(10), derf3(10)
+        double precision :: expected1(10), expected2(10), expected3(10)
+        integer :: k
+
+        print *, "Testing basic derivative factor values..."
+
+        ! Initialize expected values
+        do k = 1, 10
+            expected1(k) = dble(k - 1)
+            expected2(k) = dble((k - 1)*(k - 2))
+            expected3(k) = dble((k - 1)*(k - 2)*(k - 3))
+        end do
+
+        ! Call the function
+        call init_derivative_factors(10, derf1, derf2, derf3)
+
+        ! Check results
+        do k = 1, 10
+            if (abs(derf1(k) - expected1(k)) > 1.0d-15) then
+               print *, "ERROR: derf1(", k, ") = ", derf1(k), " expected ", expected1(k)
+                errors = errors + 1
+            end if
+            if (abs(derf2(k) - expected2(k)) > 1.0d-15) then
+               print *, "ERROR: derf2(", k, ") = ", derf2(k), " expected ", expected2(k)
+                errors = errors + 1
+            end if
+            if (abs(derf3(k) - expected3(k)) > 1.0d-15) then
+               print *, "ERROR: derf3(", k, ") = ", derf3(k), " expected ", expected3(k)
+                errors = errors + 1
+            end if
+        end do
+
+        if (errors == 0) then
+            print *, "  Basic values test PASSED"
+        end if
+
+    end subroutine test_basic_values
+
+    subroutine test_edge_cases(errors)
+        integer, intent(inout) :: errors
+        double precision :: derf1(5), derf2(5), derf3(5)
+
+        print *, "Testing edge cases..."
+
+        ! Test with small array
+        call init_derivative_factors(5, derf1, derf2, derf3)
+
+        ! Check specific edge values
+        ! For k=1: derf1 = 0, derf2 = 0, derf3 = 0
     if (abs(derf1(1)) > 1.0d-15 .or. abs(derf2(1)) > 1.0d-15 .or. abs(derf3(1)) > 1.0d-15) then
-      print *, "ERROR: k=1 should give all zeros"
-      errors = errors + 1
-    end if
-    
-    ! For k=2: derf1 = 1, derf2 = 0, derf3 = 0
+            print *, "ERROR: k=1 should give all zeros"
+            errors = errors + 1
+        end if
+
+        ! For k=2: derf1 = 1, derf2 = 0, derf3 = 0
     if (abs(derf1(2) - 1.0d0) > 1.0d-15 .or. abs(derf2(2)) > 1.0d-15 .or. abs(derf3(2)) > 1.0d-15) then
-      print *, "ERROR: k=2 values incorrect"
-      errors = errors + 1
-    end if
-    
-    ! For k=3: derf1 = 2, derf2 = 2, derf3 = 0
+            print *, "ERROR: k=2 values incorrect"
+            errors = errors + 1
+        end if
+
+        ! For k=3: derf1 = 2, derf2 = 2, derf3 = 0
     if (abs(derf1(3) - 2.0d0) > 1.0d-15 .or. abs(derf2(3) - 2.0d0) > 1.0d-15 .or. abs(derf3(3)) > 1.0d-15) then
-      print *, "ERROR: k=3 values incorrect"
-      errors = errors + 1
-    end if
-    
-    ! For k=4: derf1 = 3, derf2 = 6, derf3 = 6
+            print *, "ERROR: k=3 values incorrect"
+            errors = errors + 1
+        end if
+
+        ! For k=4: derf1 = 3, derf2 = 6, derf3 = 6
     if (abs(derf1(4) - 3.0d0) > 1.0d-15 .or. abs(derf2(4) - 6.0d0) > 1.0d-15 .or. abs(derf3(4) - 6.0d0) > 1.0d-15) then
-      print *, "ERROR: k=4 values incorrect"
-      errors = errors + 1
-    end if
-    
-    if (errors == 0) then
-      print *, "  Edge cases test PASSED"
-    end if
-    
-  end subroutine test_edge_cases
-  
-  subroutine test_large_arrays(errors)
-    integer, intent(inout) :: errors
-    integer, parameter :: n_large = 1000
-    double precision :: derf1(n_large), derf2(n_large), derf3(n_large)
-    integer :: k
-    
-    print *, "Testing large arrays..."
-    
-    ! Initialize large arrays
-    call init_derivative_factors(n_large, derf1, derf2, derf3)
-    
-    ! Check some specific values
-    ! For k=100: derf1 = 99, derf2 = 99*98 = 9702, derf3 = 99*98*97 = 941094
-    if (abs(derf1(100) - 99.0d0) > 1.0d-15) then
-      print *, "ERROR: derf1(100) incorrect"
-      errors = errors + 1
-    end if
-    if (abs(derf2(100) - 9702.0d0) > 1.0d-15) then
-      print *, "ERROR: derf2(100) incorrect"
-      errors = errors + 1
-    end if
-    if (abs(derf3(100) - 941094.0d0) > 1.0d-15) then
-      print *, "ERROR: derf3(100) incorrect"
-      errors = errors + 1
-    end if
-    
-    ! Check last value
-    if (abs(derf1(n_large) - dble(n_large-1)) > 1.0d-15) then
-      print *, "ERROR: derf1(", n_large, ") incorrect"
-      errors = errors + 1
-    end if
-    
-    if (errors == 0) then
-      print *, "  Large arrays test PASSED"
-    end if
-    
-  end subroutine test_large_arrays
-  
-  subroutine test_numerical_accuracy(errors)
-    integer, intent(inout) :: errors
-    double precision :: derf1(50), derf2(50), derf3(50)
-    double precision :: factorial_ratio
-    integer :: k
-    
-    print *, "Testing numerical accuracy..."
-    
-    call init_derivative_factors(50, derf1, derf2, derf3)
-    
-    ! Test relationships between arrays
-    ! derf2(k) should equal derf1(k) * (k-2) for k >= 3
-    do k = 3, 50
-      factorial_ratio = derf2(k) / derf1(k)
-      if (abs(factorial_ratio - dble(k-2)) > 1.0d-15) then
-        print *, "ERROR: derf2/derf1 ratio incorrect at k=", k
-        errors = errors + 1
-      end if
-    end do
-    
-    ! derf3(k) should equal derf2(k) * (k-3) for k >= 4
-    do k = 4, 50
-      factorial_ratio = derf3(k) / derf2(k)
-      if (abs(factorial_ratio - dble(k-3)) > 1.0d-15) then
-        print *, "ERROR: derf3/derf2 ratio incorrect at k=", k
-        errors = errors + 1
-      end if
-    end do
-    
-    if (errors == 0) then
-      print *, "  Numerical accuracy test PASSED"
-    end if
-    
-  end subroutine test_numerical_accuracy
+            print *, "ERROR: k=4 values incorrect"
+            errors = errors + 1
+        end if
+
+        if (errors == 0) then
+            print *, "  Edge cases test PASSED"
+        end if
+
+    end subroutine test_edge_cases
+
+    subroutine test_large_arrays(errors)
+        integer, intent(inout) :: errors
+        integer, parameter :: n_large = 1000
+        double precision :: derf1(n_large), derf2(n_large), derf3(n_large)
+        integer :: k
+
+        print *, "Testing large arrays..."
+
+        ! Initialize large arrays
+        call init_derivative_factors(n_large, derf1, derf2, derf3)
+
+        ! Check some specific values
+        ! For k=100: derf1 = 99, derf2 = 99*98 = 9702, derf3 = 99*98*97 = 941094
+        if (abs(derf1(100) - 99.0d0) > 1.0d-15) then
+            print *, "ERROR: derf1(100) incorrect"
+            errors = errors + 1
+        end if
+        if (abs(derf2(100) - 9702.0d0) > 1.0d-15) then
+            print *, "ERROR: derf2(100) incorrect"
+            errors = errors + 1
+        end if
+        if (abs(derf3(100) - 941094.0d0) > 1.0d-15) then
+            print *, "ERROR: derf3(100) incorrect"
+            errors = errors + 1
+        end if
+
+        ! Check last value
+        if (abs(derf1(n_large) - dble(n_large - 1)) > 1.0d-15) then
+            print *, "ERROR: derf1(", n_large, ") incorrect"
+            errors = errors + 1
+        end if
+
+        if (errors == 0) then
+            print *, "  Large arrays test PASSED"
+        end if
+
+    end subroutine test_large_arrays
+
+    subroutine test_numerical_accuracy(errors)
+        integer, intent(inout) :: errors
+        double precision :: derf1(50), derf2(50), derf3(50)
+        double precision :: factorial_ratio
+        integer :: k
+
+        print *, "Testing numerical accuracy..."
+
+        call init_derivative_factors(50, derf1, derf2, derf3)
+
+        ! Test relationships between arrays
+        ! derf2(k) should equal derf1(k) * (k-2) for k >= 3
+        do k = 3, 50
+            factorial_ratio = derf2(k)/derf1(k)
+            if (abs(factorial_ratio - dble(k - 2)) > 1.0d-15) then
+                print *, "ERROR: derf2/derf1 ratio incorrect at k=", k
+                errors = errors + 1
+            end if
+        end do
+
+        ! derf3(k) should equal derf2(k) * (k-3) for k >= 4
+        do k = 4, 50
+            factorial_ratio = derf3(k)/derf2(k)
+            if (abs(factorial_ratio - dble(k - 3)) > 1.0d-15) then
+                print *, "ERROR: derf3/derf2 ratio incorrect at k=", k
+                errors = errors + 1
+            end if
+        end do
+
+        if (errors == 0) then
+            print *, "  Numerical accuracy test PASSED"
+        end if
+
+    end subroutine test_numerical_accuracy
 
 end program test_array_utils

--- a/test/tests/test_boozer_chartmap_roundtrip.f90
+++ b/test/tests/test_boozer_chartmap_roundtrip.f90
@@ -7,19 +7,19 @@ program test_boozer_chartmap_roundtrip
     use velo_mod, only: isw_field_type
     use boozer_coordinates_mod, only: use_B_r
     use boozer_sub, only: splint_boozer_coord, get_boozer_coordinates, &
-        vmec_to_boozer, export_boozer_chartmap, load_boozer_from_chartmap, &
-        reset_boozer_batch_splines
+                    vmec_to_boozer, export_boozer_chartmap, load_boozer_from_chartmap, &
+                          reset_boozer_batch_splines
     use spline_vmec_sub, only: spline_vmec_data
     use vmecin_sub, only: stevvo
     use field_can_mod, only: field_can_from_name, field_can_init, &
-        eval_field => evaluate, field_can_t, get_val
+                             eval_field => evaluate, field_can_t, get_val
     use orbit_symplectic, only: orbit_sympl_init, orbit_timestep_sympl, &
-        symplectic_integrator_t
+                                symplectic_integrator_t
 
     implicit none
 
     real(dp), parameter :: pi = 3.14159265358979_dp
-    real(dp), parameter :: twopi = 2.0_dp * pi
+    real(dp), parameter :: twopi = 2.0_dp*pi
 
     ! Field comparison
     integer, parameter :: n_test = 50
@@ -81,9 +81,9 @@ program test_boozer_chartmap_roundtrip
         read (arg_value, *) orbit_tol
     end if
 
-    field_data_file = trim(artifact_prefix) // '_field_comparison.dat'
-    orbit_direct_file = trim(artifact_prefix) // '_orbit_direct.dat'
-    orbit_chartmap_file = trim(artifact_prefix) // '_orbit_chartmap.dat'
+    field_data_file = trim(artifact_prefix)//'_field_comparison.dat'
+    orbit_direct_file = trim(artifact_prefix)//'_orbit_direct.dat'
+    orbit_chartmap_file = trim(artifact_prefix)//'_orbit_chartmap.dat'
 
     print *, 'Starting roundtrip test...'
     print *, '  wout_file=', trim(wout_file)
@@ -108,7 +108,7 @@ program test_boozer_chartmap_roundtrip
         integer :: L1i
         real(dp) :: R0i, cbfi, bz0i, bf0
         call stevvo(RT0, R0i, L1i, cbfi, bz0i, bf0)
-        fper = twopi / real(L1i, dp)
+        fper = twopi/real(L1i, dp)
     end block
     phi_period = fper
     RT0 = rmajor
@@ -118,7 +118,7 @@ program test_boozer_chartmap_roundtrip
     call field_can_from_name("boozer")
 
     ! ro0 for orbit integration: rlarm * bmod00
-    ro0 = 2.23e-2_dp * 2.81e5_dp
+    ro0 = 2.23e-2_dp*2.81e5_dp
 
     print *, '=== Step 1: VMEC + Boozer initialized ==='
     print *, '  nper=', nper, ' R0=', RT0, ' fper=', fper
@@ -130,9 +130,9 @@ program test_boozer_chartmap_roundtrip
 
     do i = 1, n_test
         call splint_boozer_coord(s_test(i), th_test(i), ph_test(i), 0, &
-            A_theta, A_phi_val, dA_theta_dr, dA_phi_dr, d2A_phi_dr2, &
-            d3A_phi_dr3, Bth, dBth, d2Bth, Bph, dBph, d2Bph, &
-            Bmod, dBmod, d2Bmod, Br, dBr, d2Br)
+                              A_theta, A_phi_val, dA_theta_dr, dA_phi_dr, d2A_phi_dr2, &
+                                 d3A_phi_dr3, Bth, dBth, d2Bth, Bph, dBph, d2Bph, &
+                                 Bmod, dBmod, d2Bmod, Br, dBr, d2Br)
         Bmod_ref(i) = Bmod
     end do
 
@@ -157,7 +157,7 @@ program test_boozer_chartmap_roundtrip
 
     call vmec_to_boozer(0.35_dp, 0.33_dp, 0.97_dp, vartheta, varphi)
 
-    dtau = fper * RT0 / 400.0_dp
+    dtau = fper*RT0/400.0_dp
 
     z0(1) = 0.35_dp
     z0(2) = vartheta
@@ -167,12 +167,12 @@ program test_boozer_chartmap_roundtrip
 
     call run_symplectic_orbit(z0, dtau, n_orbit, orbit_direct, n_steps_done)
 
-    open(newunit=u_out, file=trim(orbit_direct_file), status='replace')
-    write(u_out, '(a)') '# time  s  theta  phi  pphi'
+    open (newunit=u_out, file=trim(orbit_direct_file), status='replace')
+    write (u_out, '(a)') '# time  s  theta  phi  pphi'
     do i = 1, n_steps_done
-        write(u_out, '(5es18.10)') orbit_direct(i, :)
+        write (u_out, '(5es18.10)') orbit_direct(i, :)
     end do
-    close(u_out)
+    close (u_out)
 
     print *, '=== Step 4: Direct orbit done, steps=', n_steps_done, ' ==='
 
@@ -183,9 +183,9 @@ program test_boozer_chartmap_roundtrip
 
     do i = 1, n_test
         call splint_boozer_coord(s_test(i), th_test(i), ph_test(i), 0, &
-            A_theta, A_phi_val, dA_theta_dr, dA_phi_dr, d2A_phi_dr2, &
-            d3A_phi_dr3, Bth, dBth, d2Bth, Bph, dBph, d2Bph, &
-            Bmod, dBmod, d2Bmod, Br, dBr, d2Br)
+                              A_theta, A_phi_val, dA_theta_dr, dA_phi_dr, d2A_phi_dr2, &
+                                 d3A_phi_dr3, Bth, dBth, d2Bth, Bph, dBph, d2Bph, &
+                                 Bmod, dBmod, d2Bmod, Br, dBr, d2Br)
         Bmod_new(i) = Bmod
     end do
 
@@ -195,20 +195,20 @@ program test_boozer_chartmap_roundtrip
     ! Step 6: Compare fields
     ! =========================================================
     max_err_bmod = 0.0_dp
-    open(newunit=u_out, file=trim(field_data_file), status='replace')
-    write(u_out, '(a)') '# s  theta  phi  Bmod_ref  Bmod_chartmap  rel_err'
+    open (newunit=u_out, file=trim(field_data_file), status='replace')
+    write (u_out, '(a)') '# s  theta  phi  Bmod_ref  Bmod_chartmap  rel_err'
 
     do i = 1, n_test
         if (abs(Bmod_ref(i)) > 0.0_dp) then
-            rel_err = abs(Bmod_new(i) - Bmod_ref(i)) / abs(Bmod_ref(i))
+            rel_err = abs(Bmod_new(i) - Bmod_ref(i))/abs(Bmod_ref(i))
         else
             rel_err = abs(Bmod_new(i))
         end if
         max_err_bmod = max(max_err_bmod, rel_err)
-        write(u_out, '(6es18.10)') s_test(i), th_test(i), ph_test(i), &
+        write (u_out, '(6es18.10)') s_test(i), th_test(i), ph_test(i), &
             Bmod_ref(i), Bmod_new(i), rel_err
     end do
-    close(u_out)
+    close (u_out)
 
     print *, '  max relative error Bmod:', max_err_bmod
     if (field_tol >= 0.0_dp) then
@@ -229,12 +229,12 @@ program test_boozer_chartmap_roundtrip
 
     call run_symplectic_orbit(z0, dtau, n_orbit, orbit_chartmap, n_steps_done)
 
-    open(newunit=u_out, file=trim(orbit_chartmap_file), status='replace')
-    write(u_out, '(a)') '# time  s  theta  phi  pphi'
+    open (newunit=u_out, file=trim(orbit_chartmap_file), status='replace')
+    write (u_out, '(a)') '# time  s  theta  phi  pphi'
     do i = 1, n_steps_done
-        write(u_out, '(5es18.10)') orbit_chartmap(i, :)
+        write (u_out, '(5es18.10)') orbit_chartmap(i, :)
     end do
-    close(u_out)
+    close (u_out)
 
     print *, '=== Step 7: Chartmap orbit done, steps=', n_steps_done, ' ==='
 
@@ -274,11 +274,11 @@ contains
         real(dp) :: frac
 
         do j = 1, n_test
-            frac = real(j, dp) / real(n_test + 1, dp)
-            s_test(j) = 0.1_dp + 0.7_dp * frac
-            th_test(j) = twopi * frac
-            ph_test(j) = phi_per * mod(real(2 * j + 1, dp), real(n_test + 1, dp)) &
-                          / real(n_test + 1, dp)
+            frac = real(j, dp)/real(n_test + 1, dp)
+            s_test(j) = 0.1_dp + 0.7_dp*frac
+            th_test(j) = twopi*frac
+            ph_test(j) = phi_per*mod(real(2*j + 1, dp), real(n_test + 1, dp)) &
+                         /real(n_test + 1, dp)
         end do
     end subroutine init_test_points
 
@@ -296,25 +296,25 @@ contains
         ! Initialize field_can_t
         call eval_field(f_loc, z0_in(1), z0_in(2), z0_in(3), 0)
 
-        f_loc%mu = 0.5_dp * z0_in(4)**2 * (1.0_dp - z0_in(5)**2) / &
-                   f_loc%Bmod * 2.0_dp
-        f_loc%ro0 = ro0 / sqrt(2.0_dp)
-        f_loc%vpar = z0_in(4) * z0_in(5) * sqrt(2.0_dp)
+        f_loc%mu = 0.5_dp*z0_in(4)**2*(1.0_dp - z0_in(5)**2)/ &
+                   f_loc%Bmod*2.0_dp
+        f_loc%ro0 = ro0/sqrt(2.0_dp)
+        f_loc%vpar = z0_in(4)*z0_in(5)*sqrt(2.0_dp)
 
         z_loc(1:3) = z0_in(1:3)
-        pphi = f_loc%vpar * f_loc%hph + f_loc%Aph / f_loc%ro0
+        pphi = f_loc%vpar*f_loc%hph + f_loc%Aph/f_loc%ro0
         z_loc(4) = pphi
 
         ! Midpoint integrator (mode=3), single step per call
         call orbit_sympl_init(si_loc, f_loc, z_loc, &
-                               dt / sqrt(2.0_dp), 1, 1.0e-10_dp, 3)
+                              dt/sqrt(2.0_dp), 1, 1.0e-10_dp, 3)
 
         steps_done = 0
         do j = 1, nsteps
             call orbit_timestep_sympl(si_loc, f_loc, ierr_loc)
             if (ierr_loc /= 0) exit
             steps_done = j
-            orbit_out(j, 1) = dt * real(j, dp)
+            orbit_out(j, 1) = dt*real(j, dp)
             orbit_out(j, 2) = si_loc%z(1)   ! s
             orbit_out(j, 3) = si_loc%z(2)   ! theta
             orbit_out(j, 4) = si_loc%z(3)   ! phi

--- a/test/tests/test_chartmap_meiss_debug.f90
+++ b/test/tests/test_chartmap_meiss_debug.f90
@@ -1,12 +1,12 @@
 program test_chartmap_meiss_debug
     use, intrinsic :: iso_fortran_env, only: dp => real64
-    use libneo_coordinates, only: coordinate_system_t, make_chartmap_coordinate_system, &
+   use libneo_coordinates, only: coordinate_system_t, make_chartmap_coordinate_system, &
                                   chartmap_coordinate_system_t, RHO_TOR, RHO_POL, &
                                   PSI_TOR_NORM, PSI_POL_NORM, UNKNOWN
     use field_base, only: magnetic_field_t
     use field_splined, only: splined_field_t, create_splined_field
     use field_can_meiss, only: choose_default_scaling
-    use coordinate_scaling, only: coordinate_scaling_t, sqrt_s_scaling_t, identity_scaling_t
+use coordinate_scaling, only: coordinate_scaling_t, sqrt_s_scaling_t, identity_scaling_t
     implicit none
 
     character(len=512) :: chartmap_file, coils_file, vmec_file
@@ -21,7 +21,7 @@ program test_chartmap_meiss_debug
     call get_command_argument(3, vmec_file)
 
     if (len_trim(chartmap_file) == 0) then
-        print *, "Usage: test_chartmap_meiss_debug <chartmap.nc> [coils_file] [vmec_file]"
+      print *, "Usage: test_chartmap_meiss_debug <chartmap.nc> [coils_file] [vmec_file]"
         stop 1
     end if
 
@@ -128,11 +128,11 @@ contains
         type is (chartmap_coordinate_system_t)
             if (cs%has_spl_rz) then
                 rho_min = cs%spl_rz%x_min(1)
-                rho_max = cs%spl_rz%x_min(1) + cs%spl_rz%h_step(1) * &
+                rho_max = cs%spl_rz%x_min(1) + cs%spl_rz%h_step(1)* &
                           real(cs%spl_rz%num_points(1) - 1, dp)
             else
                 rho_min = cs%spl_cart%x_min(1)
-                rho_max = cs%spl_cart%x_min(1) + cs%spl_cart%h_step(1) * &
+                rho_max = cs%spl_cart%x_min(1) + cs%spl_cart%h_step(1)* &
                           real(cs%spl_cart%num_points(1) - 1, dp)
             end if
 
@@ -159,7 +159,7 @@ contains
         print *, "=== Test 5: Meiss scaling selection ==="
 
         ! Create a minimal splined_field_t with our coords
-        allocate(dummy_field%coords, source=coords)
+        allocate (dummy_field%coords, source=coords)
 
         call choose_default_scaling(dummy_field, scaling)
 

--- a/test/tests/test_coordinate_refactoring.f90
+++ b/test/tests/test_coordinate_refactoring.f90
@@ -1,237 +1,235 @@
 program test_coordinate_refactoring
-  !> Numerical equivalence test for coordinate system refactoring (issue #206).
-  !> Verifies that:
-  !>   1. vmec_field_t evaluation produces identical results before/after refactoring
-  !>   2. Coordinate transforms integ_to_ref/ref_to_integ are inverses
-  !>   3. splined_field_t accuracy matches raw coils_field_t
+    !> Numerical equivalence test for coordinate system refactoring (issue #206).
+    !> Verifies that:
+    !>   1. vmec_field_t evaluation produces identical results before/after refactoring
+    !>   2. Coordinate transforms integ_to_ref/ref_to_integ are inverses
+    !>   3. splined_field_t accuracy matches raw coils_field_t
 
-  use, intrinsic :: iso_fortran_env, only: dp => real64
-  use simple, only: init_vmec
-  use field_base, only: magnetic_field_t
-  use field_vmec, only: vmec_field_t
-  use field_coils, only: coils_field_t, create_coils_field
-  use field_splined, only: splined_field_t, create_splined_field
-  use reference_coordinates, only: init_reference_coordinates, ref_coords
-  use field_can_mod, only: integ_to_ref, ref_to_integ, init_field_can
-  use magfie_sub, only: CANFLUX
-  use timing, only: init_timer
-  use params, only: coord_input, field_input
-  use util, only: twopi
-  use cylindrical_cartesian, only: cyl_to_cart
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use simple, only: init_vmec
+    use field_base, only: magnetic_field_t
+    use field_vmec, only: vmec_field_t
+    use field_coils, only: coils_field_t, create_coils_field
+    use field_splined, only: splined_field_t, create_splined_field
+    use reference_coordinates, only: init_reference_coordinates, ref_coords
+    use field_can_mod, only: integ_to_ref, ref_to_integ, init_field_can
+    use magfie_sub, only: CANFLUX
+    use timing, only: init_timer
+    use params, only: coord_input, field_input
+    use util, only: twopi
+    use cylindrical_cartesian, only: cyl_to_cart
 
-  implicit none
+    implicit none
 
-  integer :: n_failed
-  real(dp) :: dummy
+    integer :: n_failed
+    real(dp) :: dummy
 
-  n_failed = 0
+    n_failed = 0
 
-  call init_timer()
+    call init_timer()
 
-  call test_vmec_field_consistency(n_failed)
-  call test_coordinate_roundtrip(n_failed)
-  call test_splined_field_accuracy(n_failed)
+    call test_vmec_field_consistency(n_failed)
+    call test_coordinate_roundtrip(n_failed)
+    call test_splined_field_accuracy(n_failed)
 
-  if (n_failed == 0) then
-    print *, '================================'
-    print *, 'All coordinate refactoring tests PASSED'
-    print *, '================================'
-    stop 0
-  else
-    print *, '================================'
-    print *, n_failed, ' tests FAILED'
-    print *, '================================'
-    stop 1
-  end if
+    if (n_failed == 0) then
+        print *, '================================'
+        print *, 'All coordinate refactoring tests PASSED'
+        print *, '================================'
+        stop 0
+    else
+        print *, '================================'
+        print *, n_failed, ' tests FAILED'
+        print *, '================================'
+        stop 1
+    end if
 
 contains
 
-  subroutine test_vmec_field_consistency(n_failed)
-    !> Test vmec_field_t evaluation against independently computed reference values.
-    !> Reference values computed from known VMEC equilibrium properties.
-    integer, intent(inout) :: n_failed
-    type(vmec_field_t) :: vmec_field
-    real(dp) :: x(3), Acov(3), hcov(3), Bmod
-    real(dp), parameter :: tol = 1.0e-6_dp
-    logical :: file_exists
+    subroutine test_vmec_field_consistency(n_failed)
+        !> Test vmec_field_t evaluation against independently computed reference values.
+        !> Reference values computed from known VMEC equilibrium properties.
+        integer, intent(inout) :: n_failed
+        type(vmec_field_t) :: vmec_field
+        real(dp) :: x(3), Acov(3), hcov(3), Bmod
+        real(dp), parameter :: tol = 1.0e-6_dp
+        logical :: file_exists
 
-    print *, 'Test 1: vmec_field_t evaluation against known values'
+        print *, 'Test 1: vmec_field_t evaluation against known values'
 
-    inquire(file='wout.nc', exist=file_exists)
-    if (.not. file_exists) then
-      print *, '  FAILED: Required VMEC file (wout.nc) not found'
-      n_failed = n_failed + 1
-      return
-    end if
+        inquire (file='wout.nc', exist=file_exists)
+        if (.not. file_exists) then
+            print *, '  FAILED: Required VMEC file (wout.nc) not found'
+            n_failed = n_failed + 1
+            return
+        end if
 
-    coord_input = 'wout.nc'
-    field_input = 'wout.nc'
-    call init_vmec('wout.nc', 5, 5, 5, dummy)
-    call init_reference_coordinates(coord_input)
+        coord_input = 'wout.nc'
+        field_input = 'wout.nc'
+        call init_vmec('wout.nc', 5, 5, 5, dummy)
+        call init_reference_coordinates(coord_input)
 
-    ! Test point: r=sqrt(s)=0.5 (s=0.25), theta=0, phi=0
-    x = [0.5_dp, 0.0_dp, 0.0_dp]
-    call vmec_field%evaluate(x, Acov, hcov, Bmod)
+        ! Test point: r=sqrt(s)=0.5 (s=0.25), theta=0, phi=0
+        x = [0.5_dp, 0.0_dp, 0.0_dp]
+        call vmec_field%evaluate(x, Acov, hcov, Bmod)
 
-    ! Verify physical constraints that must hold for any valid magnetic field:
-    ! 1. Bmod must be positive (magnetic field strength)
-    if (Bmod <= 0.0_dp) then
-      print *, '  FAILED: Bmod must be positive, got ', Bmod
-      n_failed = n_failed + 1
-    end if
+        ! Verify physical constraints that must hold for any valid magnetic field:
+        ! 1. Bmod must be positive (magnetic field strength)
+        if (Bmod <= 0.0_dp) then
+            print *, '  FAILED: Bmod must be positive, got ', Bmod
+            n_failed = n_failed + 1
+        end if
 
-    ! 2. Bmod should be reasonable for fusion devices (CGS units: 1000 to 200000 G)
-    if (Bmod < 1000.0_dp .or. Bmod > 200000.0_dp) then
-      print *, '  FAILED: Bmod outside physical range [1000, 200000] G, got ', Bmod
-      n_failed = n_failed + 1
-    end if
+        ! 2. Bmod should be reasonable for fusion devices (CGS units: 1000 to 200000 G)
+        if (Bmod < 1000.0_dp .or. Bmod > 200000.0_dp) then
+           print *, '  FAILED: Bmod outside physical range [1000, 200000] G, got ', Bmod
+            n_failed = n_failed + 1
+        end if
 
-    ! 3. hcov components should have reasonable magnitudes (metric tensor elements)
-    if (any(abs(hcov) > 1.0e6_dp)) then
-      print *, '  FAILED: hcov has unphysical magnitude ', hcov
-      n_failed = n_failed + 1
-    end if
+        ! 3. hcov components should have reasonable magnitudes (metric tensor elements)
+        if (any(abs(hcov) > 1.0e6_dp)) then
+            print *, '  FAILED: hcov has unphysical magnitude ', hcov
+            n_failed = n_failed + 1
+        end if
 
-    ! 4. Test at multiple points - field should vary smoothly
-    x = [0.7_dp, 1.0_dp, 0.5_dp]
-    call vmec_field%evaluate(x, Acov, hcov, Bmod)
+        ! 4. Test at multiple points - field should vary smoothly
+        x = [0.7_dp, 1.0_dp, 0.5_dp]
+        call vmec_field%evaluate(x, Acov, hcov, Bmod)
 
-    if (Bmod <= 0.0_dp .or. Bmod > 200000.0_dp) then
-      print *, '  FAILED: Bmod at second test point invalid (CGS) ', Bmod
-      n_failed = n_failed + 1
-    end if
+        if (Bmod <= 0.0_dp .or. Bmod > 200000.0_dp) then
+            print *, '  FAILED: Bmod at second test point invalid (CGS) ', Bmod
+            n_failed = n_failed + 1
+        end if
 
-    ! 5. Near-axis point should have higher field (1/R variation)
-    x = [0.3_dp, 0.0_dp, 0.0_dp]
-    call vmec_field%evaluate(x, Acov, hcov, Bmod)
+        ! 5. Near-axis point should have higher field (1/R variation)
+        x = [0.3_dp, 0.0_dp, 0.0_dp]
+        call vmec_field%evaluate(x, Acov, hcov, Bmod)
 
-    if (Bmod <= 0.0_dp) then
-      print *, '  FAILED: Bmod near axis must be positive ', Bmod
-      n_failed = n_failed + 1
-    end if
+        if (Bmod <= 0.0_dp) then
+            print *, '  FAILED: Bmod near axis must be positive ', Bmod
+            n_failed = n_failed + 1
+        end if
 
-    print *, '  PASSED: vmec_field_t evaluation produces physically valid results'
-  end subroutine test_vmec_field_consistency
+        print *, '  PASSED: vmec_field_t evaluation produces physically valid results'
+    end subroutine test_vmec_field_consistency
 
+    subroutine test_coordinate_roundtrip(n_failed)
+        integer, intent(inout) :: n_failed
+        real(dp) :: xref(3), xinteg(3), xref_back(3)
+        real(dp), parameter :: tol = 1.0e-10_dp
+        logical :: file_exists
+        integer :: i
 
-  subroutine test_coordinate_roundtrip(n_failed)
-    integer, intent(inout) :: n_failed
-    real(dp) :: xref(3), xinteg(3), xref_back(3)
-    real(dp), parameter :: tol = 1.0e-10_dp
-    logical :: file_exists
-    integer :: i
+        print *, 'Test 2: Coordinate transform roundtrip (ref -> integ -> ref)'
 
-    print *, 'Test 2: Coordinate transform roundtrip (ref -> integ -> ref)'
+        inquire (file='wout.nc', exist=file_exists)
+        if (.not. file_exists) then
+            print *, '  FAILED: Required VMEC file (wout.nc) not found'
+            n_failed = n_failed + 1
+            return
+        end if
 
-    inquire(file='wout.nc', exist=file_exists)
-    if (.not. file_exists) then
-      print *, '  FAILED: Required VMEC file (wout.nc) not found'
-      n_failed = n_failed + 1
-      return
-    end if
+        coord_input = 'wout.nc'
+        field_input = 'wout.nc'
+        call init_vmec('wout.nc', 5, 5, 5, dummy)
+        call init_reference_coordinates(coord_input)
+        call init_field_can(CANFLUX)
 
-    coord_input = 'wout.nc'
-    field_input = 'wout.nc'
-    call init_vmec('wout.nc', 5, 5, 5, dummy)
-    call init_reference_coordinates(coord_input)
-    call init_field_can(CANFLUX)
+        do i = 1, 5
+            xref = [0.1_dp + 0.15_dp*i, mod(0.5_dp*i, twopi), mod(0.3_dp*i, twopi)]
 
-    do i = 1, 5
-      xref = [0.1_dp + 0.15_dp * i, mod(0.5_dp * i, twopi), mod(0.3_dp * i, twopi)]
+            call ref_to_integ(xref, xinteg)
+            call integ_to_ref(xinteg, xref_back)
 
-      call ref_to_integ(xref, xinteg)
-      call integ_to_ref(xinteg, xref_back)
+            xref_back(2) = mod(xref_back(2) + twopi, twopi)
+            xref_back(3) = mod(xref_back(3) + twopi, twopi)
+            xref(2) = mod(xref(2) + twopi, twopi)
+            xref(3) = mod(xref(3) + twopi, twopi)
 
-      xref_back(2) = mod(xref_back(2) + twopi, twopi)
-      xref_back(3) = mod(xref_back(3) + twopi, twopi)
-      xref(2) = mod(xref(2) + twopi, twopi)
-      xref(3) = mod(xref(3) + twopi, twopi)
+            if (abs(xref_back(1) - xref(1)) > tol) then
+                print *, '  FAILED: r roundtrip error at point ', i
+                print *, '    xref(1) = ', xref(1), ' xref_back(1) = ', xref_back(1)
+                n_failed = n_failed + 1
+            end if
 
-      if (abs(xref_back(1) - xref(1)) > tol) then
-        print *, '  FAILED: r roundtrip error at point ', i
-        print *, '    xref(1) = ', xref(1), ' xref_back(1) = ', xref_back(1)
-        n_failed = n_failed + 1
-      end if
+            if (abs(xref_back(2) - xref(2)) > tol .and. &
+                abs(abs(xref_back(2) - xref(2)) - twopi) > tol) then
+                print *, '  FAILED: theta roundtrip error at point ', i
+                print *, '    xref(2) = ', xref(2), ' xref_back(2) = ', xref_back(2)
+                n_failed = n_failed + 1
+            end if
 
-      if (abs(xref_back(2) - xref(2)) > tol .and. &
-          abs(abs(xref_back(2) - xref(2)) - twopi) > tol) then
-        print *, '  FAILED: theta roundtrip error at point ', i
-        print *, '    xref(2) = ', xref(2), ' xref_back(2) = ', xref_back(2)
-        n_failed = n_failed + 1
-      end if
+            if (abs(xref_back(3) - xref(3)) > tol .and. &
+                abs(abs(xref_back(3) - xref(3)) - twopi) > tol) then
+                print *, '  FAILED: phi roundtrip error at point ', i
+                print *, '    xref(3) = ', xref(3), ' xref_back(3) = ', xref_back(3)
+                n_failed = n_failed + 1
+            end if
+        end do
 
-      if (abs(xref_back(3) - xref(3)) > tol .and. &
-          abs(abs(xref_back(3) - xref(3)) - twopi) > tol) then
-        print *, '  FAILED: phi roundtrip error at point ', i
-        print *, '    xref(3) = ', xref(3), ' xref_back(3) = ', xref_back(3)
-        n_failed = n_failed + 1
-      end if
-    end do
+        print *, '  PASSED: Coordinate transforms are consistent inverses'
+    end subroutine test_coordinate_roundtrip
 
-    print *, '  PASSED: Coordinate transforms are consistent inverses'
-  end subroutine test_coordinate_roundtrip
+    subroutine test_splined_field_accuracy(n_failed)
+        !> Test that splined_field_t produces similar results to raw Biot-Savart.
+        !> Compares Bmod (coordinate-independent) between splined and raw evaluation.
+        integer, intent(inout) :: n_failed
+        type(coils_field_t) :: raw_coils
+        type(splined_field_t) :: splined_coils
+        real(dp) :: x_spline(3), x_vmec(3), x_cyl(3), x_cart(3)
+        real(dp) :: Acov_spline(3), hcov_spline(3), Bmod_spline
+        real(dp) :: Acov_direct(3), hcov_direct(3), Bmod_direct
+        real(dp), parameter :: tol_rel = 1.0e-2_dp
+        logical :: vmec_exists, coils_exists
+        integer :: i
 
+        print *, 'Test 3: splined_field_t vs raw coils_field_t'
 
-  subroutine test_splined_field_accuracy(n_failed)
-    !> Test that splined_field_t produces similar results to raw Biot-Savart.
-    !> Compares Bmod (coordinate-independent) between splined and raw evaluation.
-    integer, intent(inout) :: n_failed
-    type(coils_field_t) :: raw_coils
-    type(splined_field_t) :: splined_coils
-    real(dp) :: x_spline(3), x_vmec(3), x_cyl(3), x_cart(3)
-    real(dp) :: Acov_spline(3), hcov_spline(3), Bmod_spline
-    real(dp) :: Acov_direct(3), hcov_direct(3), Bmod_direct
-    real(dp), parameter :: tol_rel = 1.0e-2_dp
-    logical :: vmec_exists, coils_exists
-    integer :: i
+        inquire (file='wout.nc', exist=vmec_exists)
+        inquire (file='coils.simple', exist=coils_exists)
 
-    print *, 'Test 3: splined_field_t vs raw coils_field_t'
+        if (.not. vmec_exists) then
+            print *, '  FAILED: Required VMEC file (wout.nc) not found'
+            n_failed = n_failed + 1
+            return
+        end if
 
-    inquire(file='wout.nc', exist=vmec_exists)
-    inquire(file='coils.simple', exist=coils_exists)
+        if (.not. coils_exists) then
+            print *, '  FAIL: coils.simple not found'
+        print *, '  (Coils tests require coils.simple - run in golden_record directory)'
+            n_failed = n_failed + 1
+            return
+        end if
 
-    if (.not. vmec_exists) then
-      print *, '  FAILED: Required VMEC file (wout.nc) not found'
-      n_failed = n_failed + 1
-      return
-    end if
+        coord_input = 'wout.nc'
+        field_input = 'wout.nc'
+        call init_vmec('wout.nc', 5, 5, 5, dummy)
+        call init_reference_coordinates(coord_input)
 
-    if (.not. coils_exists) then
-      print *, '  FAIL: coils.simple not found'
-      print *, '  (Coils tests require coils.simple - run in golden_record directory)'
-      n_failed = n_failed + 1
-      return
-    end if
-
-    coord_input = 'wout.nc'
-    field_input = 'wout.nc'
-    call init_vmec('wout.nc', 5, 5, 5, dummy)
-    call init_reference_coordinates(coord_input)
-
-    call create_coils_field('coils.simple', raw_coils)
+        call create_coils_field('coils.simple', raw_coils)
     call create_splined_field(raw_coils, ref_coords, splined_coils, n_r=32, n_th=33, n_phi=32)
 
-    do i = 1, 5
-      ! Grid point in spline coords (r, theta, phi) where r = sqrt(s)
-      x_spline = [0.2_dp + 0.1_dp * i, 0.5_dp + 0.3_dp * i, 0.2_dp + 0.1_dp * i]
+        do i = 1, 5
+            ! Grid point in spline coords (r, theta, phi) where r = sqrt(s)
+            x_spline = [0.2_dp + 0.1_dp*i, 0.5_dp + 0.3_dp*i, 0.2_dp + 0.1_dp*i]
 
-      call splined_coils%evaluate(x_spline, Acov_spline, hcov_spline, Bmod_spline)
+            call splined_coils%evaluate(x_spline, Acov_spline, hcov_spline, Bmod_spline)
 
-      ! Convert to VMEC coords (s, theta, phi) for ref_coords
-      x_vmec = [x_spline(1)**2, x_spline(2), x_spline(3)]
-      call ref_coords%evaluate_cyl(x_vmec, x_cyl)
-      call cyl_to_cart(x_cyl, x_cart)
-      call raw_coils%evaluate(x_cart, Acov_direct, hcov_direct, Bmod_direct)
+            ! Convert to VMEC coords (s, theta, phi) for ref_coords
+            x_vmec = [x_spline(1)**2, x_spline(2), x_spline(3)]
+            call ref_coords%evaluate_cyl(x_vmec, x_cyl)
+            call cyl_to_cart(x_cyl, x_cart)
+            call raw_coils%evaluate(x_cart, Acov_direct, hcov_direct, Bmod_direct)
 
-      if (abs(Bmod_spline - Bmod_direct) / Bmod_direct > tol_rel) then
-        print *, '  FAILED: Bmod spline error too large at point ', i
-        print *, '    Bmod_spline = ', Bmod_spline, ' Bmod_direct = ', Bmod_direct
-        print *, '    Relative error = ', abs(Bmod_spline - Bmod_direct) / Bmod_direct
-        n_failed = n_failed + 1
-      end if
-    end do
+            if (abs(Bmod_spline - Bmod_direct)/Bmod_direct > tol_rel) then
+                print *, '  FAILED: Bmod spline error too large at point ', i
+              print *, '    Bmod_spline = ', Bmod_spline, ' Bmod_direct = ', Bmod_direct
+            print *, '    Relative error = ', abs(Bmod_spline - Bmod_direct)/Bmod_direct
+                n_failed = n_failed + 1
+            end if
+        end do
 
-    print *, '  PASSED: splined_field_t accuracy within tolerance'
-  end subroutine test_splined_field_accuracy
+        print *, '  PASSED: splined_field_t accuracy within tolerance'
+    end subroutine test_splined_field_accuracy
 
 end program test_coordinate_refactoring

--- a/test/tests/test_lapack_interfaces.f90
+++ b/test/tests/test_lapack_interfaces.f90
@@ -1,128 +1,128 @@
 program test_lapack_interfaces
-  use lapack_interfaces
-  implicit none
-  
-  integer :: errors
-  
-  errors = 0
-  
-  ! Test DGESV interface with simple linear system
-  call test_dgesv_interface(errors)
-  
-  if (errors == 0) then
-    print *, "All LAPACK interfaces tests passed!"
-  else
-    print *, "ERROR: ", errors, " test(s) failed!"
-    stop 1
-  end if
-  
+    use lapack_interfaces
+    implicit none
+
+    integer :: errors
+
+    errors = 0
+
+    ! Test DGESV interface with simple linear system
+    call test_dgesv_interface(errors)
+
+    if (errors == 0) then
+        print *, "All LAPACK interfaces tests passed!"
+    else
+        print *, "ERROR: ", errors, " test(s) failed!"
+        stop 1
+    end if
+
 contains
 
-  subroutine test_dgesv_interface(errors)
-    integer, intent(inout) :: errors
-    integer, parameter :: n = 3, nrhs = 1
-    real(8) :: a(n,n), b(n,nrhs)
-    real(8) :: a_work(n,n), b_work(n,nrhs)  ! Working copies to preserve originals
-    integer :: ipiv(n), info
-    real(8), parameter :: tolerance = 1.0d-12
-    
-    print *, "Testing DGESV interface..."
-    
-    ! Given: A simple 3x3 linear system Ax = b
-    ! When: We solve it using DGESV
-    ! Then: The solution should be correct and info should indicate success
-    
-    ! Set up the system: A*x = b where x = [1, 2, 3]
-    ! A = [[2, 1, 0], [1, 2, 1], [0, 1, 2]]
-    ! Fortran stores matrices column-major, so A(i,j) is row i, column j
-    ! b = A*[1,2,3] = [2*1+1*2+0*3, 1*1+2*2+1*3, 0*1+1*2+2*3] = [4, 8, 8]
-    
-    a(1,1) = 2.0d0; a(1,2) = 1.0d0; a(1,3) = 0.0d0
-    a(2,1) = 1.0d0; a(2,2) = 2.0d0; a(2,3) = 1.0d0
-    a(3,1) = 0.0d0; a(3,2) = 1.0d0; a(3,3) = 2.0d0
-    
-    b(1,1) = 4.0d0
-    b(2,1) = 8.0d0
-    b(3,1) = 8.0d0
-    
-    ! Create working copies since DGESV modifies inputs
-    a_work = a
-    b_work = b
-    
-    ! Call DGESV to solve the system (using working copies)
-    call dgesv(n, nrhs, a_work, n, ipiv, b_work, n, info)
-    
-    ! Check that the solution completed successfully
-    if (info /= 0) then
-      print *, "ERROR: DGESV failed with info =", info
-      errors = errors + 1
-      return
-    end if
-    
-    ! Check that the solution is correct (x = [1, 2, 3])
-    if (abs(b_work(1,1) - 1.0d0) > tolerance) then
-      print *, "ERROR: Incorrect solution for x(1)"
-      print *, "Expected: 1.0, Got:", b_work(1,1)
-      errors = errors + 1
-    end if
-    
-    if (abs(b_work(2,1) - 2.0d0) > tolerance) then
-      print *, "ERROR: Incorrect solution for x(2)"
-      print *, "Expected: 2.0, Got:", b_work(2,1)
-      errors = errors + 1
-    end if
-    
-    if (abs(b_work(3,1) - 3.0d0) > tolerance) then
-      print *, "ERROR: Incorrect solution for x(3)"
-      print *, "Expected: 3.0, Got:", b_work(3,1)
-      errors = errors + 1
-    end if
-    
-    ! Check that pivot array contains valid indices
-    if (any(ipiv < 1) .or. any(ipiv > n)) then
-      print *, "ERROR: Invalid pivot indices"
-      print *, "Pivot array:", ipiv
-      errors = errors + 1
-    end if
-    
-    ! Test edge case: singular matrix (should fail gracefully)
-    call test_singular_matrix(errors)
-    
-    if (errors == 0) then
-      print *, "  DGESV interface test PASSED"
-    end if
-    
-  end subroutine test_dgesv_interface
-  
-  subroutine test_singular_matrix(errors)
-    integer, intent(inout) :: errors
-    integer, parameter :: n = 2, nrhs = 1
-    real(8) :: a(n,n), b(n,nrhs)
-    integer :: ipiv(n), info
-    
-    print *, "Testing DGESV with singular matrix..."
-    
-    ! Given: A singular matrix (non-invertible)
-    ! When: We try to solve the system
-    ! Then: DGESV should return a non-zero info value
-    
-    ! Create a singular matrix (row 2 = 2 * row 1)
-    a(1,1) = 1.0d0; a(1,2) = 2.0d0
-    a(2,1) = 2.0d0; a(2,2) = 4.0d0
-    
-    b(1,1) = 1.0d0
-    b(2,1) = 2.0d0
-    
-    call dgesv(n, nrhs, a, n, ipiv, b, n, info)
-    
-    ! For a singular matrix, info should be > 0
-    if (info == 0) then
-      print *, "ERROR: DGESV should detect singular matrix"
-      errors = errors + 1
-    else
-      print *, "  Singular matrix correctly detected (info =", info, ")"
-    end if
-    
-  end subroutine test_singular_matrix
+    subroutine test_dgesv_interface(errors)
+        integer, intent(inout) :: errors
+        integer, parameter :: n = 3, nrhs = 1
+        real(8) :: a(n, n), b(n, nrhs)
+        real(8) :: a_work(n, n), b_work(n, nrhs)  ! Working copies to preserve originals
+        integer :: ipiv(n), info
+        real(8), parameter :: tolerance = 1.0d-12
+
+        print *, "Testing DGESV interface..."
+
+        ! Given: A simple 3x3 linear system Ax = b
+        ! When: We solve it using DGESV
+        ! Then: The solution should be correct and info should indicate success
+
+        ! Set up the system: A*x = b where x = [1, 2, 3]
+        ! A = [[2, 1, 0], [1, 2, 1], [0, 1, 2]]
+        ! Fortran stores matrices column-major, so A(i,j) is row i, column j
+        ! b = A*[1,2,3] = [2*1+1*2+0*3, 1*1+2*2+1*3, 0*1+1*2+2*3] = [4, 8, 8]
+
+        a(1, 1) = 2.0d0; a(1, 2) = 1.0d0; a(1, 3) = 0.0d0
+        a(2, 1) = 1.0d0; a(2, 2) = 2.0d0; a(2, 3) = 1.0d0
+        a(3, 1) = 0.0d0; a(3, 2) = 1.0d0; a(3, 3) = 2.0d0
+
+        b(1, 1) = 4.0d0
+        b(2, 1) = 8.0d0
+        b(3, 1) = 8.0d0
+
+        ! Create working copies since DGESV modifies inputs
+        a_work = a
+        b_work = b
+
+        ! Call DGESV to solve the system (using working copies)
+        call dgesv(n, nrhs, a_work, n, ipiv, b_work, n, info)
+
+        ! Check that the solution completed successfully
+        if (info /= 0) then
+            print *, "ERROR: DGESV failed with info =", info
+            errors = errors + 1
+            return
+        end if
+
+        ! Check that the solution is correct (x = [1, 2, 3])
+        if (abs(b_work(1, 1) - 1.0d0) > tolerance) then
+            print *, "ERROR: Incorrect solution for x(1)"
+            print *, "Expected: 1.0, Got:", b_work(1, 1)
+            errors = errors + 1
+        end if
+
+        if (abs(b_work(2, 1) - 2.0d0) > tolerance) then
+            print *, "ERROR: Incorrect solution for x(2)"
+            print *, "Expected: 2.0, Got:", b_work(2, 1)
+            errors = errors + 1
+        end if
+
+        if (abs(b_work(3, 1) - 3.0d0) > tolerance) then
+            print *, "ERROR: Incorrect solution for x(3)"
+            print *, "Expected: 3.0, Got:", b_work(3, 1)
+            errors = errors + 1
+        end if
+
+        ! Check that pivot array contains valid indices
+        if (any(ipiv < 1) .or. any(ipiv > n)) then
+            print *, "ERROR: Invalid pivot indices"
+            print *, "Pivot array:", ipiv
+            errors = errors + 1
+        end if
+
+        ! Test edge case: singular matrix (should fail gracefully)
+        call test_singular_matrix(errors)
+
+        if (errors == 0) then
+            print *, "  DGESV interface test PASSED"
+        end if
+
+    end subroutine test_dgesv_interface
+
+    subroutine test_singular_matrix(errors)
+        integer, intent(inout) :: errors
+        integer, parameter :: n = 2, nrhs = 1
+        real(8) :: a(n, n), b(n, nrhs)
+        integer :: ipiv(n), info
+
+        print *, "Testing DGESV with singular matrix..."
+
+        ! Given: A singular matrix (non-invertible)
+        ! When: We try to solve the system
+        ! Then: DGESV should return a non-zero info value
+
+        ! Create a singular matrix (row 2 = 2 * row 1)
+        a(1, 1) = 1.0d0; a(1, 2) = 2.0d0
+        a(2, 1) = 2.0d0; a(2, 2) = 4.0d0
+
+        b(1, 1) = 1.0d0
+        b(2, 1) = 2.0d0
+
+        call dgesv(n, nrhs, a, n, ipiv, b, n, info)
+
+        ! For a singular matrix, info should be > 0
+        if (info == 0) then
+            print *, "ERROR: DGESV should detect singular matrix"
+            errors = errors + 1
+        else
+            print *, "  Singular matrix correctly detected (info =", info, ")"
+        end if
+
+    end subroutine test_singular_matrix
 
 end program test_lapack_interfaces

--- a/test/tests/test_lowlevel.f90
+++ b/test/tests/test_lowlevel.f90
@@ -4,8 +4,8 @@ module test_lowlevel
 
     implicit none
 
-double precision :: errtol
-character(*), parameter :: filename = 'wout.nc'
+    double precision :: errtol
+    character(*), parameter :: filename = 'wout.nc'
 
 contains
 
@@ -13,7 +13,7 @@ contains
     subroutine test_vmec_allocate()
         use new_vmec_stuff_mod
         use vmec_alloc_sub
-        print *,'test_vmec_allocate'
+        print *, 'test_vmec_allocate'
 
         call new_allocate_vmec_stuff
         call new_deallocate_vmec_stuff
@@ -21,8 +21,8 @@ contains
 
     @test
     subroutine test_spline_vmec_data()
-        use new_vmec_stuff_mod, only : netcdffile, multharm, ns_s, ns_tp
-        print *,'test_spline_vmec_data'
+        use new_vmec_stuff_mod, only: netcdffile, multharm, ns_s, ns_tp
+        print *, 'test_spline_vmec_data'
 
         netcdffile = filename
         ns_s = 5
@@ -37,17 +37,16 @@ contains
     @test
     subroutine test_vmecin()
         use new_vmec_stuff_mod
-        use vector_potentail_mod, only : ns,hs,torflux,sA_phi
-        double precision, dimension(:,:), allocatable :: splcoe
-        double precision, dimension(:,:), allocatable :: almnc_rho,rmnc_rho,zmnc_rho
-        double precision, dimension(:,:), allocatable :: almns_rho,rmns_rho,zmns_rho
+        use vector_potentail_mod, only: ns, hs, torflux, sA_phi
+        double precision, dimension(:, :), allocatable :: splcoe
+        double precision, dimension(:, :), allocatable :: almnc_rho, rmnc_rho, zmnc_rho
+        double precision, dimension(:, :), allocatable :: almns_rho, rmns_rho, zmns_rho
 
-        print *,'test_vmecin'
-
+        print *, 'test_vmecin'
 
         call new_allocate_vmec_stuff
-        call vmecin(rmnc,zmns,almns,rmns,zmnc,almnc,aiota,phi,sps,axm,axn,s,    &
-              nsurfm,nstrm,kpar,torflux)
+       call vmecin(rmnc, zmns, almns, rmns, zmnc, almnc, aiota, phi, sps, axm, axn, s, &
+                    nsurfm, nstrm, kpar, torflux)
 
     end subroutine test_vmecin
 
@@ -55,17 +54,16 @@ contains
     subroutine test_stevvo()
         use new_vmec_stuff_mod
         use vector_potentail_mod
-        use vmecin_sub, only : stevvo
+        use vmecin_sub, only: stevvo
         integer             :: L1i
         double precision    :: RT0, R0i, cbfi, bz0i, bf0, volume, B00
 
-        print *,'test_stevvo'
+        print *, 'test_stevvo'
 
         call new_deallocate_vmec_stuff
         call spline_vmec_data ! initialize splines for VMEC field
         call stevvo(RT0, R0i, L1i, cbfi, bz0i, bf0) ! initialize periods and major radius
 
     end subroutine test_stevvo
-
 
 end module test_lowlevel

--- a/test/tests/test_orbit_symplectic_base.f90
+++ b/test/tests/test_orbit_symplectic_base.f90
@@ -1,409 +1,409 @@
 program test_orbit_symplectic_base
-  use orbit_symplectic_base
-  implicit none
-  
-  integer :: errors
-  
-  errors = 0
-  
-  ! Test integration method constants
-  call test_integration_constants(errors)
-  
-  ! Test Runge-Kutta Gauss coefficients
-  call test_rk_gauss_coefficients(errors)
-  
-  ! Test Runge-Kutta Lobatto coefficients  
-  call test_rk_lobatto_coefficients(errors)
-  
-  ! Test symplectic_integrator_t type initialization
-  call test_symplectic_integrator_type(errors)
-  
-  if (errors == 0) then
-    print *, "All orbit_symplectic_base module tests passed!"
-  else
-    print *, "ERROR: ", errors, " test(s) failed!"
-    stop 1
-  end if
-  
+    use orbit_symplectic_base
+    implicit none
+
+    integer :: errors
+
+    errors = 0
+
+    ! Test integration method constants
+    call test_integration_constants(errors)
+
+    ! Test Runge-Kutta Gauss coefficients
+    call test_rk_gauss_coefficients(errors)
+
+    ! Test Runge-Kutta Lobatto coefficients
+    call test_rk_lobatto_coefficients(errors)
+
+    ! Test symplectic_integrator_t type initialization
+    call test_symplectic_integrator_type(errors)
+
+    if (errors == 0) then
+        print *, "All orbit_symplectic_base module tests passed!"
+    else
+        print *, "ERROR: ", errors, " test(s) failed!"
+        stop 1
+    end if
+
 contains
 
-  subroutine test_integration_constants(errors)
-    integer, intent(inout) :: errors
-    integer :: methods(7)
-    integer :: i, j
-    logical :: all_distinct
-    
-    print *, "Testing integration method constants..."
-    
-    ! Given: The module defines constants for different integration methods
-    ! When: We use these constants
-    ! Then: They should be distinct and within expected range
-    
-    ! Test that constants are distinct (no two methods have same value)
-    
-    methods = [RK45, EXPL_IMPL_EULER, IMPL_EXPL_EULER, MIDPOINT, GAUSS1, GAUSS2, LOBATTO3]
-    
-    all_distinct = .true.
-    do i = 1, size(methods)
-      do j = i+1, size(methods)
-        if (methods(i) == methods(j)) then
-          print *, "ERROR: Integration method constants not distinct"
-          print *, "Method", i, "and", j, "have same value:", methods(i)
-          errors = errors + 1
-          all_distinct = .false.
-          exit
+    subroutine test_integration_constants(errors)
+        integer, intent(inout) :: errors
+        integer :: methods(7)
+        integer :: i, j
+        logical :: all_distinct
+
+        print *, "Testing integration method constants..."
+
+        ! Given: The module defines constants for different integration methods
+        ! When: We use these constants
+        ! Then: They should be distinct and within expected range
+
+        ! Test that constants are distinct (no two methods have same value)
+
+  methods = [RK45, EXPL_IMPL_EULER, IMPL_EXPL_EULER, MIDPOINT, GAUSS1, GAUSS2, LOBATTO3]
+
+        all_distinct = .true.
+        do i = 1, size(methods)
+            do j = i + 1, size(methods)
+                if (methods(i) == methods(j)) then
+                    print *, "ERROR: Integration method constants not distinct"
+                    print *, "Method", i, "and", j, "have same value:", methods(i)
+                    errors = errors + 1
+                    all_distinct = .false.
+                    exit
+                end if
+            end do
+            if (.not. all_distinct) exit
+        end do
+
+        ! Test that S_MAX is large enough for all methods
+        if (S_MAX < maxval(methods)) then
+            print *, "ERROR: S_MAX too small for defined methods"
+            print *, "S_MAX:", S_MAX, "Max method value:", maxval(methods)
+            errors = errors + 1
         end if
-      end do
-      if (.not. all_distinct) exit
-    end do
-    
-    ! Test that S_MAX is large enough for all methods
-    if (S_MAX < maxval(methods)) then
-      print *, "ERROR: S_MAX too small for defined methods"
-      print *, "S_MAX:", S_MAX, "Max method value:", maxval(methods)
-      errors = errors + 1
-    end if
-    
-    ! Test that all constants are non-negative (sensible range)
-    do i = 1, size(methods)
-      if (methods(i) < 0) then
-        print *, "ERROR: Integration method constant is negative:", methods(i)
-        errors = errors + 1
-      end if
-    end do
-    
-    if (errors == 0) then
-      print *, "  Integration constants test PASSED"
-    end if
-    
-  end subroutine test_integration_constants
-  
-  subroutine test_rk_gauss_coefficients(errors)
-    integer, intent(inout) :: errors
-    
-    print *, "Testing Runge-Kutta Gauss coefficients..."
-    
-    ! Test 1-stage Gauss method (order 2)
-    call test_gauss_n1(errors)
-    
-    ! Test 2-stage Gauss method (order 4)
-    call test_gauss_n2(errors)
-    
-    ! Test 3-stage Gauss method (order 6)
-    call test_gauss_n3(errors)
-    
-    ! Test 4-stage Gauss method (order 8)
-    call test_gauss_n4(errors)
-    
-    ! Test unsupported stage count
-    call test_gauss_unsupported(errors)
-    
-    if (errors == 0) then
-      print *, "  RK Gauss coefficients test PASSED"
-    end if
-    
-  end subroutine test_rk_gauss_coefficients
-  
-  subroutine test_gauss_n1(errors)
-    integer, intent(inout) :: errors
-    integer, parameter :: n = 1
-    real(dp) :: a(n,n), b(n), c(n)
-    real(dp), parameter :: tol = 1.0d-14
-    
-    ! Given: A 1-stage Gauss method
-    ! When: We compute the coefficients
-    ! Then: They should match the known 1-stage Gauss values
-    
-    call coeff_rk_gauss(n, a, b, c)
-    
-    ! Check a coefficients
-    if (abs(a(1,1) - 0.5d0) > tol) then
-      print *, "ERROR: 1-stage Gauss a(1,1) incorrect"
-      print *, "Expected: 0.5, Got:", a(1,1)
-      errors = errors + 1
-    end if
-    
-    ! Check b coefficients
-    if (abs(b(1) - 1.0d0) > tol) then
-      print *, "ERROR: 1-stage Gauss b(1) incorrect"
-      print *, "Expected: 1.0, Got:", b(1)
-      errors = errors + 1
-    end if
-    
-    ! Check c coefficients
-    if (abs(c(1) - 0.5d0) > tol) then
-      print *, "ERROR: 1-stage Gauss c(1) incorrect"
-      print *, "Expected: 0.5, Got:", c(1)
-      errors = errors + 1
-    end if
-    
-  end subroutine test_gauss_n1
-  
-  subroutine test_gauss_n2(errors)
-    integer, intent(inout) :: errors
-    integer, parameter :: n = 2
-    real(dp) :: a(n,n), b(n), c(n)
-    real(dp), parameter :: tol = 1.0d-14
-    
-    ! Given: A 2-stage Gauss method
-    ! When: We compute the coefficients
-    ! Then: They should satisfy Gauss method properties
-    
-    call coeff_rk_gauss(n, a, b, c)
-    
-    ! Check symmetry properties
-    if (abs(a(1,1) - a(2,2)) > tol) then
-      print *, "ERROR: 2-stage Gauss should have a(1,1) = a(2,2)"
-      errors = errors + 1
-    end if
-    
-    ! Check that b coefficients sum to 1
-    if (abs(sum(b) - 1.0d0) > tol) then
-      print *, "ERROR: 2-stage Gauss b coefficients should sum to 1"
-      print *, "Sum:", sum(b)
-      errors = errors + 1
-    end if
-    
-    ! Check that b coefficients are symmetric
-    if (abs(b(1) - b(2)) > tol) then
-      print *, "ERROR: 2-stage Gauss b coefficients should be symmetric"
-      errors = errors + 1
-    end if
-    
-    ! Check c coefficient symmetry
-    if (abs(c(1) + c(2) - 1.0d0) > tol) then
-      print *, "ERROR: 2-stage Gauss c coefficients should sum to 1"
-      errors = errors + 1
-    end if
-    
-  end subroutine test_gauss_n2
-  
-  subroutine test_gauss_n3(errors)
-    integer, intent(inout) :: errors
-    integer, parameter :: n = 3
-    real(dp) :: a(n,n), b(n), c(n)
-    real(dp), parameter :: tol = 1.0d-12  ! Slightly looser tolerance for 3-stage
-    
-    call coeff_rk_gauss(n, a, b, c)
-    
-    ! Check symmetry of diagonal elements
-    if (abs(a(1,1) - a(3,3)) > tol) then
-      print *, "ERROR: 3-stage Gauss should have a(1,1) = a(3,3)"
-      errors = errors + 1
-    end if
-    
-    ! Check that b coefficients sum to 1
-    if (abs(sum(b) - 1.0d0) > tol) then
-      print *, "ERROR: 3-stage Gauss b coefficients should sum to 1"
-      print *, "Sum:", sum(b)
-      errors = errors + 1
-    end if
-    
-    ! Check symmetry of b coefficients
-    if (abs(b(1) - b(3)) > tol) then
-      print *, "ERROR: 3-stage Gauss b(1) should equal b(3)"
-      errors = errors + 1
-    end if
-    
-    ! Check that c(2) = 0.5 for symmetric methods
-    if (abs(c(2) - 0.5d0) > tol) then
-      print *, "ERROR: 3-stage Gauss c(2) should be 0.5"
-      print *, "Got:", c(2)
-      errors = errors + 1
-    end if
-    
-  end subroutine test_gauss_n3
-  
-  subroutine test_gauss_n4(errors)
-    integer, intent(inout) :: errors
-    integer, parameter :: n = 4
-    real(dp) :: a(n,n), b(n), c(n)
-    real(dp), parameter :: tol = 1.0d-12
-    
-    call coeff_rk_gauss(n, a, b, c)
-    
-    ! Check that b coefficients sum to 1
-    if (abs(sum(b) - 1.0d0) > tol) then
-      print *, "ERROR: 4-stage Gauss b coefficients should sum to 1"
-      print *, "Sum:", sum(b)
-      errors = errors + 1
-    end if
-    
-    ! Check symmetry of b coefficients
-    if (abs(b(1) - b(4)) > tol .or. abs(b(2) - b(3)) > tol) then
-      print *, "ERROR: 4-stage Gauss b coefficients should be symmetric"
-      errors = errors + 1
-    end if
-    
-    ! Check that c coefficients are in [0,1]
-    if (any(c < 0.0d0) .or. any(c > 1.0d0)) then
-      print *, "ERROR: 4-stage Gauss c coefficients should be in [0,1]"
-      errors = errors + 1
-    end if
-    
-  end subroutine test_gauss_n4
-  
-  subroutine test_gauss_unsupported(errors)
-    integer, intent(inout) :: errors
-    integer, parameter :: n = 5  ! Unsupported stage count
-    real(dp) :: a(n,n), b(n), c(n)
-    real(dp), parameter :: tol = 1.0d-14
-    
-    ! Given: An unsupported stage count
-    ! When: We call coeff_rk_gauss
-    ! Then: All coefficients should be zero
-    
-    call coeff_rk_gauss(n, a, b, c)
-    
-    if (any(abs(a) > tol) .or. any(abs(b) > tol) .or. any(abs(c) > tol)) then
-      print *, "ERROR: Unsupported Gauss stage count should give zero coefficients"
-      errors = errors + 1
-    end if
-    
-  end subroutine test_gauss_unsupported
-  
-  subroutine test_rk_lobatto_coefficients(errors)
-    integer, intent(inout) :: errors
-    
-    print *, "Testing Runge-Kutta Lobatto coefficients..."
-    
-    ! Test 3-stage Lobatto method
-    call test_lobatto_n3(errors)
-    
-    ! Test unsupported stage count
-    call test_lobatto_unsupported(errors)
-    
-    if (errors == 0) then
-      print *, "  RK Lobatto coefficients test PASSED"
-    end if
-    
-  end subroutine test_rk_lobatto_coefficients
-  
-  subroutine test_lobatto_n3(errors)
-    integer, intent(inout) :: errors
-    integer, parameter :: n = 3
-    real(dp) :: a(n,n), ahat(n,n), b(n), c(n)
-    real(dp), parameter :: tol = 1.0d-14
-    
-    ! Given: A 3-stage Lobatto method
-    ! When: We compute the coefficients
-    ! Then: They should satisfy Lobatto method properties
-    
-    call coeff_rk_lobatto(n, a, ahat, b, c)
-    
-    ! Check that b coefficients sum to 1
-    if (abs(sum(b) - 1.0d0) > tol) then
-      print *, "ERROR: 3-stage Lobatto b coefficients should sum to 1"
-      print *, "Sum:", sum(b)
-      errors = errors + 1
-    end if
-    
-    ! Check Lobatto property: c(1) = 0, c(n) = 1
-    if (abs(c(1)) > tol) then
-      print *, "ERROR: Lobatto c(1) should be 0"
-      print *, "Got:", c(1)
-      errors = errors + 1
-    end if
-    
-    if (abs(c(3) - 1.0d0) > tol) then
-      print *, "ERROR: Lobatto c(3) should be 1"
-      print *, "Got:", c(3)
-      errors = errors + 1
-    end if
-    
-    ! Check that first row of a is zero (Lobatto IIIA property)
-    if (any(abs(a(1,:)) > tol)) then
-      print *, "ERROR: First row of Lobatto a matrix should be zero"
-      errors = errors + 1
-    end if
-    
-    ! Check symmetry of b coefficients for 3-stage
-    if (abs(b(1) - b(3)) > tol) then
-      print *, "ERROR: Lobatto b(1) should equal b(3)"
-      errors = errors + 1
-    end if
-    
-  end subroutine test_lobatto_n3
-  
-  subroutine test_lobatto_unsupported(errors)
-    integer, intent(inout) :: errors
-    integer, parameter :: n = 4  ! Unsupported stage count for Lobatto
-    real(dp) :: a(n,n), ahat(n,n), b(n), c(n)
-    real(dp), parameter :: tol = 1.0d-14
-    
-    ! Given: An unsupported stage count for Lobatto
-    ! When: We call coeff_rk_lobatto
-    ! Then: Arrays remain uninitialized (implementation specific behavior)
-    
-    ! Initialize arrays to zero before the call
-    a = 0.0_dp
-    ahat = 0.0_dp
-    b = 0.0_dp
-    c = 0.0_dp
-    
-    call coeff_rk_lobatto(n, a, ahat, b, c)
-    
-    ! Since only n=3 is supported, arrays should remain zero for n=4
-    if (any(abs(a) > tol) .or. any(abs(ahat) > tol) .or. &
-        any(abs(b) > tol) .or. any(abs(c) > tol)) then
-      print *, "ERROR: Unsupported Lobatto stage count should leave coefficients unchanged"
-      errors = errors + 1
-    end if
-    
-  end subroutine test_lobatto_unsupported
-  
-  subroutine test_symplectic_integrator_type(errors)
-    integer, intent(inout) :: errors
-    type(symplectic_integrator_t) :: si
-    type(multistage_integrator_t) :: mi
-    
-    print *, "Testing symplectic_integrator_t type..."
-    
-    ! Given: The symplectic_integrator_t and multistage_integrator_t types
-    ! When: We initialize them with default values
-    ! Then: They should have the expected structure
-    
-    ! Test symplectic_integrator_t initialization
-    si%atol = 1.0d-10
-    si%rtol = 1.0d-8
-    si%z = [1.0_dp, 0.0_dp, 0.0_dp, 0.1_dp]
-    si%pthold = 0.0_dp
-    si%ntau = 1000
-    si%dt = 1.0d-3
-    si%pabs = 0.1_dp
-    
-    ! Basic checks on data integrity
-    if (si%atol /= 1.0d-10) then
-      print *, "ERROR: symplectic_integrator_t atol assignment failed"
-      errors = errors + 1
-    end if
-    
-    if (size(si%z) /= 4) then
-      print *, "ERROR: symplectic_integrator_t z should have 4 components"
-      errors = errors + 1
-    end if
-    
-    ! Test multistage_integrator_t initialization
-    mi%s = 3
-    if (mi%s /= 3) then
-      print *, "ERROR: multistage_integrator_t s assignment failed"
-      errors = errors + 1
-    end if
-    
-    if (size(mi%alpha) /= S_MAX) then
-      print *, "ERROR: multistage_integrator_t alpha array size incorrect"
-      errors = errors + 1
-    end if
-    
-    if (size(mi%stages) /= 2*S_MAX) then
-      print *, "ERROR: multistage_integrator_t stages array size incorrect"
-      errors = errors + 1
-    end if
-    
-    if (errors == 0) then
-      print *, "  symplectic_integrator_t type test PASSED"
-    end if
-    
-  end subroutine test_symplectic_integrator_type
+
+        ! Test that all constants are non-negative (sensible range)
+        do i = 1, size(methods)
+            if (methods(i) < 0) then
+                print *, "ERROR: Integration method constant is negative:", methods(i)
+                errors = errors + 1
+            end if
+        end do
+
+        if (errors == 0) then
+            print *, "  Integration constants test PASSED"
+        end if
+
+    end subroutine test_integration_constants
+
+    subroutine test_rk_gauss_coefficients(errors)
+        integer, intent(inout) :: errors
+
+        print *, "Testing Runge-Kutta Gauss coefficients..."
+
+        ! Test 1-stage Gauss method (order 2)
+        call test_gauss_n1(errors)
+
+        ! Test 2-stage Gauss method (order 4)
+        call test_gauss_n2(errors)
+
+        ! Test 3-stage Gauss method (order 6)
+        call test_gauss_n3(errors)
+
+        ! Test 4-stage Gauss method (order 8)
+        call test_gauss_n4(errors)
+
+        ! Test unsupported stage count
+        call test_gauss_unsupported(errors)
+
+        if (errors == 0) then
+            print *, "  RK Gauss coefficients test PASSED"
+        end if
+
+    end subroutine test_rk_gauss_coefficients
+
+    subroutine test_gauss_n1(errors)
+        integer, intent(inout) :: errors
+        integer, parameter :: n = 1
+        real(dp) :: a(n, n), b(n), c(n)
+        real(dp), parameter :: tol = 1.0d-14
+
+        ! Given: A 1-stage Gauss method
+        ! When: We compute the coefficients
+        ! Then: They should match the known 1-stage Gauss values
+
+        call coeff_rk_gauss(n, a, b, c)
+
+        ! Check a coefficients
+        if (abs(a(1, 1) - 0.5d0) > tol) then
+            print *, "ERROR: 1-stage Gauss a(1,1) incorrect"
+            print *, "Expected: 0.5, Got:", a(1, 1)
+            errors = errors + 1
+        end if
+
+        ! Check b coefficients
+        if (abs(b(1) - 1.0d0) > tol) then
+            print *, "ERROR: 1-stage Gauss b(1) incorrect"
+            print *, "Expected: 1.0, Got:", b(1)
+            errors = errors + 1
+        end if
+
+        ! Check c coefficients
+        if (abs(c(1) - 0.5d0) > tol) then
+            print *, "ERROR: 1-stage Gauss c(1) incorrect"
+            print *, "Expected: 0.5, Got:", c(1)
+            errors = errors + 1
+        end if
+
+    end subroutine test_gauss_n1
+
+    subroutine test_gauss_n2(errors)
+        integer, intent(inout) :: errors
+        integer, parameter :: n = 2
+        real(dp) :: a(n, n), b(n), c(n)
+        real(dp), parameter :: tol = 1.0d-14
+
+        ! Given: A 2-stage Gauss method
+        ! When: We compute the coefficients
+        ! Then: They should satisfy Gauss method properties
+
+        call coeff_rk_gauss(n, a, b, c)
+
+        ! Check symmetry properties
+        if (abs(a(1, 1) - a(2, 2)) > tol) then
+            print *, "ERROR: 2-stage Gauss should have a(1,1) = a(2,2)"
+            errors = errors + 1
+        end if
+
+        ! Check that b coefficients sum to 1
+        if (abs(sum(b) - 1.0d0) > tol) then
+            print *, "ERROR: 2-stage Gauss b coefficients should sum to 1"
+            print *, "Sum:", sum(b)
+            errors = errors + 1
+        end if
+
+        ! Check that b coefficients are symmetric
+        if (abs(b(1) - b(2)) > tol) then
+            print *, "ERROR: 2-stage Gauss b coefficients should be symmetric"
+            errors = errors + 1
+        end if
+
+        ! Check c coefficient symmetry
+        if (abs(c(1) + c(2) - 1.0d0) > tol) then
+            print *, "ERROR: 2-stage Gauss c coefficients should sum to 1"
+            errors = errors + 1
+        end if
+
+    end subroutine test_gauss_n2
+
+    subroutine test_gauss_n3(errors)
+        integer, intent(inout) :: errors
+        integer, parameter :: n = 3
+        real(dp) :: a(n, n), b(n), c(n)
+        real(dp), parameter :: tol = 1.0d-12  ! Slightly looser tolerance for 3-stage
+
+        call coeff_rk_gauss(n, a, b, c)
+
+        ! Check symmetry of diagonal elements
+        if (abs(a(1, 1) - a(3, 3)) > tol) then
+            print *, "ERROR: 3-stage Gauss should have a(1,1) = a(3,3)"
+            errors = errors + 1
+        end if
+
+        ! Check that b coefficients sum to 1
+        if (abs(sum(b) - 1.0d0) > tol) then
+            print *, "ERROR: 3-stage Gauss b coefficients should sum to 1"
+            print *, "Sum:", sum(b)
+            errors = errors + 1
+        end if
+
+        ! Check symmetry of b coefficients
+        if (abs(b(1) - b(3)) > tol) then
+            print *, "ERROR: 3-stage Gauss b(1) should equal b(3)"
+            errors = errors + 1
+        end if
+
+        ! Check that c(2) = 0.5 for symmetric methods
+        if (abs(c(2) - 0.5d0) > tol) then
+            print *, "ERROR: 3-stage Gauss c(2) should be 0.5"
+            print *, "Got:", c(2)
+            errors = errors + 1
+        end if
+
+    end subroutine test_gauss_n3
+
+    subroutine test_gauss_n4(errors)
+        integer, intent(inout) :: errors
+        integer, parameter :: n = 4
+        real(dp) :: a(n, n), b(n), c(n)
+        real(dp), parameter :: tol = 1.0d-12
+
+        call coeff_rk_gauss(n, a, b, c)
+
+        ! Check that b coefficients sum to 1
+        if (abs(sum(b) - 1.0d0) > tol) then
+            print *, "ERROR: 4-stage Gauss b coefficients should sum to 1"
+            print *, "Sum:", sum(b)
+            errors = errors + 1
+        end if
+
+        ! Check symmetry of b coefficients
+        if (abs(b(1) - b(4)) > tol .or. abs(b(2) - b(3)) > tol) then
+            print *, "ERROR: 4-stage Gauss b coefficients should be symmetric"
+            errors = errors + 1
+        end if
+
+        ! Check that c coefficients are in [0,1]
+        if (any(c < 0.0d0) .or. any(c > 1.0d0)) then
+            print *, "ERROR: 4-stage Gauss c coefficients should be in [0,1]"
+            errors = errors + 1
+        end if
+
+    end subroutine test_gauss_n4
+
+    subroutine test_gauss_unsupported(errors)
+        integer, intent(inout) :: errors
+        integer, parameter :: n = 5  ! Unsupported stage count
+        real(dp) :: a(n, n), b(n), c(n)
+        real(dp), parameter :: tol = 1.0d-14
+
+        ! Given: An unsupported stage count
+        ! When: We call coeff_rk_gauss
+        ! Then: All coefficients should be zero
+
+        call coeff_rk_gauss(n, a, b, c)
+
+        if (any(abs(a) > tol) .or. any(abs(b) > tol) .or. any(abs(c) > tol)) then
+           print *, "ERROR: Unsupported Gauss stage count should give zero coefficients"
+            errors = errors + 1
+        end if
+
+    end subroutine test_gauss_unsupported
+
+    subroutine test_rk_lobatto_coefficients(errors)
+        integer, intent(inout) :: errors
+
+        print *, "Testing Runge-Kutta Lobatto coefficients..."
+
+        ! Test 3-stage Lobatto method
+        call test_lobatto_n3(errors)
+
+        ! Test unsupported stage count
+        call test_lobatto_unsupported(errors)
+
+        if (errors == 0) then
+            print *, "  RK Lobatto coefficients test PASSED"
+        end if
+
+    end subroutine test_rk_lobatto_coefficients
+
+    subroutine test_lobatto_n3(errors)
+        integer, intent(inout) :: errors
+        integer, parameter :: n = 3
+        real(dp) :: a(n, n), ahat(n, n), b(n), c(n)
+        real(dp), parameter :: tol = 1.0d-14
+
+        ! Given: A 3-stage Lobatto method
+        ! When: We compute the coefficients
+        ! Then: They should satisfy Lobatto method properties
+
+        call coeff_rk_lobatto(n, a, ahat, b, c)
+
+        ! Check that b coefficients sum to 1
+        if (abs(sum(b) - 1.0d0) > tol) then
+            print *, "ERROR: 3-stage Lobatto b coefficients should sum to 1"
+            print *, "Sum:", sum(b)
+            errors = errors + 1
+        end if
+
+        ! Check Lobatto property: c(1) = 0, c(n) = 1
+        if (abs(c(1)) > tol) then
+            print *, "ERROR: Lobatto c(1) should be 0"
+            print *, "Got:", c(1)
+            errors = errors + 1
+        end if
+
+        if (abs(c(3) - 1.0d0) > tol) then
+            print *, "ERROR: Lobatto c(3) should be 1"
+            print *, "Got:", c(3)
+            errors = errors + 1
+        end if
+
+        ! Check that first row of a is zero (Lobatto IIIA property)
+        if (any(abs(a(1, :)) > tol)) then
+            print *, "ERROR: First row of Lobatto a matrix should be zero"
+            errors = errors + 1
+        end if
+
+        ! Check symmetry of b coefficients for 3-stage
+        if (abs(b(1) - b(3)) > tol) then
+            print *, "ERROR: Lobatto b(1) should equal b(3)"
+            errors = errors + 1
+        end if
+
+    end subroutine test_lobatto_n3
+
+    subroutine test_lobatto_unsupported(errors)
+        integer, intent(inout) :: errors
+        integer, parameter :: n = 4  ! Unsupported stage count for Lobatto
+        real(dp) :: a(n, n), ahat(n, n), b(n), c(n)
+        real(dp), parameter :: tol = 1.0d-14
+
+        ! Given: An unsupported stage count for Lobatto
+        ! When: We call coeff_rk_lobatto
+        ! Then: Arrays remain uninitialized (implementation specific behavior)
+
+        ! Initialize arrays to zero before the call
+        a = 0.0_dp
+        ahat = 0.0_dp
+        b = 0.0_dp
+        c = 0.0_dp
+
+        call coeff_rk_lobatto(n, a, ahat, b, c)
+
+        ! Since only n=3 is supported, arrays should remain zero for n=4
+        if (any(abs(a) > tol) .or. any(abs(ahat) > tol) .or. &
+            any(abs(b) > tol) .or. any(abs(c) > tol)) then
+   print *, "ERROR: Unsupported Lobatto stage count should leave coefficients unchanged"
+            errors = errors + 1
+        end if
+
+    end subroutine test_lobatto_unsupported
+
+    subroutine test_symplectic_integrator_type(errors)
+        integer, intent(inout) :: errors
+        type(symplectic_integrator_t) :: si
+        type(multistage_integrator_t) :: mi
+
+        print *, "Testing symplectic_integrator_t type..."
+
+        ! Given: The symplectic_integrator_t and multistage_integrator_t types
+        ! When: We initialize them with default values
+        ! Then: They should have the expected structure
+
+        ! Test symplectic_integrator_t initialization
+        si%atol = 1.0d-10
+        si%rtol = 1.0d-8
+        si%z = [1.0_dp, 0.0_dp, 0.0_dp, 0.1_dp]
+        si%pthold = 0.0_dp
+        si%ntau = 1000
+        si%dt = 1.0d-3
+        si%pabs = 0.1_dp
+
+        ! Basic checks on data integrity
+        if (si%atol /= 1.0d-10) then
+            print *, "ERROR: symplectic_integrator_t atol assignment failed"
+            errors = errors + 1
+        end if
+
+        if (size(si%z) /= 4) then
+            print *, "ERROR: symplectic_integrator_t z should have 4 components"
+            errors = errors + 1
+        end if
+
+        ! Test multistage_integrator_t initialization
+        mi%s = 3
+        if (mi%s /= 3) then
+            print *, "ERROR: multistage_integrator_t s assignment failed"
+            errors = errors + 1
+        end if
+
+        if (size(mi%alpha) /= S_MAX) then
+            print *, "ERROR: multistage_integrator_t alpha array size incorrect"
+            errors = errors + 1
+        end if
+
+        if (size(mi%stages) /= 2*S_MAX) then
+            print *, "ERROR: multistage_integrator_t stages array size incorrect"
+            errors = errors + 1
+        end if
+
+        if (errors == 0) then
+            print *, "  symplectic_integrator_t type test PASSED"
+        end if
+
+    end subroutine test_symplectic_integrator_type
 
 end program test_orbit_symplectic_base

--- a/test/tests/test_poiplot_classification.f90
+++ b/test/tests/test_poiplot_classification.f90
@@ -1,133 +1,133 @@
 !
-  use new_vmec_stuff_mod, only : netcdffile,multharm,ns_A,ns_s,ns_tp
+  use new_vmec_stuff_mod, only: netcdffile, multharm, ns_A, ns_s, ns_tp
 !  use chamb_mod,  only : rbig,rcham2
-  use parmot_mod, only : rmu,ro0,eeff
-  use velo_mod,   only : isw_field_type
-use diag_mod, only : icounter
+  use parmot_mod, only: rmu, ro0, eeff
+  use velo_mod, only: isw_field_type
+  use diag_mod, only: icounter
 use field_can_mod, only: eval_field => evaluate, field_can_from_name, field_can_t, field_can_init
-  use orbit_symplectic, only : symplectic_integrator_t, orbit_timestep_sympl
-  use simple, only : init_sympl
-  use plag_coeff_sub, only : plag_coeff
+  use orbit_symplectic, only: symplectic_integrator_t, orbit_timestep_sympl
+  use simple, only: init_sympl
+  use plag_coeff_sub, only: plag_coeff
   use get_can_sub
   use spline_vmec_sub
-  use vmecin_sub, only : stevvo
+  use vmecin_sub, only: stevvo
 !
   implicit none
 !
-  double precision, parameter :: pi=3.14159265358979d0
-  double precision,parameter  :: c=2.9979d10
-  double precision,parameter  :: e_charge=4.8032d-10
-  double precision,parameter  :: e_mass=9.1094d-28
-  double precision,parameter  :: p_mass=1.6726d-24
-  double precision,parameter  :: ev=1.6022d-12
-  double precision,parameter  :: snear_axis=0.05d0
+  double precision, parameter :: pi = 3.14159265358979d0
+  double precision, parameter  :: c = 2.9979d10
+  double precision, parameter  :: e_charge = 4.8032d-10
+  double precision, parameter  :: e_mass = 9.1094d-28
+  double precision, parameter  :: p_mass = 1.6726d-24
+  double precision, parameter  :: ev = 1.6022d-12
+  double precision, parameter  :: snear_axis = 0.05d0
 !
   logical :: near_axis
-  integer          :: npoi,ierr,L1i,nper,npoiper,i,ntimstep,ntestpart
-  integer          :: ipart,notrace_passing,loopskip,iskip,ilost,it
-  double precision :: dphi,rbeg,phibeg,zbeg,bmod00,rcham,rlarm,bmax,bmin
-  double precision :: tau,dtau,dtaumin,xi,v0,bmod_ref,E_alpha,trace_time
-  double precision :: RT0,R0i,cbfi,bz0i,bf0,trap_par
-  double precision :: sbeg,thetabeg
-  double precision :: rbig,z1,z2
+  integer          :: npoi, ierr, L1i, nper, npoiper, i, ntimstep, ntestpart
+  integer          :: ipart, notrace_passing, loopskip, iskip, ilost, it
+  double precision :: dphi, rbeg, phibeg, zbeg, bmod00, rcham, rlarm, bmax, bmin
+  double precision :: tau, dtau, dtaumin, xi, v0, bmod_ref, E_alpha, trace_time
+  double precision :: RT0, R0i, cbfi, bz0i, bf0, trap_par
+  double precision :: sbeg, thetabeg
+  double precision :: rbig, z1, z2
   double precision, dimension(5) :: z
   integer          :: npoiper2
   double precision :: contr_pp
   double precision :: facE_al
   integer          :: ibins
-  integer          :: n_e,n_d,n_b
-  double precision :: r,vartheta_c,varphi_c,theta_vmec,varphi_vmec,alam0
+  integer          :: n_e, n_d, n_b
+  double precision :: r, vartheta_c, varphi_c, theta_vmec, varphi_vmec, alam0
 
   integer, parameter :: mode_sympl = 0 ! 0 = Euler1, 1 = Euler2, 2 = Verlet
 !
 !---------------------------------------------------------------------------
 ! Prepare calculation of orbit tip by interpolation
 !
-  integer                                       :: nplagr,nder,itip,npl_half
-  double precision                              :: alam_prev,zerolam,twopi,fraction
+  integer                                       :: nplagr, nder, itip, npl_half
+  double precision                              :: alam_prev, zerolam, twopi, fraction
   double precision, dimension(5)                :: z_tip
-  integer,          dimension(:),   allocatable :: ipoi
-  double precision, dimension(:),   allocatable :: xp
-  double precision, dimension(:,:), allocatable :: coef,orb_sten
+  integer, dimension(:), allocatable :: ipoi
+  double precision, dimension(:), allocatable :: xp
+  double precision, dimension(:, :), allocatable :: coef, orb_sten
 !
   type(field_can_t) :: f
   type(symplectic_integrator_t) :: si
 
-  zerolam=0.d0
-  twopi=2.d0*pi
-  nplagr=4
-  nder=0
-  npl_half=nplagr/2
-  allocate(ipoi(nplagr),coef(0:nder,nplagr),orb_sten(5,nplagr),xp(nplagr))
-  do i=1,nplagr
-    ipoi(i)=i
-  enddo
+  zerolam = 0.d0
+  twopi = 2.d0*pi
+  nplagr = 4
+  nder = 0
+  npl_half = nplagr/2
+  allocate (ipoi(nplagr), coef(0:nder, nplagr), orb_sten(5, nplagr), xp(nplagr))
+  do i = 1, nplagr
+      ipoi(i) = i
+  end do
 !
 ! End prepare calculation of orbit tip by interpolation
 !--------------------------------------------------------------------------
 !
-  open(1,file='alpha_lifetime_m.inp')
-  read (1,*) notrace_passing   !skip tracing passing prts if notrace_passing=1
-  read (1,*) nper              !number of periods for initial field line
-  read (1,*) npoiper           !number of points per period on this field line
-  read (1,*) ntimstep          !number of time steps per slowing down time
-  read (1,*) ntestpart         !number of test particles
-  read (1,*) bmod_ref          !reference field, G, for Boozer $B_{00}$
-  read (1,*) trace_time        !slowing down time, s
-  read (1,*) sbeg              !starting s for field line                       !<=2017
-  read (1,*) phibeg            !starting phi for field line                     !<=2017
-  read (1,*) thetabeg          !starting theta for field line                   !<=2017
-  read (1,*) loopskip          !how many loops to skip to shift random numbers
-  read (1,*) contr_pp          !control of passing particle fraction
-  read (1,*) facE_al           !facE_al test particle energy reduction factor
-  read (1,*) npoiper2          !additional integration step split factor
-  read (1,*) n_e               !test particle charge number (the same as Z)
-  read (1,*) n_d               !test particle mass number (the same as A)
-  read (1,*) netcdffile        !name of VMEC file in NETCDF format <=2017 NEW
-  close(1)
+  open (1, file='alpha_lifetime_m.inp')
+  read (1, *) notrace_passing   !skip tracing passing prts if notrace_passing=1
+  read (1, *) nper              !number of periods for initial field line
+  read (1, *) npoiper           !number of points per period on this field line
+  read (1, *) ntimstep          !number of time steps per slowing down time
+  read (1, *) ntestpart         !number of test particles
+  read (1, *) bmod_ref          !reference field, G, for Boozer $B_{00}$
+  read (1, *) trace_time        !slowing down time, s
+  read (1, *) sbeg              !starting s for field line                       !<=2017
+  read (1, *) phibeg            !starting phi for field line                     !<=2017
+  read (1, *) thetabeg          !starting theta for field line                   !<=2017
+  read (1, *) loopskip          !how many loops to skip to shift random numbers
+  read (1, *) contr_pp          !control of passing particle fraction
+  read (1, *) facE_al           !facE_al test particle energy reduction factor
+  read (1, *) npoiper2          !additional integration step split factor
+  read (1, *) n_e               !test particle charge number (the same as Z)
+  read (1, *) n_d               !test particle mass number (the same as A)
+  read (1, *) netcdffile        !name of VMEC file in NETCDF format <=2017 NEW
+  close (1)
 !
 ! inverse relativistic temperature
-  rmu=1d8
+  rmu = 1d8
 !
 ! alpha particle energy, eV:
-  E_alpha=3.5d6/facE_al
+  E_alpha = 3.5d6/facE_al
 ! alpha particle velocity, cm/s
-  v0=sqrt(2.d0*E_alpha*ev/(n_d*p_mass))
+  v0 = sqrt(2.d0*E_alpha*ev/(n_d*p_mass))
 ! 14.04.2013 end
 !
 ! Larmor radius:
-  rlarm=v0*n_d*p_mass*c/(n_e*e_charge*bmod_ref)
+  rlarm = v0*n_d*p_mass*c/(n_e*e_charge*bmod_ref)
 ! normalized slowing down time:
-  tau=trace_time*v0
+  tau = trace_time*v0
 ! normalized time step:
-  dtau=tau/dble(ntimstep-1)
+  dtau = tau/dble(ntimstep - 1)
 !
-bmod00=281679.46317784750d0
+  bmod00 = 281679.46317784750d0
 ! Larmor raidus corresponds to the field stregth egual to $B_{00}$ harmonic
 ! in Boozer coordinates:
 ! 14.11.2011  bmod00=bmod_ref  !<=deactivated, use value from the 'alpha_lifetime.inp'
-  ro0=rlarm*bmod00  ! 23.09.2013
+  ro0 = rlarm*bmod00  ! 23.09.2013
 !
-  multharm=3 !3 !7
-  ns_A=5
-  ns_s=5
-  ns_tp=5
+  multharm = 3 !3 !7
+  ns_A = 5
+  ns_s = 5
+  ns_tp = 5
 !
   call spline_vmec_data
 !call testing
 !
-  call stevvo(RT0,R0i,L1i,cbfi,bz0i,bf0)         !<=2017
+  call stevvo(RT0, R0i, L1i, cbfi, bz0i, bf0)         !<=2017
 !
-  rbig=rt0
+  rbig = rt0
 ! field line integration step step over phi (to check chamber wall crossing)
-  dphi=2.d0*pi/(L1i*npoiper)
+  dphi = 2.d0*pi/(L1i*npoiper)
 ! orbit integration time step (to check chamber wall crossing)
-  dtaumin=dphi*rbig/npoiper2!
+  dtaumin = dphi*rbig/npoiper2!
 !dtau=2*dtaumin
-dtau=dtaumin
-ntimstep = L1i*npoiper*npoiper2*10000
-print *, 'dtau = ', dtau, ' dtau/dtaumin = ', dtau/dtaumin
-print *, 'ttrace = ', ntimstep*dtau/v0, 'nstep = ', ntimstep
+  dtau = dtaumin
+  ntimstep = L1i*npoiper*npoiper2*10000
+  print *, 'dtau = ', dtau, ' dtau/dtaumin = ', dtau/dtaumin
+  print *, 'ttrace = ', ntimstep*dtau/v0, 'nstep = ', ntimstep
 !
   call get_canonical_coordinates
 !call testing
@@ -140,139 +140,139 @@ print *, 'ttrace = ', ntimstep*dtau/v0, 'nstep = ', ntimstep
   varphi_c = 0.314
   alam0 = 0.0
 !
-  isw_field_type=0
-  z(1)=r
-  z(2)=vartheta_c
-  z(3)=varphi_c
-  z(4)=1.d0
-  z(5)=alam0
+  isw_field_type = 0
+  z(1) = r
+  z(2) = vartheta_c
+  z(3) = varphi_c
+  z(4) = 1.d0
+  z(5) = alam0
 !
-icounter=0
+  icounter = 0
   call field_can_from_name('flux')
   call init_sympl(si, f, z, dtau, dtaumin, 1d-12, mode_sympl)
 !
 !--------------------------------
 ! Initialize tip detector
 !
-  itip=3
-  alam_prev=z(5)
+  itip = 3
+  alam_prev = z(5)
 !
 ! End initialize tip detector
 !--------------------------------
 !
-  open(101,file='poiplot.dat')
+  open (101, file='poiplot.dat')
 !
-  do i=1,ntimstep !300 !10
+  do i = 1, ntimstep !300 !10
 !
 !    call orbit_timestep_axis(z,dtau,dtaumin,ierr)
-    call orbit_timestep_sympl(si, f, ierr)
+      call orbit_timestep_sympl(si, f, ierr)
 !
-    if(ierr.ne.0) exit
+      if (ierr .ne. 0) exit
 !
 !-------------------------------------------------------------------------
 ! Tip detection and interpolation
 !
-    if(alam_prev.lt.0.d0.and.z(5).gt.0.d0) itip=0   !<=tip has been passed
-    itip=itip+1
-    alam_prev=z(5)
-    if(i.le.nplagr) then          !<=first nplagr points to initialize stencil
-      orb_sten(:,i)=z
-    else                          !<=normal case, shift stencil
-      orb_sten(:,ipoi(1))=z
-      ipoi=cshift(ipoi,1)
-      if(itip.eq.npl_half) then   !<=stencil around tip is complete, interpolate
-        xp=orb_sten(5,ipoi)
+      if (alam_prev .lt. 0.d0 .and. z(5) .gt. 0.d0) itip = 0   !<=tip has been passed
+      itip = itip + 1
+      alam_prev = z(5)
+      if (i .le. nplagr) then          !<=first nplagr points to initialize stencil
+          orb_sten(:, i) = z
+      else                          !<=normal case, shift stencil
+          orb_sten(:, ipoi(1)) = z
+          ipoi = cshift(ipoi, 1)
+          if (itip .eq. npl_half) then   !<=stencil around tip is complete, interpolate
+              xp = orb_sten(5, ipoi)
 !
-        call plag_coeff(nplagr,nder,zerolam,xp,coef)
+              call plag_coeff(nplagr, nder, zerolam, xp, coef)
 !
-        z_tip=matmul(orb_sten(:,ipoi),coef(0,:))
-        z_tip(2)=modulo(z_tip(2),twopi)
-        z_tip(3)=modulo(z_tip(3),twopi)
-        write(101,*) z_tip
-      endif
-    endif
+              z_tip = matmul(orb_sten(:, ipoi), coef(0, :))
+              z_tip(2) = modulo(z_tip(2), twopi)
+              z_tip(3) = modulo(z_tip(3), twopi)
+              write (101, *) z_tip
+          end if
+      end if
 !
 ! End tip detection and interpolation
 !-------------------------------------------------------------------------
 !
-  enddo
-  close(101)
+  end do
+  close (101)
 !
-print *,'done  ',icounter,'  field calls', icounter*1.0d0/ntimstep, 'per step'
+  print *, 'done  ', icounter, '  field calls', icounter*1.0d0/ntimstep, 'per step'
 !
   call fract_dimension(fraction)
 !
-  if(fraction.gt.0.3d0) then
-    print *,'chaotic orbit'
+  if (fraction .gt. 0.3d0) then
+      print *, 'chaotic orbit'
   else
-    print *,'regular orbit'
-  endif
+      print *, 'regular orbit'
+  end if
 !enddo
 !
   call deallocate_can_coord
 !
-  end
+end
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !
-  subroutine fract_dimension(fraction)
+subroutine fract_dimension(fraction)
 !
-  implicit none
+    implicit none
 !
-  integer, parameter :: iunit=171
-  integer :: itr,ntr,ir,it,ngrid,nrefine,irefine,kr,kt,nboxes
-  double precision :: fraction,r,rmax,rmin,tmax,tmin,hr,ht
-  logical,          dimension(:,:), allocatable :: free
-  double precision, dimension(:,:), allocatable :: rt
+    integer, parameter :: iunit = 171
+    integer :: itr, ntr, ir, it, ngrid, nrefine, irefine, kr, kt, nboxes
+    double precision :: fraction, r, rmax, rmin, tmax, tmin, hr, ht
+    logical, dimension(:, :), allocatable :: free
+    double precision, dimension(:, :), allocatable :: rt
 !
-  ntr=0
+    ntr = 0
 !
-  open(iunit,file='poiplot.dat')
-  do
-    read(iunit,*,end=1) r
-    ntr=ntr+1
-  enddo
-1 close(iunit)
+    open (iunit, file='poiplot.dat')
+    do
+        read (iunit, *, end=1) r
+        ntr = ntr + 1
+    end do
+1   close (iunit)
 !
-  allocate(rt(2,ntr))
-  open(iunit,file='poiplot.dat')
-  do itr=1,ntr
-    read(iunit,*) rt(:,itr)
-  enddo
-  close(iunit)
+    allocate (rt(2, ntr))
+    open (iunit, file='poiplot.dat')
+    do itr = 1, ntr
+        read (iunit, *) rt(:, itr)
+    end do
+    close (iunit)
 !
-  rmin=minval(rt(1,:))
-  rmax=maxval(rt(1,:))
-  tmin=minval(rt(2,:))
-  tmax=maxval(rt(2,:))
+    rmin = minval(rt(1, :))
+    rmax = maxval(rt(1, :))
+    tmin = minval(rt(2, :))
+    tmax = maxval(rt(2, :))
 !
-  nrefine=int(log(dble(ntr))/log(4.d0))
+    nrefine = int(log(dble(ntr))/log(4.d0))
 !
-  open(iunit,file='boxcount.dat')
-  ngrid=1
-  nrefine=nrefine+3       !<=add 3 for curiousity
-  do irefine=1,nrefine
-    ngrid=ngrid*2
-    allocate(free(0:ngrid,0:ngrid))
-    free=.true.
-    hr=(rmax-rmin)/dble(ngrid)
-    ht=(tmax-tmin)/dble(ngrid)
-    nboxes=0
-    do itr=1,ntr
-      kr=int((rt(1,itr)-rmin)/hr)
-      kr=min(ngrid-1,max(0,kr))
-      kt=int((rt(2,itr)-tmin)/ht)
-      kt=min(ngrid-1,max(0,kt))
-      if(free(kr,kt)) then
-        free(kr,kt)=.false.
-        nboxes=nboxes+1
-      endif
-    enddo
-    deallocate(free)
-    write(iunit,*) dble(irefine),dble(nboxes)/dble(ngrid**2)
-    if(irefine.eq.nrefine-3) fraction=dble(nboxes)/dble(ngrid**2)
-  enddo
-  close(iunit)
-  deallocate(rt)
+    open (iunit, file='boxcount.dat')
+    ngrid = 1
+    nrefine = nrefine + 3       !<=add 3 for curiousity
+    do irefine = 1, nrefine
+        ngrid = ngrid*2
+        allocate (free(0:ngrid, 0:ngrid))
+        free = .true.
+        hr = (rmax - rmin)/dble(ngrid)
+        ht = (tmax - tmin)/dble(ngrid)
+        nboxes = 0
+        do itr = 1, ntr
+            kr = int((rt(1, itr) - rmin)/hr)
+            kr = min(ngrid - 1, max(0, kr))
+            kt = int((rt(2, itr) - tmin)/ht)
+            kt = min(ngrid - 1, max(0, kt))
+            if (free(kr, kt)) then
+                free(kr, kt) = .false.
+                nboxes = nboxes + 1
+            end if
+        end do
+        deallocate (free)
+        write (iunit, *) dble(irefine), dble(nboxes)/dble(ngrid**2)
+        if (irefine .eq. nrefine - 3) fraction = dble(nboxes)/dble(ngrid**2)
+    end do
+    close (iunit)
+    deallocate (rt)
 !
-  end subroutine fract_dimension
+end subroutine fract_dimension


### PR DESCRIPTION
## What

Reindent 31 files with `fprettify` to the formatting the 6D-port branch
(#408) already uses, so that PR's diff carries real changes only. This is
formatting churn lifted out ahead of it: ~7600 of #408's ~18900 changed
lines are reindentation.

`fprettify` 0.3.7 with the repo `.fprettify` config (4-space indent, 88
cols) produces these files from `main`. `get_canonical_coordinates.F90` is
the branch's whole-file reformat, taken verbatim (zero real change).

## No semantic change

```
$ git diff -w --ignore-blank-lines origin/main
(empty)
```

No token changes anywhere: only indentation and blank-line normalization.
Build passes (`make CONFIG=Fast`).

## After merge

Rebasing #408 on top drops the reformatted files from its diff, since the
formatting matches. The seven files `fprettify` does not reproduce
(`orbit_symplectic`, `classification`, `simple`, `params`, `field_can_test`,
`simple_main`, plus the field-can hand-formatting) stay in #408 with their
real changes.
