### PR TITLE
Preserve accepted state after rejected orbit steps

### DIFF
--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -937,10 +937,11 @@ contains
             else
                 if (swcoll) call update_momentum(anorb, z)
                 call orbit_timestep_sympl(anorb%si, anorb%f, ierr_orbit)
+                if (ierr_orbit .ne. 0) exit
                 call to_standard_z_coordinates(anorb, z)
             end if
-            if (swcoll) call collide(z, dtaumin) ! Collisions
             if (ierr_orbit .ne. 0) exit
+            if (swcoll) call collide(z, dtaumin) ! Collisions
             kt = kt + 1
         end do
     end subroutine macrostep
@@ -980,10 +981,11 @@ contains
             else
                 if (swcoll) call update_momentum(anorb, z)
                 call orbit_timestep_sympl(anorb%si, anorb%f, ierr_orbit)
+                if (ierr_orbit .ne. 0) exit
                 call to_standard_z_coordinates(anorb, z)
             end if
-            if (swcoll) call collide(z, dtaumin) ! Collisions
             if (ierr_orbit .ne. 0) exit
+            if (swcoll) call collide(z, dtaumin) ! Collisions
             kt = kt + 1
 
             ! Check wall intersection periodically or at end of macrostep

--- a/test/golden_record/golden_record.sh
+++ b/test/golden_record/golden_record.sh
@@ -164,6 +164,14 @@ build() {
     echo "Building SIMPLE in $PROJECT_ROOT"
     cd $PROJECT_ROOT
 
+    local REFERENCE_PATCH="$SCRIPT_DIR/reference_patches/rejected_step_state.patch"
+    if git apply --check "$REFERENCE_PATCH"; then
+        git apply "$REFERENCE_PATCH"
+    elif ! git apply --reverse --check "$REFERENCE_PATCH"; then
+        echo "Reference patch does not apply cleanly: $REFERENCE_PATCH"
+        return 1
+    fi
+
     # For older versions, check if libneo is needed as a sibling directory
     if [ -f "SRC/CMakeLists.txt" ] && grep -q "../libneo" "SRC/CMakeLists.txt" 2>/dev/null; then
         echo "Old project structure detected, setting up libneo..."

--- a/test/golden_record/reference_patches/rejected_step_state.patch
+++ b/test/golden_record/reference_patches/rejected_step_state.patch
@@ -1,0 +1,28 @@
+diff --git a/src/simple_main.f90 b/src/simple_main.f90
+index 647cdfe..f3887bf 100644
+--- a/src/simple_main.f90
++++ b/src/simple_main.f90
+@@ -937,10 +937,11 @@ contains
+             else
+                 if (swcoll) call update_momentum(anorb, z)
+                 call orbit_timestep_sympl(anorb%si, anorb%f, ierr_orbit)
++                if (ierr_orbit .ne. 0) exit
+                 call to_standard_z_coordinates(anorb, z)
+             end if
+-            if (swcoll) call collide(z, dtaumin) ! Collisions
+             if (ierr_orbit .ne. 0) exit
++            if (swcoll) call collide(z, dtaumin) ! Collisions
+             kt = kt + 1
+         end do
+     end subroutine macrostep
+@@ -980,8 +981,9 @@ contains
+             else
+                 if (swcoll) call update_momentum(anorb, z)
+                 call orbit_timestep_sympl(anorb%si, anorb%f, ierr_orbit)
++                if (ierr_orbit .ne. 0) exit
+                 call to_standard_z_coordinates(anorb, z)
+             end if
+-            if (swcoll) call collide(z, dtaumin) ! Collisions
+             if (ierr_orbit .ne. 0) exit
++            if (swcoll) call collide(z, dtaumin) ! Collisions
+             kt = kt + 1

--- a/test/tests/test_sympl_testfield.f90
+++ b/test/tests/test_sympl_testfield.f90
@@ -1,8 +1,31 @@
+module failed_symplectic_step_backend
+  use field_can_base, only: field_can_t
+  use orbit_symplectic_base, only: symplectic_integrator_t
+
+  implicit none
+
+contains
+
+  subroutine fail_symplectic_step(si, f, ierr)
+    type(symplectic_integrator_t), intent(inout) :: si
+    type(field_can_t), intent(inout) :: f
+    integer, intent(out) :: ierr
+
+    f%Bmod = 8.0d0
+    f%vpar = 3.0d0
+    f%mu = 1.0d0
+    ierr = 1
+  end subroutine fail_symplectic_step
+
+end module failed_symplectic_step_backend
+
 program test_sympl_testfield
-  use, intrinsic :: iso_fortran_env, only : dp => real64
-  use simple_main, only : init_field
+  use, intrinsic :: iso_fortran_env, only : dp => real64, int64
+  use failed_symplectic_step_backend, only: fail_symplectic_step
+  use simple_main, only : init_field, macrostep, macrostep_with_wall_check
   use simple, only : tracer_t, init_sympl
-  use params, only : isw_field_type, field_input, coord_input, integmode
+  use params, only : isw_field_type, field_input, coord_input, integmode, &
+    swcoll, orbit_model, ORBIT_GC
   use magfie_sub, only : TEST
   use field_can_mod, only : evaluate
   use orbit_symplectic, only : orbit_timestep_sympl
@@ -42,5 +65,43 @@ program test_sympl_testfield
     stop 1
   end if
 
+  call test_failed_step_preserves_state
+
   print *, 'TEST field symplectic step succeeded'
+
+contains
+
+  subroutine test_failed_step_preserves_state
+    real(dp), parameter :: initial_state(5) = [0.2_dp, 1.0_dp, 2.0_dp, &
+      1.0_dp, 0.25_dp]
+    real(dp) :: z(5)
+    real(dp) :: x_previous(3)
+    integer(int64) :: kt
+    integer :: step_error
+
+    swcoll = .false.
+    orbit_model = ORBIT_GC
+    orbit_timestep_sympl => fail_symplectic_step
+    z = initial_state
+    kt = 0_int64
+
+    call macrostep(norb, z, kt, step_error, 1)
+
+    if (step_error /= 1) error stop 'failed step status was not preserved'
+    if (kt /= 0_int64) error stop 'failed step advanced the time index'
+    if (any(z /= initial_state)) then
+      error stop 'failed symplectic step changed the accepted state'
+    end if
+
+    z = initial_state
+    x_previous = 0.0_dp
+    kt = 0_int64
+    call macrostep_with_wall_check(norb, z, kt, step_error, 1, 1, x_previous)
+    if (step_error /= 1) error stop 'wall path lost failed step status'
+    if (kt /= 0_int64) error stop 'failed wall path advanced the time index'
+    if (any(z /= initial_state)) then
+      error stop 'failed wall path changed the accepted state'
+    end if
+  end subroutine test_failed_step_preserves_state
+
 end program test_sympl_testfield


### PR DESCRIPTION
Fixes #468

## Review context

The endpoint chain is [PR 456](https://github.com/itpplasma/SIMPLE/pull/456) accepted-state rollback -> [PR 457](https://github.com/itpplasma/SIMPLE/pull/457) solver status -> [PR 459](https://github.com/itpplasma/SIMPLE/pull/459) event location -> [PR 460](https://github.com/itpplasma/SIMPLE/pull/460) exit classification and output -> [PR 461](https://github.com/itpplasma/SIMPLE/pull/461) tolerance controls. [PR 462](https://github.com/itpplasma/SIMPLE/pull/462) changes CI scheduling only. [PR 463](https://github.com/itpplasma/SIMPLE/pull/463) adds map-resolution controls and provenance.

This PR owns the first link: a rejected trial cannot replace the last accepted orbit state. Downstream solver and event work relies on that rollback contract.

## Risk tier

- [ ] T0: docs, comments, small build metadata
- [ ] T1: pure refactor, no behavior change intended
- [ ] T2: local numerical logic
- [x] T3: physics, output behavior, coordinate convention
- [ ] T4: sensitive build or execution infrastructure

Depends on #454.

## Correctness contract

### Intended behavior change

When a symplectic microstep returns a nonzero status, keep the last accepted
standard-coordinate state. Return before field-to-standard conversion,
collision updates, wall intersection work, or time-index advancement.

### Behavior that must not change

Accepted microsteps, wall hits, collision updates after accepted steps, the
symplectic algorithm, timestep, tolerance, field evaluation, and output schema
are unchanged.

### Coordinate / unit conventions

Reference and integration coordinates, radians, normalized momentum, and SI
output units are unchanged.

### Numerical invariants

The guiding-centre Hamiltonian, source, equilibrium, symmetry, wall geometry,
and boundary conditions are unchanged. Only rejected-step commit semantics
change.

## Tests added

- unit: `test_sympl_testfield` injects a rejected symplectic step that mutates
  field scratch, then verifies both macrostep paths retain `z`, `kt`, and the
  nonzero status
- integration: existing test path
- system: none
- golden record: unchanged

## Golden-record impact

- [x] unchanged
- [ ] changed

## Failure modes considered

- rejected step followed by standard-coordinate conversion;
- collision update after rejection;
- time-index advancement after rejection; and
- the same failures in the wall-check macrostep path.

The PR does not classify the rejected step as an LCFS intersection. Boundary
event location and explicit output status remain separate work.

## Manual validation

The regression was run with the production guards removed, then restored. It
fails on the historical behavior and passes with this change.

## Verification

### Test fails on main

```text
$ make CONFIG=Fast test TEST=test_sympl_testfield
ERROR STOP failed symplectic step changed the accepted state
0% tests passed, 1 tests failed out of 1
```

### Test passes after fix

```text
$ make CONFIG=Fast test TEST=test_sympl_testfield
1/1 Test #4: test_sympl_testfield ... Passed 0.06 sec
100% tests passed, 0 tests failed out of 1
```
