### PR TITLE
Remove unused Fortran imports

### DIFF
--- a/app/simple_diag_meiss.f90
+++ b/app/simple_diag_meiss.f90
@@ -9,7 +9,7 @@ use params, only: read_config, netcdffile, ns_s, ns_tp, multharm, integmode, par
     use timing, only: init_timer, print_phase_time
     use diag_meiss, only: plot_rh_can_vs_rc
     use field_can_mod, only: field_can_from_id
-    use field, only: field_from_file, vmec_field_t, create_vmec_field
+    use field, only: vmec_field_t, create_vmec_field
     use field_can_meiss, only: init_transformation_arrays
 
     implicit none

--- a/app/simple_diag_orbit.f90
+++ b/app/simple_diag_orbit.f90
@@ -8,14 +8,14 @@ program diag_orbit_main
     use params, only: read_config, netcdffile, ns_s, ns_tp, multharm, &
    integmode, params_init, isw_field_type, dtaumin, relerr, ntestpart, ntimstep, ntau, &
          zstart, startmode, grid_density, special_ants_file, reuse_batch, num_surf, sbeg
-    use simple, only: tracer_t, init_sympl
+    use simple, only: tracer_t
     use simple_main, only: init_field
     use magfie_sub, only: init_magfie, VMEC
     use samplers, only: init_starting_surf, sample, START_FILE
     use timing, only: init_timer, print_phase_time
     use diag_orbit, only: integrate_orbit_with_trajectory_debug
     use orbit_symplectic_base, only: symplectic_integrator_t
-    use field_can_mod, only: field_can_t, get_val, eval_field => evaluate
+    use field_can_mod, only: field_can_t
 
     implicit none
 

--- a/app/simple_diag_traj.f90
+++ b/app/simple_diag_traj.f90
@@ -18,7 +18,7 @@ program diag_traj_main
     use simple_main, only: init_field
     use magfie_sub, only: init_magfie, VMEC
     use samplers, only: init_starting_surf, sample, START_FILE
-    use field_can_mod, only: field_can_t, get_val, eval_field => evaluate, ref_to_integ
+    use field_can_mod, only: field_can_t, get_val, ref_to_integ
     use orbit_symplectic, only: orbit_timestep_sympl
     use orbit_symplectic_base, only: symplectic_integrator_t
     use alpha_lifetime_sub, only: orbit_timestep_axis

--- a/examples/fortran/orbit_symplectic_test.f90
+++ b/examples/fortran/orbit_symplectic_test.f90
@@ -3,7 +3,7 @@ program orbit_symplectic_test
     use field_can_mod, only: eval_field
     use diag_mod, only: icounter
 
-    use orbit_symplectic, only: orbit_sympl_init, orbit_timestep_sympl, &
+    use orbit_symplectic, only: orbit_timestep_sympl, &
                                 mu, ro0, f, df, d2f, z, pth, ntau
 
     implicit none

--- a/src/coordinates/array_utils.f90
+++ b/src/coordinates/array_utils.f90
@@ -1,5 +1,4 @@
 module array_utils
-    use, intrinsic :: iso_fortran_env, only: dp => real64
     implicit none
 
     private

--- a/src/coordinates/stencil_utils.f90
+++ b/src/coordinates/stencil_utils.f90
@@ -1,5 +1,4 @@
 module stencil_utils
-    use, intrinsic :: iso_fortran_env, only: dp => real64
     implicit none
 
     private

--- a/src/diag/diag_meiss.f90
+++ b/src/diag/diag_meiss.f90
@@ -4,7 +4,7 @@ module diag_meiss
 !> Provides visualization and analysis tools for canonical coordinate transformations
 
     use, intrinsic :: iso_fortran_env, only: dp => real64
-    use field_can_meiss, only: rh_can, grid_indices_t, n_r, xmin, xmax, h_r
+    use field_can_meiss, only: rh_can, n_r, xmin, xmax
     use fortplot, only: figure, plot, savefig, xlabel, ylabel, title
 
     implicit none

--- a/src/diag/diag_newton.f90
+++ b/src/diag/diag_newton.f90
@@ -4,7 +4,7 @@ module diag_newton
 !> during orbit integration using midpoint rule
 
     use, intrinsic :: iso_fortran_env, only: dp => real64
-    use util, only: pi, twopi
+    use util, only: twopi
     use field_can_mod, only: field_can_t, get_val, eval_field => evaluate
     use orbit_symplectic_base, only: symplectic_integrator_t
     use vector_potentail_mod, only: torflux

--- a/src/diag/diag_orbit.f90
+++ b/src/diag/diag_orbit.f90
@@ -4,12 +4,11 @@ module diag_orbit
 !> full SIMPLE initialization and real orbit integration
 
     use, intrinsic :: iso_fortran_env, only: dp => real64
-use params, only: dtau, dtaumin, ntestpart, ntimstep, ntau, zstart, startmode, grid_density, &
+use params, only: dtaumin, ntestpart, ntimstep, ntau, zstart, &
     special_ants_file, reuse_batch, num_surf, sbeg, integmode, relerr, reset_seed_if_deterministic
-    use samplers, only: sample, START_FILE
     use field_can_mod, only: field_can_t, get_val, eval_field => evaluate, ref_to_integ
     use orbit_symplectic_base, only: symplectic_integrator_t, extrap_field
- use orbit_symplectic, only: orbit_timestep_sympl, f_midpoint_part1, f_midpoint_part2, &
+ use orbit_symplectic, only: f_midpoint_part1, f_midpoint_part2, &
                                 jac_midpoint_part1, jac_midpoint_part2
     use simple, only: init_sympl
     use vector_potentail_mod, only: torflux

--- a/test/tests/export_boozer_chartmap_tool.f90
+++ b/test/tests/export_boozer_chartmap_tool.f90
@@ -4,7 +4,7 @@ program export_boozer_chartmap_tool
     !>
     !> Usage: export_boozer_chartmap_tool.x <wout.nc> <chartmap.nc> <start_vmec.dat> <start_boozer.dat>
     use, intrinsic :: iso_fortran_env, only: dp => real64
-    use new_vmec_stuff_mod, only: netcdffile, multharm, ns_A, ns_s, ns_tp, nper
+    use new_vmec_stuff_mod, only: netcdffile, multharm, ns_A, ns_s, ns_tp
     use parmot_mod, only: rmu
     use velo_mod, only: isw_field_type
     use boozer_coordinates_mod, only: use_B_r

--- a/test/tests/field_can/test_albert_transform_diagnostic.f90
+++ b/test/tests/field_can/test_albert_transform_diagnostic.f90
@@ -16,7 +16,7 @@ program test_albert_transform_diagnostic
 
     use field, only: vmec_field_t, create_vmec_field
     use simple, only: init_vmec
-    use field_can_meiss, only: init_meiss, get_meiss_coordinates, cleanup_meiss, &
+    use field_can_meiss, only: init_meiss, cleanup_meiss, &
                                spl_field_batch, xmin, xmax, n_r, n_th, n_phi, twopi
     use field_can_albert, only: get_albert_coordinates, psi_inner, psi_outer, &
                                 psi_of_x, Ath_norm, r_of_xc, spl_r_batch, &

--- a/test/tests/field_can/test_coord_transform_roundtrip.f90
+++ b/test/tests/field_can/test_coord_transform_roundtrip.f90
@@ -13,7 +13,7 @@ program test_coord_transform_roundtrip
     use, intrinsic :: iso_fortran_env, only: dp => real64
 
     use magfie_sub, only: MEISS, ALBERT
-    use field_can_mod, only: init_field_can, integ_to_ref, ref_to_integ
+    use field_can_mod, only: integ_to_ref, ref_to_integ
     use field_can_meiss, only: integ_to_ref_meiss, ref_to_integ_meiss, twopi
     use field_can_albert, only: integ_to_ref_albert, ref_to_integ_albert
     use simple, only: init_vmec

--- a/test/tests/field_can/test_field_can_albert.f90
+++ b/test/tests/field_can/test_field_can_albert.f90
@@ -7,7 +7,6 @@ program test_field_can_albert
     use magfie_sub, only: ALBERT
     use velo_mod, only: isw_field_type
     use field, only: vmec_field_t, create_vmec_field
-    use field_can_albert, only: init_albert
 
     implicit none
 

--- a/test/tests/field_can/test_field_can_albert_diagnostic.f90
+++ b/test/tests/field_can/test_field_can_albert_diagnostic.f90
@@ -8,7 +8,7 @@ program test_field_can_albert_diagnostic
     use magfie_sub, only: ALBERT
     use velo_mod, only: isw_field_type
     use field, only: vmec_field_t, create_vmec_field
-    use field_can_albert, only: init_albert, psi_inner, psi_outer, &
+    use field_can_albert, only: psi_inner, psi_outer, &
                                 psi_of_x, Ath_norm, dpsi_dr_positive
     use field_can_meiss, only: spl_field_batch, xmin, xmax, n_r, n_th, n_phi
     use interpolate, only: evaluate_batch_splines_3d

--- a/test/tests/field_can/test_field_can_meiss.f90
+++ b/test/tests/field_can/test_field_can_meiss.f90
@@ -1,17 +1,15 @@
 program test_field_can_meiss
 
     use, intrinsic :: iso_fortran_env, only: dp => real64
-    use params, only: read_config
     use simple, only: tracer_t
     use simple_main, only: init_field
     use velo_mod, only: isw_field_type
     use field, only: vmec_field_t, create_vmec_field
-    use field_can_mod, only: eval_field => evaluate, field_can_t, field_can_init
+    use field_can_mod, only: eval_field => evaluate, field_can_t
     use magfie_sub, only: MEISS
-    use field_can_meiss, only: init_meiss, init_transformation, &
+    use field_can_meiss, only: init_meiss, &
                                spline_transformation, init_canonical_field_components, &
            xmin, h_r, h_phi, h_th, ah_cov_on_slice, n_r, n_phi, n_th, lam_phi, chi_gauge
-    use new_vmec_stuff_mod, only: old_axis_healing, old_axis_healing_boundary
     implicit none
 
     real(dp), parameter :: twopi = atan(1.d0)*8.d0

--- a/test/tests/magfie/test_chartmap_wall_losses.f90
+++ b/test/tests/magfie/test_chartmap_wall_losses.f90
@@ -24,7 +24,7 @@ program test_chartmap_wall_losses
     use simple, only: init_vmec
     use util, only: twopi
     use new_vmec_stuff_mod, only: nper
-    use magfie_sub, only: init_magfie, magfie, VMEC, BOOZER, MEISS, REFCOORDS, &
+    use magfie_sub, only: init_magfie, VMEC, BOOZER, MEISS, REFCOORDS, &
                           set_magfie_refcoords_field
     use alpha_lifetime_sub, only: orbit_timestep_axis
     use parmot_mod, only: ro0, rmu
@@ -33,12 +33,12 @@ program test_chartmap_wall_losses
     use field_can_mod, only: field_can_t, eval_field => evaluate
     use field_vmec, only: vmec_field_t, create_vmec_field
     use field_splined, only: splined_field_t, create_splined_field
-    use field_can_mod, only: init_field_can, integ_to_ref, ref_to_integ, &
+    use field_can_mod, only: integ_to_ref, ref_to_integ, &
                              field_can_from_id
     use field_can_meiss, only: init_meiss, get_meiss_coordinates, cleanup_meiss
     use boozer_sub, only: vmec_to_boozer, boozer_to_vmec, get_boozer_coordinates
     use reference_coordinates, only: init_reference_coordinates, ref_coords
-    use libneo_coordinates, only: coordinate_system_t, vmec_coordinate_system_t, &
+    use libneo_coordinates, only: coordinate_system_t, &
                                   make_chartmap_coordinate_system
 
     implicit none
@@ -516,7 +516,7 @@ contains
 
     subroutine trace_particles_boozer_sympl(z0, loss_times, loss_pos, lost_step)
         !> Trace particles using Boozer canonical coordinates with midpoint symplectic.
-        use field_can_mod, only: field_can_t, field_can_init, eval_field => evaluate
+        use field_can_mod, only: field_can_t, eval_field => evaluate
 
         real(dp), intent(in) :: z0(5, n_particles)
         real(dp), intent(out) :: loss_times(n_particles)
@@ -571,7 +571,7 @@ contains
     subroutine trace_particles_meiss_vmec_sympl(z0, loss_times, loss_pos, lost_step)
         !> Trace particles using Meiss coords from VMEC with midpoint symplectic.
         !> Uses npoiper2=256 for proper timestep based on major radius.
-        use field_can_mod, only: field_can_t, field_can_init, eval_field => evaluate
+        use field_can_mod, only: field_can_t, eval_field => evaluate
         use new_vmec_stuff_mod, only: rmajor
 
         real(dp), intent(in) :: z0(5, n_particles)
@@ -629,7 +629,7 @@ contains
     subroutine trace_particles_meiss_chart_sympl(z0, loss_times, loss_pos, lost_step)
         !> Trace particles using Meiss coords from chartmap with midpoint symplectic.
         !> Uses npoiper2=256 for proper timestep based on major radius.
-        use field_can_mod, only: field_can_t, field_can_init, eval_field => evaluate
+        use field_can_mod, only: field_can_t, eval_field => evaluate
         use new_vmec_stuff_mod, only: rmajor
 
         real(dp), intent(in) :: z0(5, n_particles)

--- a/test/tests/magfie/test_magfie_coils.f90
+++ b/test/tests/magfie/test_magfie_coils.f90
@@ -6,13 +6,11 @@ program test_magfie_coils
     use simple, only: init_vmec
     use magfie_sub, only: VMEC
     use velo_mod, only: isw_field_type
-    use field_base, only: magnetic_field_t
     use field_vmec, only: vmec_field_t
     use field_coils, only: coils_field_t, create_coils_field
     use field_splined, only: splined_field_t, create_splined_field
     use reference_coordinates, only: init_reference_coordinates, ref_coords
     use magfie_sub, only: magfie_vmec
-    use util, only: twopi
     use cylindrical_cartesian, only: cyl_to_cart
 
     implicit none

--- a/test/tests/magfie/test_orbit_chartmap_comparison.f90
+++ b/test/tests/magfie/test_orbit_chartmap_comparison.f90
@@ -23,7 +23,7 @@ program test_orbit_chartmap_comparison
     use parmot_mod, only: ro0, rmu
     use field_vmec, only: vmec_field_t, create_vmec_field
     use field_splined, only: splined_field_t, create_splined_field
-    use field_can_mod, only: init_field_can, integ_to_ref
+    use field_can_mod, only: integ_to_ref
     use field_can_meiss, only: init_meiss, get_meiss_coordinates, cleanup_meiss
     use reference_coordinates, only: init_reference_coordinates, ref_coords
     use libneo_coordinates, only: coordinate_system_t, vmec_coordinate_system_t, &
@@ -268,7 +268,6 @@ contains
 
     subroutine set_physics_parameters(v0_out)
         use util, only: ev, p_mass, c_light => c, e_charge
-        use vector_potentail_mod, only: torflux
 
         real(dp), intent(out) :: v0_out
         real(dp) :: E_alpha, rlarm

--- a/test/tests/magfie/test_orbit_refcoords_rk45.f90
+++ b/test/tests/magfie/test_orbit_refcoords_rk45.f90
@@ -21,7 +21,6 @@ program test_orbit_refcoords_rk45
     use netcdf
     use simple, only: init_vmec
     use util, only: twopi
-    use new_vmec_stuff_mod, only: nper
     use magfie_sub, only: init_magfie, magfie, VMEC, REFCOORDS, &
                           set_magfie_refcoords_field
     use alpha_lifetime_sub, only: orbit_timestep_axis
@@ -190,7 +189,6 @@ program test_orbit_refcoords_rk45
 contains
 
     subroutine set_physics_parameters
-        use vector_potentail_mod, only: torflux
 
         ro0 = 1.0d-5
         rmu = 1.0d8

--- a/test/tests/test_array_utils.f90
+++ b/test/tests/test_array_utils.f90
@@ -1,5 +1,4 @@
 program test_array_utils
-    use, intrinsic :: iso_fortran_env, only: dp => real64
     use array_utils, only: init_derivative_factors
     implicit none
 

--- a/test/tests/test_boozer_chartmap_roundtrip.f90
+++ b/test/tests/test_boozer_chartmap_roundtrip.f90
@@ -11,7 +11,7 @@ program test_boozer_chartmap_roundtrip
     use boozer_chartmap, only: export_boozer_chartmap, load_boozer_from_chartmap
     use spline_vmec_sub, only: spline_vmec_data
     use vmecin_sub, only: stevvo
-    use field_can_mod, only: field_can_from_name, field_can_init, &
+    use field_can_mod, only: field_can_from_name, &
                              eval_field => evaluate, field_can_t, get_val
     use orbit_symplectic, only: orbit_sympl_init, orbit_timestep_sympl, &
                                 symplectic_integrator_t

--- a/test/tests/test_chartmap_meiss_debug.f90
+++ b/test/tests/test_chartmap_meiss_debug.f90
@@ -3,8 +3,7 @@ program test_chartmap_meiss_debug
    use libneo_coordinates, only: coordinate_system_t, make_chartmap_coordinate_system, &
                                   chartmap_coordinate_system_t, RHO_TOR, RHO_POL, &
                                   PSI_TOR_NORM, PSI_POL_NORM, UNKNOWN
-    use field_base, only: magnetic_field_t
-    use field_splined, only: splined_field_t, create_splined_field
+    use field_splined, only: splined_field_t
     use field_can_meiss, only: choose_default_scaling
 use coordinate_scaling, only: coordinate_scaling_t, sqrt_s_scaling_t, identity_scaling_t
     implicit none

--- a/test/tests/test_coordinate_refactoring.f90
+++ b/test/tests/test_coordinate_refactoring.f90
@@ -7,7 +7,6 @@ program test_coordinate_refactoring
 
     use, intrinsic :: iso_fortran_env, only: dp => real64
     use simple, only: init_vmec
-    use field_base, only: magnetic_field_t
     use field_vmec, only: vmec_field_t
     use field_coils, only: coils_field_t, create_coils_field
     use field_splined, only: splined_field_t, create_splined_field

--- a/test/tests/test_poiplot_classification.f90
+++ b/test/tests/test_poiplot_classification.f90
@@ -1,10 +1,10 @@
 !
   use new_vmec_stuff_mod, only: netcdffile, multharm, ns_A, ns_s, ns_tp
 !  use chamb_mod,  only : rbig,rcham2
-  use parmot_mod, only: rmu, ro0, eeff
+  use parmot_mod, only: rmu, ro0
   use velo_mod, only: isw_field_type
   use diag_mod, only: icounter
-use field_can_mod, only: eval_field => evaluate, field_can_from_name, field_can_t, field_can_init
+use field_can_mod, only: field_can_from_name, field_can_t
   use orbit_symplectic, only: symplectic_integrator_t, orbit_timestep_sympl
   use simple, only: init_sympl
   use plag_coeff_sub, only: plag_coeff


### PR DESCRIPTION
Fixes #467

Removes imports that are not referenced by diagnostics, examples, or tests. This is a mechanical cleanup with no generated-code, ABI, memory-layout, dispatch, lifetime, or numerical changes.

## Verification

Failing before:
```text
Lint: FAIL (47 unused imports)
```

Passing after:
```text
fo lint
0 unused imports
git diff --check
```