### PR TITLE
Propagate implicit solver failures

### DIFF
--- a/src/orbit_symplectic.f90
+++ b/src/orbit_symplectic.f90
@@ -7,7 +7,9 @@ use field_can_mod, only: field_can_t, get_val, get_derivatives, get_derivatives2
 use orbit_symplectic_base, only: symplectic_integrator_t, multistage_integrator_t, &
   RK45, EXPL_IMPL_EULER, IMPL_EXPL_EULER, MIDPOINT, GAUSS1, GAUSS2, GAUSS3, GAUSS4, &
   LOBATTO3, S_MAX, orbit_timestep_sympl_i, extrap_field, &
-  coeff_rk_gauss, coeff_rk_lobatto, f_rk_lobatto
+  coeff_rk_gauss, coeff_rk_lobatto, f_rk_lobatto, &
+  SYMPLECTIC_STEP_OK, SYMPLECTIC_STEP_OUTSIDE_DOMAIN, &
+  SYMPLECTIC_STEP_MAXITER, SYMPLECTIC_STEP_LINEAR_SOLVE
 use orbit_symplectic_quasi, only: orbit_timestep_quasi, timestep_expl_impl_euler_quasi, &
   timestep_impl_expl_euler_quasi, timestep_midpoint_quasi, orbit_timestep_rk45, &
   timestep_rk_gauss_quasi, timestep_rk_lobatto_quasi
@@ -450,7 +452,22 @@ recursive subroutine newton2(si, f, x, atol, rtol, maxit, xlast)
   call count_event(EVT_NEWTON2_MAXIT)
 end subroutine
 
-recursive subroutine newton_midpoint(si, f, x, atol, rtol, maxit, xlast)
+subroutine solve_newton_system(matrix, residual, status)
+  real(dp), intent(inout) :: matrix(:, :), residual(:)
+  integer, intent(out) :: status
+
+  integer :: info, n, pivot(size(residual))
+
+  n = size(residual)
+  call dgesv(n, 1, matrix, n, pivot, residual, n, info)
+  if (info == 0) then
+    status = SYMPLECTIC_STEP_OK
+  else
+    status = SYMPLECTIC_STEP_LINEAR_SOLVE
+  end if
+end subroutine solve_newton_system
+
+recursive subroutine newton_midpoint(si, f, x, atol, rtol, maxit, xlast, status)
   type(symplectic_integrator_t), intent(inout) :: si
   type(field_can_t), intent(inout) :: f
 
@@ -463,11 +480,14 @@ recursive subroutine newton_midpoint(si, f, x, atol, rtol, maxit, xlast)
   real(dp), intent(in) :: atol, rtol
   integer, intent(in) :: maxit
   real(dp), intent(out) :: xlast(n)
+  integer, intent(out) :: status
 
   real(dp) :: fvec(n), fjac(n,n)
-  integer :: pivot(n), info
 
   real(dp) :: xabs(n), tolref(n), fabs(n)
+
+  xlast = x
+  status = SYMPLECTIC_STEP_MAXITER
 
   tolref(1) = 1d0
   tolref(2) = twopi
@@ -476,7 +496,10 @@ recursive subroutine newton_midpoint(si, f, x, atol, rtol, maxit, xlast)
   tolref(5) = 1d0
 
   do kit = 1, maxit
-    if(x(1) > 1.0) return
+    if(x(1) > 1.0 .or. x(5) > 1.0) then
+      status = SYMPLECTIC_STEP_OUTSIDE_DOMAIN
+      return
+    end if
     ! Transient guards for intermediate iterates; the converged-negative
     ! case is handled by the caller via a chart switch (#370).
     if(x(1) < 0.0) x(1) = 0.01
@@ -488,16 +511,28 @@ recursive subroutine newton_midpoint(si, f, x, atol, rtol, maxit, xlast)
     call jac_midpoint_part2(si, f, fmid, x, fjac)
     fabs = dabs(fvec)
     xlast = x
-    call dgesv(n, 1, fjac, n, pivot, fvec, n, info)
+    call solve_newton_system(fjac, fvec, status)
+    if (status /= SYMPLECTIC_STEP_OK) return
+    status = SYMPLECTIC_STEP_MAXITER
     ! after solution: fvec = (xold-xnew)_Newton
     x = x - fvec
+    if (x(1) > 1d0 .or. x(5) > 1d0) then
+      status = SYMPLECTIC_STEP_OUTSIDE_DOMAIN
+      return
+    end if
     xabs = dabs(x - xlast)
 
     ! Don't take too small values in pphi as tolerance reference
     tolref(4) = max(dabs(x(4)), tolref(4))
 
-    if (all(fabs < atol)) return
-    if (all(xabs < rtol*tolref)) return
+    if (all(fabs < atol)) then
+      status = SYMPLECTIC_STEP_OK
+      return
+    end if
+    if (all(xabs < rtol*tolref)) then
+      status = SYMPLECTIC_STEP_OK
+      return
+    end if
   enddo
 end subroutine
 
@@ -533,7 +568,7 @@ recursive subroutine jac_rk_gauss(si, fs, s, jac)
 
 end subroutine jac_rk_gauss
 
-recursive subroutine newton_rk_gauss(si, fs, s, x, atol, rtol, maxit, xlast)
+recursive subroutine newton_rk_gauss(si, fs, s, x, atol, rtol, maxit, xlast, status)
   type(symplectic_integrator_t), intent(inout) :: si
 
   integer, intent(in) :: s
@@ -544,17 +579,23 @@ recursive subroutine newton_rk_gauss(si, fs, s, x, atol, rtol, maxit, xlast)
   real(dp), intent(in) :: atol, rtol
   integer, intent(in) :: maxit
   real(dp), intent(out) :: xlast(4*s)
+  integer, intent(out) :: status
 
   real(dp) :: fvec(4*s), fjac(4*s, 4*s)
-  integer :: pivot(4*s), info
 
   real(dp) :: xabs(4*s), tolref(4*s), fabs(4*s)
+
+  xlast = x
+  status = SYMPLECTIC_STEP_MAXITER
 
   do kit = 1, maxit
 
     ! Check if radius left the boundary
     do ks = 1, s
-      if (x(4*ks-3) > 1d0) return
+      if (x(4*ks-3) > 1d0) then
+        status = SYMPLECTIC_STEP_OUTSIDE_DOMAIN
+        return
+      end if
       ! Transient guard for intermediate iterates; the converged-negative
       ! case is handled by the caller via a chart switch (#370).
       if (x(4*ks-3) < 0.0) x(4*ks-3) = 0.01d0
@@ -564,9 +605,17 @@ recursive subroutine newton_rk_gauss(si, fs, s, x, atol, rtol, maxit, xlast)
     call jac_rk_gauss(si, fs, s, fjac)
     fabs = dabs(fvec)
     xlast = x
-    call dgesv(4*s, 1, fjac, 4*s, pivot, fvec, 4*s, info)
+    call solve_newton_system(fjac, fvec, status)
+    if (status /= SYMPLECTIC_STEP_OK) return
+    status = SYMPLECTIC_STEP_MAXITER
     ! after solution: fvec = (xold-xnew)_Newton
     x = x - fvec
+    do ks = 1, s
+      if (x(4*ks-3) > 1d0) then
+        status = SYMPLECTIC_STEP_OUTSIDE_DOMAIN
+        return
+      end if
+    end do
     xabs = dabs(x - xlast)
 
     do ks = 1, s
@@ -576,8 +625,14 @@ recursive subroutine newton_rk_gauss(si, fs, s, x, atol, rtol, maxit, xlast)
       tolref(4*ks) = dabs(xlast(4*ks))
     end do
 
-    if (all(fabs < atol)) return
-    if (all(xabs < rtol*tolref)) return
+    if (all(fabs < atol)) then
+      status = SYMPLECTIC_STEP_OK
+      return
+    end if
+    if (all(xabs < rtol*tolref)) then
+      status = SYMPLECTIC_STEP_OK
+      return
+    end if
   enddo
   call count_event(EVT_RK_GAUSS_MAXIT)
 end subroutine newton_rk_gauss
@@ -812,8 +867,32 @@ recursive subroutine jac_rk_lobatto(si, fs, s, jac)
   end do
 end subroutine jac_rk_lobatto
 
+subroutine guard_lobatto_stage_radii(x, s, status)
+  integer, intent(in) :: s
+  real(dp), intent(inout) :: x(4*s-2)
+  integer, intent(out) :: status
 
-recursive subroutine newton_rk_lobatto(si, fs, s, x, atol, rtol, maxit, xlast)
+  integer :: ks, radius_index
+
+  status = SYMPLECTIC_STEP_OK
+  if (x(1) > 1d0) then
+    status = SYMPLECTIC_STEP_OUTSIDE_DOMAIN
+    return
+  end if
+  if (x(1) < 0d0) x(1) = 0.01d0
+
+  do ks = 2, s
+    radius_index = 4*ks - 5
+    if (x(radius_index) > 1d0) then
+      status = SYMPLECTIC_STEP_OUTSIDE_DOMAIN
+      return
+    end if
+    if (x(radius_index) < 0d0) x(radius_index) = 0.01d0
+  end do
+end subroutine guard_lobatto_stage_radii
+
+
+recursive subroutine newton_rk_lobatto(si, fs, s, x, atol, rtol, maxit, xlast, status)
   type(symplectic_integrator_t), intent(inout) :: si
 
   integer, intent(in) :: s
@@ -824,30 +903,40 @@ recursive subroutine newton_rk_lobatto(si, fs, s, x, atol, rtol, maxit, xlast)
   real(dp), intent(in) :: atol, rtol
   integer, intent(in) :: maxit
   real(dp), intent(out) :: xlast(4*s-2)
+  integer, intent(out) :: status
 
   real(dp) :: fvec(4*s-2), fjac(4*s-2, 4*s-2)
-  integer :: pivot(4*s-2), info
 
   real(dp) :: xabs(4*s-2), tolref(4*s-2), fabs(4*s-2)
 
+  xlast = x
+  status = SYMPLECTIC_STEP_MAXITER
+
   do kit = 1, maxit
 
-    ! Check if radius left the boundary
-    if (x(1) > 1d0) return
-    ! Transient guard for intermediate iterates (#370).
-    if (x(1) < 0.0) x(1) = 0.01d0
-    do ks = 2, s
-      if (x(4*ks-2-3) > 1d0) return
-      if (x(4*ks-2-3) < 0.0) x(4*ks-3) = 0.01d0
-    end do
+    call guard_lobatto_stage_radii(x, s, status)
+    if (status /= SYMPLECTIC_STEP_OK) return
+    status = SYMPLECTIC_STEP_MAXITER
 
     call f_rk_lobatto(si, fs, s, x, fvec, 2)
     call jac_rk_lobatto(si, fs, s, fjac)
     fabs = dabs(fvec)
     xlast = x
-    call dgesv(4*s-2, 1, fjac, 4*s-2, pivot, fvec, 4*s-2, info)
+    call solve_newton_system(fjac, fvec, status)
+    if (status /= SYMPLECTIC_STEP_OK) return
+    status = SYMPLECTIC_STEP_MAXITER
     ! after solution: fvec = (xold-xnew)_Newton
     x = x - fvec
+    if (x(1) > 1d0) then
+      status = SYMPLECTIC_STEP_OUTSIDE_DOMAIN
+      return
+    end if
+    do ks = 2, s
+      if (x(4*ks-5) > 1d0) then
+        status = SYMPLECTIC_STEP_OUTSIDE_DOMAIN
+        return
+      end if
+    end do
     xabs = dabs(x - xlast)
 
     tolref(1) = 1d0
@@ -859,8 +948,14 @@ recursive subroutine newton_rk_lobatto(si, fs, s, x, atol, rtol, maxit, xlast)
       tolref(4*ks-2) = dabs(xlast(4*ks-2))
     end do
 
-    if (all(fabs < atol)) return
-    if (all(xabs < rtol*tolref)) return
+    if (all(fabs < atol)) then
+      status = SYMPLECTIC_STEP_OK
+      return
+    end if
+    if (all(xabs < rtol*tolref)) then
+      status = SYMPLECTIC_STEP_OK
+      return
+    end if
   enddo
   call count_event(EVT_RK_LOBATTO_MAXIT)
 end subroutine newton_rk_lobatto
@@ -1257,17 +1352,28 @@ recursive subroutine orbit_timestep_sympl_midpoint(si, f, ierr)
   integer, parameter :: maxit = 8
 
   real(dp), dimension(n) :: x, xlast
-  integer :: ktau
+  integer :: ktau, newton_status
+  type(symplectic_integrator_t) :: accepted_integrator
+  type(field_can_t) :: accepted_field
 
   ierr = 0
   ktau = 0
   do while(ktau .lt. si%ntau)
+    accepted_integrator = si
+    accepted_field = f
     si%pthold = f%pth
 
     x(1:4) = si%z
     x(5) = si%z(1)
 
-    call newton_midpoint(si, f, x, si%atol, si%rtol, maxit, xlast)
+    call newton_midpoint(si, f, x, si%atol, si%rtol, maxit, xlast, &
+      newton_status)
+    if (newton_status /= SYMPLECTIC_STEP_OK) then
+      si = accepted_integrator
+      f = accepted_field
+      ierr = newton_status
+      return
+    end if
 
     if (x(1) > 1.0) then
       ierr = 1
@@ -1317,9 +1423,11 @@ recursive subroutine orbit_timestep_sympl_rk_gauss(si, f, s, ierr)
 
   integer, intent(in) :: s
   real(dp), dimension(4*s) :: x, xlast
-  integer :: k, l, ktau
+  integer :: k, l, ktau, newton_status
 
   type(field_can_t) :: fs(s)
+  type(field_can_t) :: accepted_field
+  type(symplectic_integrator_t) :: accepted_integrator
   real(dp) :: a(s,s), b(s), c(s), Hprime(s), dz(4*s)
 
   do k = 1,s
@@ -1330,13 +1438,22 @@ recursive subroutine orbit_timestep_sympl_rk_gauss(si, f, s, ierr)
   ierr = 0
   ktau = 0
   do while(ktau .lt. si%ntau)
+    accepted_integrator = si
+    accepted_field = f
     si%pthold = f%pth
 
     do k = 1,s
       x((4*k-3):(4*k)) = si%z
     end do
 
-    call newton_rk_gauss(si, fs, s, x, si%atol, si%rtol, maxit, xlast)
+    call newton_rk_gauss(si, fs, s, x, si%atol, si%rtol, maxit, xlast, &
+      newton_status)
+    if (newton_status /= SYMPLECTIC_STEP_OK) then
+      si = accepted_integrator
+      f = accepted_field
+      ierr = newton_status
+      return
+    end if
     !optionally try fixed point iterations, doesn't work yet
     !call fixpoint_rk_gauss(si, fs, s, x, si%atol, si%rtol, maxit, xlast)
 
@@ -1453,9 +1570,11 @@ recursive subroutine orbit_timestep_sympl_rk_lobatto(si, f, s, ierr)
 
   integer, intent(in) :: s
   real(dp), dimension(4*s-2) :: x, xlast
-  integer :: ktau, k, l
+  integer :: ktau, k, l, newton_status
 
   type(field_can_t) :: fs(s)
+  type(field_can_t) :: accepted_field
+  type(symplectic_integrator_t) :: accepted_integrator
   real(dp) :: a(s,s), ahat(s,s), b(s), c(s), Hprime(s)
 
   do k = 1,s
@@ -1465,6 +1584,8 @@ recursive subroutine orbit_timestep_sympl_rk_lobatto(si, f, s, ierr)
   ierr = 0
   ktau = 0
   do while(ktau .lt. si%ntau)
+    accepted_integrator = si
+    accepted_field = f
     si%pthold = f%pth
 
     x(1) = si%z(1)
@@ -1473,7 +1594,14 @@ recursive subroutine orbit_timestep_sympl_rk_lobatto(si, f, s, ierr)
       x((4*k-3-2):(4*k-2)) = si%z
     end do
 
-    call newton_rk_lobatto(si, fs, s, x, si%atol, si%rtol, maxit, xlast)
+    call newton_rk_lobatto(si, fs, s, x, si%atol, si%rtol, maxit, xlast, &
+      newton_status)
+    if (newton_status /= SYMPLECTIC_STEP_OK) then
+      si = accepted_integrator
+      f = accepted_field
+      ierr = newton_status
+      return
+    end if
 
     call coeff_rk_lobatto(s, a, ahat, b, c)
 

--- a/src/orbit_symplectic_base.f90
+++ b/src/orbit_symplectic_base.f90
@@ -12,6 +12,10 @@ use field_can_mod, only: eval_field => evaluate, field_can_t, get_val, get_deriv
     ! Integration methods
     integer, parameter :: RK45 = 0, EXPL_IMPL_EULER = 1, IMPL_EXPL_EULER = 2, &
              MIDPOINT = 3, GAUSS1 = 4, GAUSS2 = 5, GAUSS3 = 6, GAUSS4 = 7, LOBATTO3 = 15
+    integer, parameter :: SYMPLECTIC_STEP_OK = 0
+    integer, parameter :: SYMPLECTIC_STEP_OUTSIDE_DOMAIN = 1
+    integer, parameter :: SYMPLECTIC_STEP_MAXITER = 2
+    integer, parameter :: SYMPLECTIC_STEP_LINEAR_SOLVE = 3
 
     type :: symplectic_integrator_t
         real(dp) :: atol

--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -937,10 +937,11 @@ contains
             else
                 if (swcoll) call update_momentum(anorb, z)
                 call orbit_timestep_sympl(anorb%si, anorb%f, ierr_orbit)
+                if (ierr_orbit .ne. 0) exit
                 call to_standard_z_coordinates(anorb, z)
             end if
-            if (swcoll) call collide(z, dtaumin) ! Collisions
             if (ierr_orbit .ne. 0) exit
+            if (swcoll) call collide(z, dtaumin) ! Collisions
             kt = kt + 1
         end do
     end subroutine macrostep
@@ -980,10 +981,11 @@ contains
             else
                 if (swcoll) call update_momentum(anorb, z)
                 call orbit_timestep_sympl(anorb%si, anorb%f, ierr_orbit)
+                if (ierr_orbit .ne. 0) exit
                 call to_standard_z_coordinates(anorb, z)
             end if
-            if (swcoll) call collide(z, dtaumin) ! Collisions
             if (ierr_orbit .ne. 0) exit
+            if (swcoll) call collide(z, dtaumin) ! Collisions
             kt = kt + 1
 
             ! Check wall intersection periodically or at end of macrostep

--- a/test/golden_record/golden_record.sh
+++ b/test/golden_record/golden_record.sh
@@ -164,6 +164,14 @@ build() {
     echo "Building SIMPLE in $PROJECT_ROOT"
     cd $PROJECT_ROOT
 
+    local REFERENCE_PATCH="$SCRIPT_DIR/reference_patches/rejected_step_state.patch"
+    if git apply --check "$REFERENCE_PATCH"; then
+        git apply "$REFERENCE_PATCH"
+    elif ! git apply --reverse --check "$REFERENCE_PATCH"; then
+        echo "Reference patch does not apply cleanly: $REFERENCE_PATCH"
+        return 1
+    fi
+
     # For older versions, check if libneo is needed as a sibling directory
     if [ -f "SRC/CMakeLists.txt" ] && grep -q "../libneo" "SRC/CMakeLists.txt" 2>/dev/null; then
         echo "Old project structure detected, setting up libneo..."

--- a/test/golden_record/reference_patches/rejected_step_state.patch
+++ b/test/golden_record/reference_patches/rejected_step_state.patch
@@ -1,0 +1,28 @@
+diff --git a/src/simple_main.f90 b/src/simple_main.f90
+index 647cdfe..f3887bf 100644
+--- a/src/simple_main.f90
++++ b/src/simple_main.f90
+@@ -937,10 +937,11 @@ contains
+             else
+                 if (swcoll) call update_momentum(anorb, z)
+                 call orbit_timestep_sympl(anorb%si, anorb%f, ierr_orbit)
++                if (ierr_orbit .ne. 0) exit
+                 call to_standard_z_coordinates(anorb, z)
+             end if
+-            if (swcoll) call collide(z, dtaumin) ! Collisions
+             if (ierr_orbit .ne. 0) exit
++            if (swcoll) call collide(z, dtaumin) ! Collisions
+             kt = kt + 1
+         end do
+     end subroutine macrostep
+@@ -980,8 +981,9 @@ contains
+             else
+                 if (swcoll) call update_momentum(anorb, z)
+                 call orbit_timestep_sympl(anorb%si, anorb%f, ierr_orbit)
++                if (ierr_orbit .ne. 0) exit
+                 call to_standard_z_coordinates(anorb, z)
+             end if
+-            if (swcoll) call collide(z, dtaumin) ! Collisions
+             if (ierr_orbit .ne. 0) exit
++            if (swcoll) call collide(z, dtaumin) ! Collisions
+             kt = kt + 1

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -589,6 +589,10 @@ add_executable(test_orbit_symplectic_base.x test_orbit_symplectic_base.f90)
 target_link_libraries(test_orbit_symplectic_base.x simple)
 add_test(NAME test_orbit_symplectic_base COMMAND test_orbit_symplectic_base.x)
 
+add_executable(test_newton_solver_status.x test_newton_solver_status.f90)
+target_link_libraries(test_newton_solver_status.x simple)
+add_test(NAME test_newton_solver_status COMMAND test_newton_solver_status.x)
+
 add_executable(test_field_base.x test_field_base.f90)
 target_link_libraries(test_field_base.x simple)
 add_test(NAME test_field_base COMMAND test_field_base.x)

--- a/test/tests/test_newton_solver_status.f90
+++ b/test/tests/test_newton_solver_status.f90
@@ -1,0 +1,74 @@
+program test_newton_solver_status
+  use, intrinsic :: iso_fortran_env, only: dp => real64
+  use field_can_mod, only: field_can_t
+  use orbit_symplectic, only: guard_lobatto_stage_radii, newton_midpoint, &
+    solve_newton_system
+  use orbit_symplectic_base, only: symplectic_integrator_t, &
+    SYMPLECTIC_STEP_OK, SYMPLECTIC_STEP_OUTSIDE_DOMAIN, &
+    SYMPLECTIC_STEP_MAXITER, SYMPLECTIC_STEP_LINEAR_SOLVE
+
+  implicit none
+
+  type(symplectic_integrator_t) :: integrator
+  type(field_can_t) :: field
+  real(dp) :: x(5), xlast(5), matrix(2, 2), residual(2)
+  real(dp) :: lobatto_state(10), expected_lobatto_state(10)
+  integer :: i, status
+
+  field%Aph = 0.0_dp
+  field%ro0 = 1.0_dp
+  x = [0.5_dp, 0.1_dp, 0.2_dp, 0.3_dp, 0.5_dp]
+  call newton_midpoint(integrator, field, x, 1.0e-15_dp, 1.0e-12_dp, &
+    0, xlast, status)
+  if (status /= SYMPLECTIC_STEP_MAXITER) then
+    error stop 'zero-iteration midpoint solve did not report max iterations'
+  end if
+  if (any(xlast /= x)) error stop 'zero-iteration solve changed the iterate'
+
+  x(1) = 1.1_dp
+  call newton_midpoint(integrator, field, x, 1.0e-15_dp, 1.0e-12_dp, &
+    1, xlast, status)
+  if (status /= SYMPLECTIC_STEP_OUTSIDE_DOMAIN) then
+    error stop 'exterior midpoint iterate did not report its domain failure'
+  end if
+
+  matrix = 0.0_dp
+  residual = 1.0_dp
+  call solve_newton_system(matrix, residual, status)
+  if (status /= SYMPLECTIC_STEP_LINEAR_SOLVE) then
+    error stop 'singular Newton system did not report its LAPACK failure'
+  end if
+
+  matrix = 0.0_dp
+  matrix(1, 1) = 1.0_dp
+  matrix(2, 2) = 1.0_dp
+  residual = [2.0_dp, -3.0_dp]
+  call solve_newton_system(matrix, residual, status)
+  if (status /= SYMPLECTIC_STEP_OK) then
+    error stop 'nonsingular Newton system reported a failure'
+  end if
+  if (any(residual /= [2.0_dp, -3.0_dp])) then
+    error stop 'Newton system returned the wrong correction'
+  end if
+
+  lobatto_state = [(-0.1_dp*real(i, dp), i = 1, 10)]
+  lobatto_state(1) = -0.2_dp
+  lobatto_state(3) = -0.4_dp
+  lobatto_state(7) = 0.7_dp
+  expected_lobatto_state = lobatto_state
+  expected_lobatto_state(1) = 0.01_dp
+  expected_lobatto_state(3) = 0.01_dp
+  call guard_lobatto_stage_radii(lobatto_state, 3, status)
+  if (status /= SYMPLECTIC_STEP_OK) then
+    error stop 'valid Lobatto stage radii reported a domain failure'
+  end if
+  if (any(lobatto_state /= expected_lobatto_state)) then
+    error stop 'Lobatto radius guard changed a nonradial stage component'
+  end if
+
+  lobatto_state(7) = 1.1_dp
+  call guard_lobatto_stage_radii(lobatto_state, 3, status)
+  if (status /= SYMPLECTIC_STEP_OUTSIDE_DOMAIN) then
+    error stop 'exterior Lobatto stage did not report its domain failure'
+  end if
+end program test_newton_solver_status

--- a/test/tests/test_sympl_testfield.f90
+++ b/test/tests/test_sympl_testfield.f90
@@ -1,8 +1,31 @@
+module failed_symplectic_step_backend
+  use field_can_base, only: field_can_t
+  use orbit_symplectic_base, only: symplectic_integrator_t
+
+  implicit none
+
+contains
+
+  subroutine fail_symplectic_step(si, f, ierr)
+    type(symplectic_integrator_t), intent(inout) :: si
+    type(field_can_t), intent(inout) :: f
+    integer, intent(out) :: ierr
+
+    f%Bmod = 8.0d0
+    f%vpar = 3.0d0
+    f%mu = 1.0d0
+    ierr = 1
+  end subroutine fail_symplectic_step
+
+end module failed_symplectic_step_backend
+
 program test_sympl_testfield
-  use, intrinsic :: iso_fortran_env, only : dp => real64
-  use simple_main, only : init_field
+  use, intrinsic :: iso_fortran_env, only : dp => real64, int64
+  use failed_symplectic_step_backend, only: fail_symplectic_step
+  use simple_main, only : init_field, macrostep, macrostep_with_wall_check
   use simple, only : tracer_t, init_sympl
-  use params, only : isw_field_type, field_input, coord_input, integmode
+  use params, only : isw_field_type, field_input, coord_input, integmode, &
+    swcoll, orbit_model, ORBIT_GC
   use magfie_sub, only : TEST
   use field_can_mod, only : evaluate
   use orbit_symplectic, only : orbit_timestep_sympl
@@ -42,5 +65,43 @@ program test_sympl_testfield
     stop 1
   end if
 
+  call test_failed_step_preserves_state
+
   print *, 'TEST field symplectic step succeeded'
+
+contains
+
+  subroutine test_failed_step_preserves_state
+    real(dp), parameter :: initial_state(5) = [0.2_dp, 1.0_dp, 2.0_dp, &
+      1.0_dp, 0.25_dp]
+    real(dp) :: z(5)
+    real(dp) :: x_previous(3)
+    integer(int64) :: kt
+    integer :: step_error
+
+    swcoll = .false.
+    orbit_model = ORBIT_GC
+    orbit_timestep_sympl => fail_symplectic_step
+    z = initial_state
+    kt = 0_int64
+
+    call macrostep(norb, z, kt, step_error, 1)
+
+    if (step_error /= 1) error stop 'failed step status was not preserved'
+    if (kt /= 0_int64) error stop 'failed step advanced the time index'
+    if (any(z /= initial_state)) then
+      error stop 'failed symplectic step changed the accepted state'
+    end if
+
+    z = initial_state
+    x_previous = 0.0_dp
+    kt = 0_int64
+    call macrostep_with_wall_check(norb, z, kt, step_error, 1, 1, x_previous)
+    if (step_error /= 1) error stop 'wall path lost failed step status'
+    if (kt /= 0_int64) error stop 'failed wall path advanced the time index'
+    if (any(z /= initial_state)) then
+      error stop 'failed wall path changed the accepted state'
+    end if
+  end subroutine test_failed_step_preserves_state
+
 end program test_sympl_testfield


### PR DESCRIPTION
Fixes #469

## Review context

The endpoint chain is [PR 456](https://github.com/itpplasma/SIMPLE/pull/456) accepted-state rollback -> [PR 457](https://github.com/itpplasma/SIMPLE/pull/457) solver status -> [PR 459](https://github.com/itpplasma/SIMPLE/pull/459) event location -> [PR 460](https://github.com/itpplasma/SIMPLE/pull/460) exit classification and output -> [PR 461](https://github.com/itpplasma/SIMPLE/pull/461) tolerance controls. [PR 462](https://github.com/itpplasma/SIMPLE/pull/462) changes CI scheduling only. [PR 463](https://github.com/itpplasma/SIMPLE/pull/463) adds map-resolution controls and provenance.

This PR consumes PR 456's rollback rule and makes nonlinear failures observable. It does not locate or classify physical boundary events; PRs 459 and 460 own those contracts.

Depends on #456.

## Risk tier

- [ ] T0: docs, comments, small build metadata
- [ ] T1: pure refactor, no behavior change intended
- [ ] T2: local numerical logic
- [x] T3: physics, output behavior, coordinate convention
- [ ] T4: sensitive build or execution infrastructure

## Correctness contract

Midpoint, Gauss, and Lobatto Newton solves now return distinct statuses for an exterior iterate, iteration exhaustion, and LAPACK failure. A rejected solve restores the accepted integrator and field state before returning. `dgesv` corrections are applied only when `info=0`.

Successful steps retain the same nonlinear equations and update order. Their tolerances and iteration limits are unchanged. The physical problem, timestep, coordinate conventions, and units are unchanged. The top-level timestep interface and derived-type memory layout are also unchanged. Internal Newton procedure signatures gain a status result and all repository callers are rebuilt.

The patch also corrects the Lobatto stage layout invariant. For stage `k>=2`, the radius is at `4*k-5`; the old negative-radius guard wrote `4*k-3`, which is the toroidal-angle slot. The correction changes only this invalid intermediate-iterate path and leaves angular periodicity unchanged.

## Tests added

- zero-iteration midpoint status
- exterior midpoint status
- singular and nonsingular LAPACK systems
- Lobatto stage-radius indexing and nonradial-component preservation

## Verification

### Test fails before fix

```text
test_newton_solver_status.f90: Error: Symbol 'symplectic_step_maxiter' has no IMPLICIT type
test_newton_solver_status.f90: Error: More actual than formal arguments in procedure call
ninja: build stopped: subcommand failed
```

The pre-fix Lobatto guard also changes the stage-2 toroidal-angle component instead of flooring its negative radius.

### Test passes after fix

```text
test_newton_solver_status ... Passed
100% tests passed, 0 tests failed out of 1

make test-nopy
100% tests passed, 0 tests failed out of 54
```

The full gate used four build CPUs and completed with 10.5 GB peak memory.
