### PR TITLE
Allow chartmap pipeline test scheduling margin

### DIFF
--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -670,7 +670,7 @@ add_test(NAME test_chartmap_pipeline
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 set_tests_properties(test_chartmap_pipeline PROPERTIES
     LABELS "unit"
-    TIMEOUT 60)
+    TIMEOUT 120)
 
 # Chartmap R,Z consistency tests
 add_executable(test_chartmap_rz_consistency.x test_chartmap_rz_consistency.f90)


### PR DESCRIPTION
## Risk tier

- [ ] T0: docs, comments, small build metadata
- [ ] T1: pure refactor, no behavior change intended
- [ ] T2: local numerical logic
- [ ] T3: physics, output behavior, coordinate convention
- [x] T4: parallelism, GPU, dependency, CI, or security-sensitive build logic

## Correctness contract

### Intended behavior change

Allow the existing chartmap pipeline test to finish under parallel test-suite
scheduling. The observed runtime is 54.47 seconds alone and 60.69 seconds in
the suite; the former 60-second limit has no scheduling margin.

### Behavior that must not change

The test executable, assertions, input grids, labels, build flags, and test
selection are unchanged. Production code is unchanged.

### Coordinate / unit conventions

Unchanged.

### Numerical invariants

Unchanged. The chartmap roundtrip, covariant-basis, and tensor-transform
assertions remain identical.

## Tests added

- unit: no new test; the existing `test_chartmap_pipeline` remains enabled
- integration: none
- system: none
- golden record: none

## Golden-record impact

- [x] unchanged
- [ ] changed

## Failure modes considered

- A slower test is not hidden: the limit remains the repository maximum of
  120 seconds.
- Assertions and datasets are not reduced.
- The test is not relabeled or excluded from the default suite.

## Manual validation

The same executable passed alone in 54.47 seconds. Under the parallel suite it
reached 60.69 seconds and was terminated only by the former timeout.

## Verification

### Test fails on main

```text
$ FO_TEST_TIMEOUT=300 fo test
test_chartmap_pipeline  TIMEOUT  60.69s
Summary: 45 passed, 1 failed, 0 skipped
```

### Test passes after fix

```text
$ make CONFIG=Fast test TEST=test_chartmap_pipeline
1/1 Test #38: test_chartmap_pipeline ... Passed 54.47 sec
100% tests passed, 0 tests failed out of 1
```
