### PR TITLE
Configure boundary event tolerances

### DIFF
--- a/DOC/config.md
+++ b/DOC/config.md
@@ -4,3 +4,9 @@
   them off via `notrace_passing=.True.`, one may resort to 128, or even 64
   in extreme cases with short tracing time. However, also for these cases,
   `npoiper2=256` appears to be a safer choice.
+
+* `boundary_event_fraction_tolerance` sets the dimensionless fractional-step
+  bracket tolerance for an `s=1` event. `boundary_event_radial_tolerance` sets
+  its dimensionless radial residual tolerance in the integrator coordinate.
+  Both default to `-1`, which derives the tolerance from `relerr`. Set positive
+  values to refine event location independently of the nonlinear solve.

--- a/src/orbit_symplectic.f90
+++ b/src/orbit_symplectic.f90
@@ -11,7 +11,8 @@ use orbit_symplectic_base, only: symplectic_integrator_t, multistage_integrator_
   SYMPLECTIC_STEP_OK, SYMPLECTIC_STEP_OUTSIDE_DOMAIN, &
   SYMPLECTIC_STEP_MAXITER, SYMPLECTIC_STEP_LINEAR_SOLVE, &
   SYMPLECTIC_STEP_BOUNDARY, SYMPLECTIC_STEP_EVENT_NOT_CONVERGED, &
-  SYMPLECTIC_STEP_BOUNDARY_LIMITED
+  SYMPLECTIC_STEP_BOUNDARY_LIMITED, boundary_event_fraction_tolerance, &
+  boundary_event_radial_tolerance
 use orbit_symplectic_quasi, only: orbit_timestep_quasi, timestep_expl_impl_euler_quasi, &
   timestep_impl_expl_euler_quasi, timestep_midpoint_quasi, orbit_timestep_rk45, &
   timestep_rk_gauss_quasi, timestep_rk_lobatto_quasi
@@ -1583,6 +1584,20 @@ subroutine attempt_midpoint_step(si, f, status)
   end if
 end subroutine attempt_midpoint_step
 
+subroutine get_boundary_event_tolerances(rtol, fraction_tolerance, radial_tolerance)
+  real(dp), intent(in) :: rtol
+  real(dp), intent(out) :: fraction_tolerance, radial_tolerance
+
+  fraction_tolerance = max(1d-12, 10d0*rtol)
+  radial_tolerance = max(1d-10, 10d0*rtol)
+  if (boundary_event_fraction_tolerance > 0d0) then
+    fraction_tolerance = boundary_event_fraction_tolerance
+  end if
+  if (boundary_event_radial_tolerance > 0d0) then
+    radial_tolerance = boundary_event_radial_tolerance
+  end if
+end subroutine get_boundary_event_tolerances
+
 subroutine locate_symplectic_boundary(accepted_integrator, accepted_field, &
     raw_step, si, f, status, event_fraction, radial_residual, fraction_width)
   type(symplectic_integrator_t), intent(in) :: accepted_integrator
@@ -1609,8 +1624,8 @@ subroutine locate_symplectic_boundary(accepted_integrator, accepted_field, &
   root_estimate_available = .false.
   best_integrator = accepted_integrator
   best_field = accepted_field
-  fraction_tolerance = max(1d-12, 10d0*accepted_integrator%rtol)
-  radial_tolerance = max(1d-10, 10d0*accepted_integrator%rtol)
+  call get_boundary_event_tolerances(accepted_integrator%rtol, &
+    fraction_tolerance, radial_tolerance)
 
   do iteration = 1, max_event_iterations
     trial_integrator = accepted_integrator

--- a/src/orbit_symplectic_base.f90
+++ b/src/orbit_symplectic_base.f90
@@ -26,6 +26,8 @@ use field_can_mod, only: eval_field => evaluate, field_can_t, get_val, get_deriv
     integer, parameter :: SYMPLECTIC_STEP_BOUNDARY = 4
     integer, parameter :: SYMPLECTIC_STEP_EVENT_NOT_CONVERGED = 5
     integer, parameter :: SYMPLECTIC_STEP_BOUNDARY_LIMITED = 6
+    real(dp) :: boundary_event_fraction_tolerance = -1d0
+    real(dp) :: boundary_event_radial_tolerance = -1d0
 
     type :: symplectic_integrator_t
         real(dp) :: atol

--- a/src/params.f90
+++ b/src/params.f90
@@ -12,7 +12,9 @@ module params
     use magfie_sub, only: TEST
     use field_can_mod, only: eval_field => evaluate, field_can_t
     use orbit_symplectic_base, only: symplectic_integrator_t, multistage_integrator_t, &
-                                     EXPL_IMPL_EULER
+                                     EXPL_IMPL_EULER, &
+                                     boundary_event_fraction_tolerance, &
+                                     boundary_event_radial_tolerance
     use vmecin_sub, only: stevvo
     use callback, only: output_error, output_orbits_macrostep
 
@@ -155,6 +157,7 @@ module params
 	        facE_al, npoiper2, n_e, n_d, netcdffile, ns_s, ns_tp, multharm, &
 	        isw_field_type, generate_start_only, startmode, grid_density, &
 	        special_ants_file, integmode, orbit_model, orbit_coord, relerr, &
+	        boundary_event_fraction_tolerance, boundary_event_radial_tolerance, &
 	        tcut, nturns, debug, &
 	        class_plot, cut_in_per, fast_class, vmec_B_scale, &
 	        vmec_RZ_scale, swcoll, deterministic, old_axis_healing, &
@@ -188,6 +191,15 @@ contains
         call apply_config_aliases
 
         call reset_seed_if_deterministic
+
+        if (boundary_event_fraction_tolerance /= -1d0 .and. &
+            boundary_event_fraction_tolerance <= 0d0) then
+            error stop 'boundary_event_fraction_tolerance must be positive or -1'
+        end if
+        if (boundary_event_radial_tolerance /= -1d0 .and. &
+            boundary_event_radial_tolerance <= 0d0) then
+            error stop 'boundary_event_radial_tolerance must be positive or -1'
+        end if
 
         if (swcoll .and. (tcut > 0.0d0 .or. class_plot .or. fast_class)) then
             error stop 'Collisions are incompatible with classification'

--- a/src/params.f90
+++ b/src/params.f90
@@ -1,5 +1,5 @@
 module params
-    use, intrinsic :: iso_fortran_env, only: int8
+    use, intrinsic :: iso_fortran_env, only: int8, int64
     use util, only: pi, c, e_charge, p_mass, ev
     use parmot_mod, only: ro0, rmu
     use new_vmec_stuff_mod, only: old_axis_healing, old_axis_healing_boundary, &
@@ -19,6 +19,8 @@ module params
     use callback, only: output_error, output_orbits_macrostep
 
     implicit none
+
+    private :: config_value_is_finite
 
     ! Define real(dp) kind parameter
     integer, parameter :: dp = kind(1.0d0)
@@ -192,20 +194,36 @@ contains
 
         call reset_seed_if_deterministic
 
-        if (boundary_event_fraction_tolerance /= -1d0 .and. &
-            boundary_event_fraction_tolerance <= 0d0) then
-            error stop 'boundary_event_fraction_tolerance must be positive or -1'
-        end if
-        if (boundary_event_radial_tolerance /= -1d0 .and. &
-            boundary_event_radial_tolerance <= 0d0) then
-            error stop 'boundary_event_radial_tolerance must be positive or -1'
-        end if
+        call validate_boundary_event_tolerances
 
         if (swcoll .and. (tcut > 0.0d0 .or. class_plot .or. fast_class)) then
             error stop 'Collisions are incompatible with classification'
         end if
 
     end subroutine read_config
+
+    subroutine validate_boundary_event_tolerances
+        if (.not. config_value_is_finite(boundary_event_fraction_tolerance) .or. &
+            (boundary_event_fraction_tolerance /= -1d0 .and. &
+             boundary_event_fraction_tolerance <= 0d0)) then
+            error stop 'boundary_event_fraction_tolerance must be finite and positive or -1'
+        end if
+        if (.not. config_value_is_finite(boundary_event_radial_tolerance) .or. &
+            (boundary_event_radial_tolerance /= -1d0 .and. &
+             boundary_event_radial_tolerance <= 0d0)) then
+            error stop 'boundary_event_radial_tolerance must be finite and positive or -1'
+        end if
+    end subroutine validate_boundary_event_tolerances
+
+    pure logical function config_value_is_finite(value)
+        real(dp), intent(in) :: value
+        integer(int64), parameter :: exponent_mask = &
+            int(z'7ff0000000000000', int64)
+        integer(int64) :: bits
+
+        bits = transfer(value, bits)
+        config_value_is_finite = iand(bits, exponent_mask) /= exponent_mask
+    end function config_value_is_finite
 
 	    subroutine params_init
 	        real(dp) :: E_alpha

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -617,6 +617,28 @@ add_executable(test_newton_solver_status.x test_newton_solver_status.f90)
 target_link_libraries(test_newton_solver_status.x simple)
 add_test(NAME test_newton_solver_status COMMAND test_newton_solver_status.x)
 
+add_executable(test_boundary_event_config.x test_boundary_event_config.f90)
+target_link_libraries(test_boundary_event_config.x simple)
+add_test(NAME test_boundary_event_config_valid
+    COMMAND test_boundary_event_config.x valid)
+add_test(NAME test_boundary_event_config_fraction_nan
+    COMMAND test_boundary_event_config.x fraction_nan)
+add_test(NAME test_boundary_event_config_fraction_inf
+    COMMAND test_boundary_event_config.x fraction_inf)
+add_test(NAME test_boundary_event_config_radial_nan
+    COMMAND test_boundary_event_config.x radial_nan)
+set_tests_properties(
+    test_boundary_event_config_valid
+    test_boundary_event_config_fraction_nan
+    test_boundary_event_config_fraction_inf
+    test_boundary_event_config_radial_nan
+    PROPERTIES LABELS "unit")
+set_tests_properties(
+    test_boundary_event_config_fraction_nan
+    test_boundary_event_config_fraction_inf
+    test_boundary_event_config_radial_nan
+    PROPERTIES WILL_FAIL TRUE)
+
 add_executable(test_field_base.x test_field_base.f90)
 target_link_libraries(test_field_base.x simple)
 add_test(NAME test_field_base COMMAND test_field_base.x)

--- a/test/tests/test_boundary_event_config.f90
+++ b/test/tests/test_boundary_event_config.f90
@@ -1,0 +1,27 @@
+program test_boundary_event_config
+    use, intrinsic :: ieee_arithmetic, only: ieee_positive_inf, ieee_quiet_nan, &
+        ieee_value
+    use params, only: boundary_event_fraction_tolerance, &
+        boundary_event_radial_tolerance, validate_boundary_event_tolerances
+
+    implicit none
+
+    character(16) :: mode
+
+    call get_command_argument(1, mode)
+    boundary_event_fraction_tolerance = 1.0d-8
+    boundary_event_radial_tolerance = 1.0d-9
+    select case (trim(mode))
+    case ('valid')
+        continue
+    case ('fraction_nan')
+        boundary_event_fraction_tolerance = ieee_value(0.0d0, ieee_quiet_nan)
+    case ('fraction_inf')
+        boundary_event_fraction_tolerance = ieee_value(0.0d0, ieee_positive_inf)
+    case ('radial_nan')
+        boundary_event_radial_tolerance = ieee_value(0.0d0, ieee_quiet_nan)
+    case default
+        error stop 'unknown boundary event configuration test mode'
+    end select
+    call validate_boundary_event_tolerances
+end program test_boundary_event_config

--- a/test/tests/test_newton_solver_status.f90
+++ b/test/tests/test_newton_solver_status.f90
@@ -46,13 +46,28 @@ contains
       step_status = SYMPLECTIC_STEP_OK
     end if
   end subroutine basin_limited_step
+
+  subroutine nonlinear_boundary_step(si, f, step_status)
+    type(symplectic_integrator_t), intent(inout) :: si
+    type(field_can_t), intent(inout) :: f
+    integer, intent(out) :: step_status
+    real(dp) :: radius
+
+    if (si%dt > 0.4_dp) then
+      step_status = SYMPLECTIC_STEP_OUTSIDE_DOMAIN
+    else
+      radius = 1.0_dp - 1.0e-7_dp - (0.4_dp - si%dt)**2
+      si%z(1) = radius
+      step_status = SYMPLECTIC_STEP_OK
+    end if
+  end subroutine nonlinear_boundary_step
 end module linear_radial_field_backend
 
 program test_newton_solver_status
   use, intrinsic :: iso_fortran_env, only: dp => real64
   use field_can_mod, only: field_can_t, eval_field => evaluate
   use linear_radial_field_backend, only: basin_limited_step, &
-    evaluate_linear_radial
+    evaluate_linear_radial, nonlinear_boundary_step
   use orbit_symplectic, only: guard_lobatto_stage_radii, boundary_event_converged, &
     advance_symplectic_with_boundary, newton_midpoint, orbit_sympl_init, &
     orbit_timestep_sympl, matrix3_near_singular, solve_newton_system, &
@@ -202,21 +217,6 @@ contains
       error stop 'unresolved configured event changed the accepted state'
     end if
   end subroutine test_configured_event_tolerances
-
-  subroutine nonlinear_boundary_step(si, f, step_status)
-    type(symplectic_integrator_t), intent(inout) :: si
-    type(field_can_t), intent(inout) :: f
-    integer, intent(out) :: step_status
-    real(dp) :: radius
-
-    if (si%dt > 0.4_dp) then
-      step_status = SYMPLECTIC_STEP_OUTSIDE_DOMAIN
-    else
-      radius = 1.0_dp - 1.0e-7_dp - (0.4_dp - si%dt)**2
-      si%z(1) = radius
-      step_status = SYMPLECTIC_STEP_OK
-    end if
-  end subroutine nonlinear_boundary_step
 
   subroutine test_solver_basin_is_not_boundary
     type(symplectic_integrator_t) :: basin_integrator

--- a/test/tests/test_newton_solver_status.f90
+++ b/test/tests/test_newton_solver_status.f90
@@ -55,13 +55,15 @@ program test_newton_solver_status
     evaluate_linear_radial
   use orbit_symplectic, only: guard_lobatto_stage_radii, boundary_event_converged, &
     advance_symplectic_with_boundary, newton_midpoint, orbit_sympl_init, &
-    orbit_timestep_sympl, matrix3_near_singular, solve_newton_system
+    orbit_timestep_sympl, matrix3_near_singular, solve_newton_system, &
+    get_boundary_event_tolerances
   use orbit_symplectic_base, only: symplectic_integrator_t, &
     EXPL_IMPL_EULER, IMPL_EXPL_EULER, MIDPOINT, LOBATTO3, &
     SYMPLECTIC_STEP_BOUNDARY, &
     SYMPLECTIC_STEP_OK, SYMPLECTIC_STEP_OUTSIDE_DOMAIN, &
     SYMPLECTIC_STEP_MAXITER, SYMPLECTIC_STEP_LINEAR_SOLVE, &
-    SYMPLECTIC_STEP_EVENT_NOT_CONVERGED, SYMPLECTIC_STEP_BOUNDARY_LIMITED
+    SYMPLECTIC_STEP_EVENT_NOT_CONVERGED, SYMPLECTIC_STEP_BOUNDARY_LIMITED, &
+    boundary_event_fraction_tolerance, boundary_event_radial_tolerance
 
   implicit none
 
@@ -150,9 +152,71 @@ program test_newton_solver_status
   end if
 
   call test_lcfs_location
+  call test_configured_event_tolerances
   call test_solver_basin_is_not_boundary
 
 contains
+
+  subroutine test_configured_event_tolerances
+    type(symplectic_integrator_t) :: loose_integrator, tight_integrator
+    type(field_can_t) :: event_field
+    real(dp) :: configured_fraction_tolerance, configured_radial_tolerance
+    integer :: event_status
+
+    eval_field => evaluate_linear_radial
+    event_field%ro0 = 1.0_dp
+    event_field%mu = 1.0_dp
+
+    loose_integrator%z = [0.9_dp, 0.0_dp, 0.0_dp, 0.0_dp]
+    loose_integrator%dt = 1.0_dp
+    loose_integrator%ntau = 1
+    loose_integrator%rtol = 1.0e-12_dp
+    boundary_event_fraction_tolerance = 1.0e-4_dp
+    boundary_event_radial_tolerance = 1.0e-4_dp
+    call get_boundary_event_tolerances(1.0e-12_dp, &
+      configured_fraction_tolerance, configured_radial_tolerance)
+    if (configured_fraction_tolerance /= 1.0e-4_dp .or. &
+        configured_radial_tolerance /= 1.0e-4_dp) then
+      error stop 'configured event tolerances were not selected'
+    end if
+    call advance_symplectic_with_boundary(loose_integrator, event_field, &
+      nonlinear_boundary_step, event_status)
+    if (event_status /= SYMPLECTIC_STEP_BOUNDARY) then
+      error stop 'loose configured event tolerances rejected the crossing'
+    end if
+
+    tight_integrator%z = [0.9_dp, 0.0_dp, 0.0_dp, 0.0_dp]
+    tight_integrator%dt = 1.0_dp
+    tight_integrator%ntau = 1
+    tight_integrator%rtol = 1.0e-12_dp
+    boundary_event_fraction_tolerance = 1.0e-8_dp
+    boundary_event_radial_tolerance = 1.0e-8_dp
+    call advance_symplectic_with_boundary(tight_integrator, event_field, &
+      nonlinear_boundary_step, event_status)
+    boundary_event_fraction_tolerance = -1.0_dp
+    boundary_event_radial_tolerance = -1.0_dp
+    if (event_status /= SYMPLECTIC_STEP_EVENT_NOT_CONVERGED) then
+      error stop 'tight radial tolerance accepted an unresolved crossing'
+    end if
+    if (any(tight_integrator%z /= [0.9_dp, 0.0_dp, 0.0_dp, 0.0_dp])) then
+      error stop 'unresolved configured event changed the accepted state'
+    end if
+  end subroutine test_configured_event_tolerances
+
+  subroutine nonlinear_boundary_step(si, f, step_status)
+    type(symplectic_integrator_t), intent(inout) :: si
+    type(field_can_t), intent(inout) :: f
+    integer, intent(out) :: step_status
+    real(dp) :: radius
+
+    if (si%dt > 0.4_dp) then
+      step_status = SYMPLECTIC_STEP_OUTSIDE_DOMAIN
+    else
+      radius = 1.0_dp - 1.0e-7_dp - (0.4_dp - si%dt)**2
+      si%z(1) = radius
+      step_status = SYMPLECTIC_STEP_OK
+    end if
+  end subroutine nonlinear_boundary_step
 
   subroutine test_solver_basin_is_not_boundary
     type(symplectic_integrator_t) :: basin_integrator


### PR DESCRIPTION
Fixes #472

## Review context

The endpoint chain is [PR 456](https://github.com/itpplasma/SIMPLE/pull/456) accepted-state rollback -> [PR 457](https://github.com/itpplasma/SIMPLE/pull/457) solver status -> [PR 459](https://github.com/itpplasma/SIMPLE/pull/459) event location -> [PR 460](https://github.com/itpplasma/SIMPLE/pull/460) exit classification and output -> [PR 461](https://github.com/itpplasma/SIMPLE/pull/461) tolerance controls. [PR 462](https://github.com/itpplasma/SIMPLE/pull/462) changes CI scheduling only. [PR 463](https://github.com/itpplasma/SIMPLE/pull/463) adds map-resolution controls and provenance.

This PR changes configuration only. It exposes the two acceptance thresholds already used by PR 459 without changing solver tolerances, event arithmetic, or defaults.

Adds independent namelist controls for the dimensionless fractional-step bracket and radial residual tolerances used to accept an `s=1` event. The default `-1` preserves the existing `relerr`-derived behavior exactly; positive values allow one-parameter event-location refinement without changing the nonlinear solver tolerance.

Configuration validation uses the binary64 exponent bits because the production module is compiled with `-ffast-math`, under which `ieee_is_finite` can be optimized to true. NaN and infinity overrides are rejected under the actual production flags.

The physical model, solver arithmetic, public interfaces, and memory layout are unchanged. Only the event acceptance threshold changes when a positive override is requested.

## Verification

Failing before:

```text
Event-location tolerance could not be varied independently of relerr.
NaN overrides bypassed the nonpositive-value check under -ffast-math.
Nested test callbacks failed -Werror=trampolines.
```

Passing after on the exact dependent stack:

```text
loose configured tolerance: boundary accepted
tight configured radial tolerance: unresolved status with exact rollback
valid event configuration: accepted
fractional NaN: rejected
fractional positive infinity: rejected
radial NaN: rejected
Static: OK (155 modules)
Build: OK
Tests: OK
Lint: OK
All stages passed
```

## Golden-record status

The dependent stack now applies the reviewed physical-exit reference patch. Golden comparisons pass with unchanged tolerances; this PR does not alter default-input results.