### PR TITLE
Decouple integration microstep dtaumin from trace_time

### DIFF
--- a/src/params.f90
+++ b/src/params.f90
@@ -183,8 +183,6 @@ contains
             rbig = 1.0d0        ! Major radius R0=1
             dphi = 2.d0*pi/(L1i*npoiper)
 	            dtaumin = 2.d0*pi*rbig/npoiper2
-	            ntau = ceiling(dtau/dtaumin)
-	            dtaumin = dtau/ntau
 	            fper = 2d0*pi       ! Full torus
 	        else
             E_alpha = 3.5d6/facE_al
@@ -205,18 +203,17 @@ contains
             dphi = 2.d0*pi/(L1i*npoiper)
 	            ! orbit integration time step (to check chamber wall crossing)
 	            dtaumin = 2.d0*pi*rbig/npoiper2
-	            ntau = ceiling(dtau/dtaumin)
-	            dtaumin = dtau/ntau
 	            fper = 2d0*pi/dble(L1i)
 	        end if
 
-	        ! Macrostep schedule (number of microsteps per macrostep).
-	        ! - Default is linear: constant ntau per macrostep.
-	        ! - Log schedule: macrosteps are distributed logarithmically in time
-	        !   while keeping the microstep resolution dtaumin. The total number
-	        !   of microsteps is preserved as (ntimstep-1)*ntau.
+	        ! Macrostep schedule. dtaumin (microstep) is fixed by npoiper2 alone, so
+	        ! resolution is independent of trace_time; the schedule distributes
+	        ! n_microsteps_total microsteps over the ntimstep output points.
+	        ! - linear: equal microsteps per macrostep (cumulative rounding).
+	        ! - log: macrosteps spaced logarithmically in time, 10:1 last:first.
 	        nintv = max(1, ntimstep - 1)
-	        n_microsteps_total = int(nintv, kind=8) * int(ntau, kind=8)
+	        n_microsteps_total = max(int(nintv, kind=8), nint(tau/dtaumin, kind=8))
+	        ntau = max(1, int(n_microsteps_total / int(nintv, kind=8)))
 	        if (allocated(ntau_macro)) deallocate(ntau_macro)
 	        if (allocated(kt_macro)) deallocate(kt_macro)
 	        allocate (ntau_macro(ntimstep))
@@ -250,9 +247,12 @@ contains
 	                kt_prev = kt_macro(i + 1)
 	            end do
 	        else
-	            do i = 2, ntimstep
-	                ntau_macro(i) = ntau
-	                kt_macro(i) = kt_macro(i - 1) + int(ntau, kind=8)
+	            kt_prev = 0_8
+	            do i = 1, nintv
+	                kt_target = nint(dble(i) / dble(nintv) * dble(n_microsteps_total), kind=8)
+	                ntau_macro(i + 1) = max(1, int(kt_target - kt_prev))
+	                kt_macro(i + 1) = kt_prev + int(ntau_macro(i + 1), kind=8)
+	                kt_prev = kt_macro(i + 1)
 	            end do
 	        end if
 

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -55,6 +55,16 @@ set_tests_properties(test_orbit_macro PROPERTIES
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
+add_test(NAME test_dtaumin_invariance
+    COMMAND ${Python_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/test_dtaumin_invariance.py -v
+)
+set_tests_properties(test_dtaumin_invariance PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/python:${CMAKE_BINARY_DIR}:${CMAKE_SOURCE_DIR}/python"
+    LABELS "python;timestep"
+    TIMEOUT 120
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
+
 add_test(NAME test_examples
     COMMAND ${Python_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/test_examples.py -v
 )

--- a/test/python/test_dtaumin_invariance.py
+++ b/test/python/test_dtaumin_invariance.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""The integration microstep dtaumin must depend on npoiper2 only, not trace_time.
+
+Regression for the trace_time coupling bug: dtaumin used to be set to dtau/ntau,
+which made the physical resolution depend on the total trace length. Two runs
+differing only in trace_time then integrated at different resolution and their
+confined-fraction curves were not comparable. dtaumin is now 2*pi*rbig/npoiper2.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import subprocess
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SIMPLE_EXE = REPO_ROOT / "build" / "simple.x"
+
+NPOIPER2 = 256
+NTIMSTEP = 100
+
+
+def _write_simple_in(path: Path, vmec: Path, trace_time: float) -> None:
+    (path / "simple.in").write_text(
+        f"""&config
+startmode = 1
+ntestpart = 1
+ntimstep = {NTIMSTEP}
+trace_time = {trace_time}
+npoiper2 = {NPOIPER2}
+notrace_passing = 0
+isw_field_type = -1
+integmode = 3
+netcdffile = '{vmec}'
+deterministic = .true.
+sbeg(1) = 0.35
+num_surf = 1
+/
+"""
+    )
+
+
+def _run_dtaumin(tmp: Path, vmec: Path, trace_time: float) -> tuple[float, float]:
+    _write_simple_in(tmp, vmec, trace_time)
+    out = subprocess.run(
+        [str(SIMPLE_EXE), "simple.in"], cwd=tmp, check=True,
+        capture_output=True, text=True,
+    ).stdout
+    line = next(ln for ln in out.splitlines() if ln.strip().startswith("tau:"))
+    nums = re.findall(r"[-+]?\d*\.?\d+(?:[eEdD][-+]?\d+)?", line.split("tau:")[1])
+    dtaumin = float(nums[1].replace("d", "e").replace("D", "e"))
+    last_t = np.loadtxt(tmp / "confined_fraction.dat")[-1, 0]
+    return dtaumin, last_t
+
+
+@pytest.mark.usefixtures("vmec_file")
+def test_dtaumin_independent_of_trace_time(tmp_path: Path, vmec_file: str) -> None:
+    if not SIMPLE_EXE.exists():
+        pytest.skip("simple.x is not built; run CMake/Ninja build first")
+    vmec = Path(vmec_file).resolve()
+
+    short = tmp_path / "short"; short.mkdir()
+    long = tmp_path / "long"; long.mkdir()
+    dt_short, t_short = _run_dtaumin(short, vmec, 10.0)
+    dt_long, t_long = _run_dtaumin(long, vmec, 100.0)
+
+    # dtaumin identical across a 10x trace_time change (was ~2x apart before the fix)
+    assert dt_short == pytest.approx(dt_long, rel=1e-12)
+    # and equal to the resolution target 2*pi*rbig/npoiper2 (rbig=1 for the TEST field)
+    assert dt_short == pytest.approx(2.0 * math.pi / NPOIPER2, rel=1e-12)
+    # the macrostep schedule still spans each requested trace_time
+    assert t_short == pytest.approx(10.0, rel=2e-2)
+    assert t_long == pytest.approx(100.0, rel=2e-2)


### PR DESCRIPTION
## Risk tier

- [x] T3: physics, output behavior, coordinate convention

## Correctness contract

### Intended behavior change

The integration microstep `dtaumin` no longer depends on `trace_time`. It was
overwritten with `dtau/ntau` (`dtau = trace_time*v0/(ntimstep-1)`), so the
physical resolution was tied to the total trace length: two runs differing only
in `trace_time` integrated at slightly different microsteps (an off-by-one in
`ntau = ceiling(dtau/dtaumin)`), and confined-fraction curves of different
length were not comparable. On the W7-X reactor case this shifted the confined
fraction ~11% at 100 ms between a 0.1 s and a 1 s run with identical start.dat.

`dtaumin` is now pinned to `2*pi*rbig/npoiper2` (resolution from `npoiper2`
alone). The total microsteps are derived from it (`nint(tau/dtaumin)`) and
distributed over the `ntimstep` output points by cumulative rounding, in both
the linear and log macrostep schedules (the log branch already did this).

### Behavior that must not change

Macrostep/output count (`ntimstep`), log-grid 10:1 spacing, and the microstep
resolution in the asymptotic regime (`dtau >> dtaumin`, i.e. large `ntau`):
there the change is < 1 part in `ntau`.

### Coordinate / unit conventions

Unchanged.

### Numerical invariants

`dtaumin` is a function of `(rbig, npoiper2)` only. Two runs differing only in
`trace_time` integrate at identical resolution.

## Tests added

- unit:
- integration: `test_dtaumin_invariance` - `dtaumin` is identical across a 10x
  `trace_time` change and equals `2*pi*rbig/npoiper2`.
- system:
- golden record: regeneration pending review (see impact).

## Golden-record impact

- [x] changed

Loss times shift. Measured against `run_main`:

- realistic fields (boozer, canonical, ...): `max|dt| ~ 9.4e-5` - the
  total-trace-time rounding on confined markers' final time. Negligible.
- analytic TEST tokamak (test_tokamak, *_classifier): large
  (`max|dt| ~ 2.5e2`). Those configs request a coarse `npoiper2` whose microstep
  the old code silently refined for short traces; the orbits are chaotic, so
  loss times decorrelate. The new resolution is exactly what `npoiper2` asks for.

All 12 golden records change for the corrected (now `trace_time`-independent)
behavior and need regeneration.

## Failure modes considered

Degenerate short traces (`tau < nintv*dtaumin`) are guarded by
`n_microsteps_total = max(nintv, nint(tau/dtaumin))` so every macrostep keeps at
least one microstep. `init_sympl` is called with `(dtaumin, dtaumin)`, so its
`dtau/dtaumin` integer check is unaffected.

## Manual validation

10/10 orbit/timestep/macrostep ctest pass (`test_macrostep_log_grid`,
`orbit_netcdf_output`, `test_orbit_chartmap_comparison`,
`test_orbit_refcoords_rk45`, ...).

## Verification

Failing-before (old `dtaumin = dtau/ntau`), TEST field npoiper2=256:

```
assert 0.0202020202020202 == 0.02405002405002405 +/- 1.0e-12   # trace_time 10 vs 100
FAILED test_dtaumin_invariance.py::test_dtaumin_independent_of_trace_time
```

Passing-after (pinned `dtaumin`):

```
test/python/test_dtaumin_invariance.py::test_dtaumin_independent_of_trace_time PASSED
```
