### PR TITLE
Align golden dependency FP contract

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,10 @@ option(SIMPLE_ENABLE_PYTHON_TOOLS "Enable Python helpers (tests/data generation)
 option(SIMPLE_ENABLE_OPENACC "Enable OpenACC offload (NVHPC only)" OFF)
 option(SIMPLE_ENABLE_DEBUG_OUTPUT "Enable debug output in hot loops" OFF)
 
+if(SIMPLE_DETERMINISTIC_FP)
+    set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+endif()
+
 if(SIMPLE_ENABLE_DEBUG_OUTPUT)
     add_compile_definitions(SIMPLE_ENABLE_DEBUG_OUTPUT)
 endif()
@@ -174,6 +178,10 @@ else()
     find_package(LAPACK REQUIRED)
 endif()
 
+if(SIMPLE_DETERMINISTIC_FP)
+    set(LIBNEO_DETERMINISTIC_FP ON CACHE BOOL
+        "Use deterministic floating-point options in libneo" FORCE)
+endif()
 find_or_fetch(libneo)
 
 # Consume the NetCDF stack libneo resolved (see comment near the top). In the

--- a/Makefile
+++ b/Makefile
@@ -78,32 +78,15 @@ test-regression: build-deterministic-nopy
 
 # Build with deterministic floating-point for regression tests
 # Keeps CODE intact so local dependency paths are respected
-# Patches libneo to also use deterministic FP (no -ffast-math)
 build-deterministic:
 	@echo "Building with deterministic FP..."
 	cmake -S . -B$(BUILD_DIR) -GNinja -DCMAKE_BUILD_TYPE=$(CONFIG) -DSIMPLE_DETERMINISTIC_FP=ON -DCMAKE_COLOR_DIAGNOSTICS=ON $(FLAGS)
-	@LIBNEO_CMAKE="$(BUILD_DIR)/_deps/libneo-src/CMakeLists.txt"; \
-	if [ -f "$$LIBNEO_CMAKE" ] && grep -q "\-ffast-math" "$$LIBNEO_CMAKE" 2>/dev/null; then \
-		echo "Patching libneo for deterministic FP..."; \
-		sed 's/-ffast-math[[:space:]]*-ffp-contract=fast/-ffp-contract=off/g' "$$LIBNEO_CMAKE" > "$$LIBNEO_CMAKE.tmp" && mv "$$LIBNEO_CMAKE.tmp" "$$LIBNEO_CMAKE"; \
-		sed 's/-ffast-math/-ffp-contract=off/g' "$$LIBNEO_CMAKE" > "$$LIBNEO_CMAKE.tmp" && mv "$$LIBNEO_CMAKE.tmp" "$$LIBNEO_CMAKE"; \
-		echo "Reconfiguring after libneo patch..."; \
-		cmake -S . -B$(BUILD_DIR) -GNinja -DCMAKE_BUILD_TYPE=$(CONFIG) -DSIMPLE_DETERMINISTIC_FP=ON -DCMAKE_COLOR_DIAGNOSTICS=ON $(FLAGS); \
-	fi
 	cmake --build $(BUILD_DIR) --config $(CONFIG)
 
 # Deterministic build matching golden record reference configuration (Python OFF)
 build-deterministic-nopy:
 	@echo "Building with deterministic FP and Python interface OFF (golden record reference)..."
 	cmake -S . -B$(BUILD_DIR) -GNinja -DCMAKE_BUILD_TYPE=$(CONFIG) -DSIMPLE_DETERMINISTIC_FP=ON -DENABLE_PYTHON_INTERFACE=OFF -DCMAKE_COLOR_DIAGNOSTICS=ON $(FLAGS)
-	@LIBNEO_CMAKE="$(BUILD_DIR)/_deps/libneo-src/CMakeLists.txt"; \
-	if [ -f "$$LIBNEO_CMAKE" ] && grep -q "\-ffast-math" "$$LIBNEO_CMAKE" 2>/dev/null; then \
-		echo "Patching libneo for deterministic FP..."; \
-		sed 's/-ffast-math[[:space:]]*-ffp-contract=fast/-ffp-contract=off/g' "$$LIBNEO_CMAKE" > "$$LIBNEO_CMAKE.tmp" && mv "$$LIBNEO_CMAKE.tmp" "$$LIBNEO_CMAKE"; \
-		sed 's/-ffast-math/-ffp-contract=off/g' "$$LIBNEO_CMAKE" > "$$LIBNEO_CMAKE.tmp" && mv "$$LIBNEO_CMAKE.tmp" "$$LIBNEO_CMAKE"; \
-		echo "Reconfiguring after libneo patch..."; \
-		cmake -S . -B$(BUILD_DIR) -GNinja -DCMAKE_BUILD_TYPE=$(CONFIG) -DSIMPLE_DETERMINISTIC_FP=ON -DENABLE_PYTHON_INTERFACE=OFF -DCMAKE_COLOR_DIAGNOSTICS=ON $(FLAGS); \
-	fi
 	cmake --build $(BUILD_DIR) --config $(CONFIG)
 
 # Run all tests including regression tests

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CONFIG ?= Release
 FLAGS ?=
 BUILD_DIR := build
+GOLDEN_LIBNEO_REF := cbb57e125390cd21ea906cc0ec9bff5b28c6fc26
 
 # Prevent ambient shell env from silently changing which libneo is fetched.
 # Pass the ref explicitly via: make ... LIBNEO_REF=<branch|tag|sha>
@@ -73,8 +74,9 @@ test-slow: build-deterministic
 	$(CTEST_CMD) -L "slow" -LE "regression|performance|scalability"
 
 # Run only regression tests (requires deterministic FP build without Python interface)
+test-regression: FLAGS += -DLIBNEO_REF=$(GOLDEN_LIBNEO_REF)
 test-regression: build-deterministic-nopy
-	$(CTEST_CMD) -L "regression"
+	export GOLDEN_LIBNEO_REF=$(GOLDEN_LIBNEO_REF); $(CTEST_CMD) -L "regression"
 
 # Build with deterministic floating-point for regression tests
 # Keeps CODE intact so local dependency paths are respected

--- a/test/golden_record/golden_record.sh
+++ b/test/golden_record/golden_record.sh
@@ -27,6 +27,7 @@ fi
 RUN_DIR_REF="$GOLDEN_RECORD_BASE_DIR/runs/run_$REF_VER"
 RUN_DIR_CUR="$GOLDEN_RECORD_BASE_DIR/runs/run_$CUR_VER"
 TEST_DATA_DIR="$GOLDEN_RECORD_BASE_DIR/test_data"
+GOLDEN_LIBNEO_REF=${GOLDEN_LIBNEO_REF:-cbb57e125390cd21ea906cc0ec9bff5b28c6fc26}
 
 # Find test cases - they should be copied by CMake to the golden_record directory
 if [ -n "$SINGLE_CASE" ]; then
@@ -113,6 +114,12 @@ main() {
     mkdir -p "$GOLDEN_RECORD_BASE_DIR"
     mkdir -p "$TEST_DATA_DIR"
 
+    local REF_CONTRACT_STAMP="$PROJECT_ROOT_REF/build/.golden-libneo-ref"
+    if [ -f "$PROJECT_ROOT_REF/build/simple.x" ] && \
+       [ "$(cat "$REF_CONTRACT_STAMP" 2>/dev/null)" != "$GOLDEN_LIBNEO_REF" ]; then
+        rm -rf "$PROJECT_ROOT_REF/build"
+    fi
+
     # Check if we need to build reference version
     if [ ! -f "$PROJECT_ROOT_REF/build/simple.x" ]; then
         echo "Reference build not found, cloning and building..."
@@ -164,18 +171,20 @@ build() {
     echo "Building SIMPLE in $PROJECT_ROOT"
     cd $PROJECT_ROOT
 
-    local REFERENCE_PATCH
-    for REFERENCE_PATCH in \
-        "$SCRIPT_DIR/reference_patches/rejected_step_state.patch" \
-        "$SCRIPT_DIR/reference_patches/physical_exit_reporting.patch" \
-        "$SCRIPT_DIR/reference_patches/canonical_map_resolution.patch"; do
-        if git apply --check "$REFERENCE_PATCH"; then
-            git apply "$REFERENCE_PATCH"
-        elif ! git apply --reverse --check "$REFERENCE_PATCH"; then
-            echo "Reference patch does not apply cleanly: $REFERENCE_PATCH"
-            return 1
-        fi
-    done
+    if ! git merge-base --is-ancestor cc5872a855820e6fa2065a5f9aa7e17604e45d77 HEAD; then
+        local REFERENCE_PATCH
+        for REFERENCE_PATCH in \
+            "$SCRIPT_DIR/reference_patches/rejected_step_state.patch" \
+            "$SCRIPT_DIR/reference_patches/physical_exit_reporting.patch" \
+            "$SCRIPT_DIR/reference_patches/canonical_map_resolution.patch"; do
+            if git apply --check "$REFERENCE_PATCH"; then
+                git apply "$REFERENCE_PATCH"
+            elif ! git apply --reverse --check "$REFERENCE_PATCH"; then
+                echo "Reference patch does not apply cleanly: $REFERENCE_PATCH"
+                return 1
+            fi
+        done
+    fi
 
     # For older versions, check if libneo is needed as a sibling directory
     if [ -f "SRC/CMakeLists.txt" ] && grep -q "../libneo" "SRC/CMakeLists.txt" 2>/dev/null; then
@@ -192,6 +201,7 @@ build() {
 
     # Enable deterministic floating-point for reproducible golden record tests
     CMAKE_OPTS="$CMAKE_OPTS -DSIMPLE_DETERMINISTIC_FP=ON -DLIBNEO_DETERMINISTIC_FP=ON"
+    CMAKE_OPTS="$CMAKE_OPTS -DLIBNEO_REF=$GOLDEN_LIBNEO_REF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
 
     cmake -S . -Bbuild -GNinja $CMAKE_OPTS > $PROJECT_ROOT/configure.log 2>&1
     if [ $? -ne 0 ]; then
@@ -207,6 +217,11 @@ build() {
         tail -n 200 "$PROJECT_ROOT/build.log" 2>/dev/null || true
         return 1
     fi
+
+    python3 "$SCRIPT_DIR/../python/test_deterministic_dependency_flags.py" \
+        "$PROJECT_ROOT/build/compile_commands.json" \
+        "$PROJECT_ROOT/build/_deps/libneo-src"
+    printf '%s\n' "$GOLDEN_LIBNEO_REF" > "$PROJECT_ROOT/build/.golden-libneo-ref"
 }
 
 

--- a/test/golden_record/golden_record.sh
+++ b/test/golden_record/golden_record.sh
@@ -191,23 +191,13 @@ build() {
     fi
 
     # Enable deterministic floating-point for reproducible golden record tests
-    CMAKE_OPTS="$CMAKE_OPTS -DSIMPLE_DETERMINISTIC_FP=ON"
+    CMAKE_OPTS="$CMAKE_OPTS -DSIMPLE_DETERMINISTIC_FP=ON -DLIBNEO_DETERMINISTIC_FP=ON"
 
     cmake -S . -Bbuild -GNinja $CMAKE_OPTS > $PROJECT_ROOT/configure.log 2>&1
     if [ $? -ne 0 ]; then
         echo "CMake configuration failed. Check $PROJECT_ROOT/configure.log"
         tail -n 200 "$PROJECT_ROOT/configure.log" 2>/dev/null || true
         return 1
-    fi
-
-    # Patch libneo CMakeLists.txt after cmake fetches it, then reconfigure
-    # (libneo doesn't have SIMPLE_DETERMINISTIC_FP, so we patch -ffast-math directly)
-    local LIBNEO_CMAKE="$PROJECT_ROOT/build/_deps/libneo-src/CMakeLists.txt"
-    if [ -f "$LIBNEO_CMAKE" ]; then
-        if patch_libneo_for_deterministic_fp "$LIBNEO_CMAKE"; then
-            echo "Reconfiguring after libneo patch..."
-            cmake -S . -Bbuild -GNinja $CMAKE_OPTS >> $PROJECT_ROOT/configure.log 2>&1
-        fi
     fi
 
     local BUILD_PARALLEL="${CMAKE_BUILD_PARALLEL_LEVEL:-2}"
@@ -217,31 +207,6 @@ build() {
         tail -n 200 "$PROJECT_ROOT/build.log" 2>/dev/null || true
         return 1
     fi
-}
-
-
-# Patch libneo CMakeLists.txt for deterministic floating-point
-# Returns 0 (success) if patching was done, 1 if no patching needed
-patch_libneo_for_deterministic_fp() {
-    local CMAKE_FILE="$1"
-
-    if [ ! -f "$CMAKE_FILE" ]; then
-        return 1
-    fi
-
-    # Check if -ffast-math is present (needs patching)
-    if ! grep -q "\-ffast-math" "$CMAKE_FILE" 2>/dev/null; then
-        return 1
-    fi
-
-    echo "Patching libneo for deterministic floating-point..."
-
-    # Replace -ffast-math -ffp-contract=fast with -ffp-contract=off
-    sed -i.bak 's/-ffast-math[[:space:]]*-ffp-contract=fast/-ffp-contract=off/g' "$CMAKE_FILE"
-    # Replace remaining standalone -ffast-math
-    sed -i.bak 's/-ffast-math/-ffp-contract=off/g' "$CMAKE_FILE"
-    echo "Patched: Replaced -ffast-math with -ffp-contract=off in libneo"
-    return 0
 }
 
 

--- a/test/python/test_deterministic_dependency_flags.py
+++ b/test/python/test_deterministic_dependency_flags.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+import json
+import pathlib
+import shlex
+import sys
+
+
+def main():
+    commands = json.loads(pathlib.Path(sys.argv[1]).read_text())
+    dependency_source = pathlib.Path(sys.argv[2]).resolve()
+    dependency_commands = []
+
+    for entry in commands:
+        source = pathlib.Path(entry["file"]).resolve()
+        if dependency_source / "src" not in source.parents:
+            continue
+        if source.suffix.lower() != ".f90":
+            continue
+        dependency_commands.append(entry["command"])
+
+    if not dependency_commands:
+        raise SystemExit("no libneo Fortran compile command found")
+
+    for command in dependency_commands:
+        options = shlex.split(command)
+        if "-ffast-math" in options:
+            raise SystemExit("libneo deterministic build enables -ffast-math")
+        if "-ffp-contract=fast" in options:
+            raise SystemExit("libneo deterministic build enables fast contraction")
+        if "-fno-fast-math" not in options:
+            raise SystemExit("libneo deterministic build lacks -fno-fast-math")
+        if "-ffp-contract=off" not in options:
+            raise SystemExit("libneo deterministic build lacks -ffp-contract=off")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -38,6 +38,19 @@ file(CREATE_LINK "${WOUT_FILE}" "${CMAKE_CURRENT_BINARY_DIR}/wout.nc" SYMBOLIC)
 file(CREATE_LINK "${WOUT_QH_FILE}" "${CMAKE_CURRENT_BINARY_DIR}/wout_qh.nc" SYMBOLIC)
 
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+if(SIMPLE_DETERMINISTIC_FP AND CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+    add_test(
+        NAME test_deterministic_dependency_flags
+        COMMAND ${Python3_EXECUTABLE}
+            ${CMAKE_CURRENT_SOURCE_DIR}/../python/test_deterministic_dependency_flags.py
+            ${CMAKE_BINARY_DIR}/compile_commands.json
+            ${libneo_SOURCE_DIR}
+    )
+    set_tests_properties(test_deterministic_dependency_flags PROPERTIES
+        LABELS "unit;regression")
+endif()
+
 set(BOOZER_CHARTMAP_PYTHON "${Python3_EXECUTABLE}")
 if(EXISTS "${CMAKE_SOURCE_DIR}/.venv/bin/python")
     set(BOOZER_CHARTMAP_PYTHON "${CMAKE_SOURCE_DIR}/.venv/bin/python")


### PR DESCRIPTION
Fixes #465

Uses the deterministic build contract merged by [libneo PR 388](https://github.com/itpplasma/libneo/pull/388) at `cbb57e1`.

## Risk tier

- [ ] T0: docs, comments, small build metadata
- [ ] T1: pure refactor, no behavior change intended
- [ ] T2: local numerical logic
- [ ] T3: physics, output behavior, coordinate convention
- [x] T4: parallelism, GPU, dependency, CI, or security-sensitive build logic

## Correctness contract

`SIMPLE_DETERMINISTIC_FP=ON` enables libneo deterministic floating point before dependency configuration. Current and golden-reference builds pin the same reachable libneo commit and assert the same strict compiler flags. Reference compatibility patches are applied only before the merged physical-exit implementation.

Default builds remain unchanged. This does not change orbit equations, integrators, discretizations, tolerances, convergence criteria, coordinates, units, fields, walls, collisions, memory layout, ABI, or generated physics code. Deterministic GNU builds retain `-O3` while disabling value-changing fast-math and contraction in SIMPLE and libneo.

## Tests added

- compile-database regression over every libneo Fortran source command
- explicit golden dependency pin and contract stamp
- existing non-Python and golden-record suites against the matching libneo revision

## Verification

### Test fails on main

```text
python3 test/python/test_deterministic_dependency_flags.py \
  build/compile_commands.json build/_deps/libneo-src
libneo deterministic build enables -ffast-math
```

### Tests pass after fix

```text
$ FO_TEST_TIMEOUT=600 fo
Static: OK
Build: OK
Tests: OK
Lint: OK
All stages passed

$ make test-regression
100% tests passed, 0 tests failed out of 15
Total Test time (real) = 1292.94 sec
```

The regression target fetches merged libneo commit `cbb57e1` for both candidate and reference builds. No baseline or tolerance changes are included.