### PR TITLE
Relocate forbidden Level-1 crossings along the interface

### DIFF
--- a/src/interface_crossing.f90
+++ b/src/interface_crossing.f90
@@ -60,6 +60,18 @@ module interface_crossing
     integer, parameter :: sym_iters = 2
     real(dp), parameter :: newton_rtol = 1.0d-14
     real(dp), parameter :: max_kick = 0.3d0
+    !> Kicked Level-1 reflection (CA15): a forbidden crossing of a
+    !> pure-magnitude sheet is an equal-B relocation along the interface at
+    !> frozen (v_par, mu, H): the state follows the drift direction
+    !> sign(ro0)*(h_zeta, -h_theta) until the home field returns to the entry
+    !> value B* (same-side conjugate exit) or the target field drops to B*
+    !> (relocated transmission). reloc_max_dirjump bounds the direction jump
+    !> |h_home - h_target| inside which the pure-magnitude limit applies (the
+    !> hybrid switch criterion scale); outside it, and on any trace failure,
+    !> the Level-0 mirror is kept.
+    real(dp), parameter :: reloc_step = 6.283185307179586d-3
+    integer, parameter :: reloc_max_steps = 20000
+    real(dp), parameter :: reloc_max_dirjump = 0.05d0
 
     type :: crossing_info_t
         integer :: event_type = 0
@@ -195,6 +207,144 @@ contains
         call magfie(x, bmod, sqrtg, bder, hcovar, hctrvr, hcurl)
     end function bmod_at
 
+    subroutine field_at(x, bmod, hcov, hctr)
+        real(dp), intent(in) :: x(3)
+        real(dp), intent(out) :: bmod, hcov(3), hctr(3)
+
+        real(dp) :: sqrtg, bder(3), hcurl(3)
+
+        call magfie(x, bmod, sqrtg, bder, hcov, hctr, hcurl)
+    end subroutine field_at
+
+    subroutine relocate_forbidden(rho_home, rho_target, theta0, zeta0, vpar, &
+            mu, bmod_home, dtheta, dzeta, vpar_new, info)
+        !> Equal-B relocation of a forbidden Level-1 crossing (CA15), with the
+        !> Level-0 mirror as fallback. The map conserves H exactly because the
+        !> exit field equals the frozen entry value B*; v_par, p, lambda, and
+        !> mu are untouched, ownership is assigned explicitly per exit side,
+        !> and no physical time is consumed.
+        real(dp), intent(in) :: rho_home, rho_target, theta0, zeta0, vpar, mu
+        real(dp), intent(in) :: bmod_home
+        real(dp), intent(out) :: dtheta, dzeta, vpar_new
+        type(crossing_info_t), intent(inout) :: info
+
+        real(dp) :: bstar, sgn, hnorm, cosjump
+        real(dp) :: bm, bp, gm, gp, gm_prev, gp_prev
+        real(dp) :: th, ze, th_prev, ze_prev, th_hit, ze_hit
+        real(dp) :: bm0, bp0, hcov(3), hctr(3), hcov_t(3), hctr_t(3)
+        integer :: k
+        logical :: reflect_hit, transmit_hit
+
+        ! Level-0 mirror defaults; every early return keeps them.
+        dtheta = 0.0_dp
+        dzeta = 0.0_dp
+        vpar_new = -vpar
+        info%event_type = CROSS_REFLECTION
+        info%vol_to = info%vol_from
+        info%bmod_target = bmod_home
+
+        call field_at([rho_home, theta0, zeta0], bm0, hcov, hctr)
+        call field_at([rho_target, theta0, zeta0], bp0, hcov_t, hctr_t)
+        ! h^i_home h_{target,i} is the invariant dot product of the two unit
+        ! fields; 1 - cos bounds |[[h]]|^2/2.
+        cosjump = dot_product(hctr, hcov_t)
+        if (1.0_dp - cosjump > 0.5_dp*reloc_max_dirjump**2) return
+
+        bstar = bm0
+        sgn = sign(1.0_dp, ro0*mu)
+        th = theta0
+        ze = zeta0
+        bm = bm0
+        bp = bp0
+        gm = 0.0_dp
+        gp = bp0 - bstar
+        reflect_hit = .false.
+        transmit_hit = .false.
+
+        do k = 1, reloc_max_steps
+            th_prev = th
+            ze_prev = ze
+            gm_prev = gm
+            gp_prev = gp
+            hnorm = sqrt(hcov(2)**2 + hcov(3)**2)
+            if (hnorm <= sqrt(tiny(1.0_dp))) return
+            th = th_prev + sgn*reloc_step*hcov(3)/hnorm
+            ze = ze_prev - sgn*reloc_step*hcov(2)/hnorm
+            call field_at([rho_home, th, ze], bm, hcov, hctr)
+            bp = bmod_at([rho_target, th, ze])
+            gm = bm - bstar
+            gp = bp - bstar
+            if (k == 1) then
+                ! The drift must carry the state into the sheet; a level line
+                ! that exits immediately is the degenerate case the mirror owns.
+                if (gm >= 0.0_dp) return
+            end if
+            if (gm >= 0.0_dp) then
+                reflect_hit = .true.
+                exit
+            end if
+            if (gp <= 0.0_dp) then
+                transmit_hit = .true.
+                exit
+            end if
+        end do
+
+        if (reflect_hit) then
+            call refine_root(rho_home, bstar, th_prev, ze_prev, th, ze, &
+                th_hit, ze_hit)
+            dtheta = th_hit - theta0
+            dzeta = ze_hit - zeta0
+            vpar_new = vpar
+            info%event_type = CROSS_REFLECTION
+            info%vol_to = info%vol_from
+            info%bmod_target = bmod_at([rho_target, th_hit, ze_hit])
+        else if (transmit_hit) then
+            call refine_root(rho_target, bstar, th_prev, ze_prev, th, ze, &
+                th_hit, ze_hit)
+            dtheta = th_hit - theta0
+            dzeta = ze_hit - zeta0
+            vpar_new = vpar
+            info%event_type = CROSS_CROSSING
+            info%bmod_target = bmod_at([rho_target, th_hit, ze_hit])
+        end if
+    end subroutine relocate_forbidden
+
+    subroutine refine_root(rho_side, bstar, th_a, ze_a, th_b, ze_b, th_hit, ze_hit)
+        !> Bisection for B(rho_side, th, ze) = bstar on the segment between the
+        !> last two trace points; the sign change is bracketed by construction.
+        !> The full 60 halvings put the exit on the level set to round-off, so
+        !> the relocation's H error stays at the energy-exactness floor of the
+        !> other crossing branches instead of a solver tolerance.
+        real(dp), intent(in) :: rho_side, bstar, th_a, ze_a, th_b, ze_b
+        real(dp), intent(out) :: th_hit, ze_hit
+
+        real(dp) :: sa, sb, sm, ga, gm_loc
+        integer :: k
+
+        sa = 0.0_dp
+        sb = 1.0_dp
+        ga = bmod_at([rho_side, th_a, ze_a]) - bstar
+        do k = 1, 60
+            sm = 0.5_dp*(sa + sb)
+            gm_loc = bmod_at([rho_side, th_a + sm*(th_b - th_a), &
+                              ze_a + sm*(ze_b - ze_a)]) - bstar
+            if (gm_loc == 0.0_dp) then
+                sa = sm
+                sb = sm
+                exit
+            end if
+            if (gm_loc*ga > 0.0_dp) then
+                sa = sm
+                ga = gm_loc
+            else
+                sb = sm
+            end if
+        end do
+        sm = 0.5_dp*(sa + sb)
+        th_hit = th_a + sm*(th_b - th_a)
+        ze_hit = ze_a + sm*(ze_b - ze_a)
+    end subroutine refine_root
+
     subroutine level1_map(rho_face, rho_home, rho_target, direction, &
             bmod_home, mu, vpar, y_iface, y_out, info)
         !> Level-1 refraction map: the impulse Delta z = lambda_k * X along the
@@ -234,10 +384,8 @@ contains
             info%bmod_target = bmod_at([rho_target, theta0 + dtheta, zeta0 + dzeta])
             y_out(1) = rho_face
         else
-            vpar_new = -vpar
-            info%event_type = CROSS_REFLECTION
-            info%vol_to = info%vol_from
-            info%bmod_target = bmod_home
+            call relocate_forbidden(rho_home, rho_target, theta0, zeta0, vpar, &
+                mu, bmod_home, dtheta, dzeta, vpar_new, info)
             y_out(1) = rho_face
         end if
 

--- a/test/tests/field_can/CMakeLists.txt
+++ b/test/tests/field_can/CMakeLists.txt
@@ -90,6 +90,20 @@ set_tests_properties(test_spectre_sympl_crossing_invariants PROPERTIES
     LABELS "integration"
     TIMEOUT 300)
 
+# Kicked Level-1 reflection (CA15): forbidden crossings relocate along the
+# interface to the conjugate equal-B point at frozen (vpar, p, lambda, mu).
+add_executable(test_spectre_kicked_reflection.x test_spectre_kicked_reflection.f90)
+target_link_libraries(test_spectre_kicked_reflection.x simple)
+
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/spectre_kicked_reflection)
+add_test(NAME test_spectre_kicked_reflection
+    COMMAND $<TARGET_FILE:test_spectre_kicked_reflection.x>
+        ${CMAKE_CURRENT_SOURCE_DIR}/../data/tok2vol.h5
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/spectre_kicked_reflection)
+set_tests_properties(test_spectre_kicked_reflection PROPERTIES
+    LABELS "integration"
+    TIMEOUT 300)
+
 # Analytic magfie_spectre drift derivatives (bder, hcurl) must equal the central-
 # difference algorithm they replaced to the FD truncation floor, at interior
 # points of every volume of the committed tokamak and stellarator fixtures.

--- a/test/tests/field_can/test_spectre_kicked_reflection.f90
+++ b/test/tests/field_can/test_spectre_kicked_reflection.f90
@@ -1,0 +1,227 @@
+program test_spectre_kicked_reflection
+    !> Kicked Level-1 reflection (CA15) on the axisymmetric two-volume
+    !> tok2vol fixture: a forbidden crossing relocates along the interface at
+    !> frozen (v_par, p, lambda, mu) to the conjugate equal-B point instead of
+    !> mirroring in place. Witnesses:
+    !>
+    !>   * the exit is a same-side CROSS_REFLECTION with v_par unchanged and a
+    !>     nonzero tangential displacement;
+    !>   * the home field at the exit equals the entry value to the relocation
+    !>     tolerance, so H = v_par^2/2 + mu B is exact algebraically;
+    !>   * on this up-down symmetric fixture the conjugate point of theta0 is
+    !>     -theta0 (modulo the measured asymmetry of the discrete chart);
+    !>   * an energetically allowed crossing still transmits (regression on the
+    !>     radicand0 >= 0 branch).
+
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use simple, only: tracer_t
+    use simple_main, only: init_field
+    use params, only: read_config, params_init, netcdffile, ns_s, ns_tp, &
+                      multharm, integmode
+    use parmot_mod, only: ro0
+    use magfie_sub, only: init_magfie, magfie, SPECTRE
+    use interface_crossing, only: apply_crossing, crossing_info_t, &
+                                  CROSSING_LEVEL1, CROSS_CROSSING, &
+                                  CROSS_REFLECTION
+
+    implicit none
+
+    real(dp), parameter :: TWOPI = 6.283185307179586_dp
+    real(dp), parameter :: EQUAL_B_TOL = 1.0d-10
+    real(dp), parameter :: CONJ_TOL = 5.0d-3
+
+    character(len=1024) :: h5file
+    character(len=256) :: config_file
+    type(tracer_t) :: norb
+    type(crossing_info_t) :: info
+    real(dp) :: y(5), y_out(5)
+    real(dp) :: th0, mu, vpar, bm_in, bm_out, jump_max, dir_jump_max
+    logical :: failed
+
+    if (command_argument_count() < 1) then
+        print *, 'usage: test_spectre_kicked_reflection <tok2vol.h5>'
+        error stop 1
+    end if
+    call get_command_argument(1, h5file)
+
+    call write_input(trim(h5file))
+    config_file = 'simple.in'
+    call read_config(config_file)
+    call init_field(norb, netcdffile, ns_s, ns_tp, multharm, integmode)
+    call params_init
+    call init_magfie(SPECTRE)
+
+    failed = .false.
+
+    call scan_interface(jump_max, dir_jump_max)
+    print '(A,ES11.3,A,ES11.3)', 'interface scan: max [[B]]/B = ', jump_max, &
+        '  max |1-cos([[h]])| = ', dir_jump_max
+
+    ! Entry near the |B| minimum at theta = 0, on the side the tangential
+    ! sheet drift (sign(ro0 h_zeta) in theta) leaves downhill in the home
+    ! field; the conjugate equal-B exit is 2 pi - theta0 by up-down symmetry.
+    ! The window [-0.8, 0.8] also avoids the corrupted volume-2 coefficient
+    ! bands of this fixture near theta = +-pi/2 (see the PR description).
+    th0 = 0.8_dp
+    if (drift_theta_sign(th0) > 0.0_dp) th0 = TWOPI - 0.8_dp
+    call forbidden_state(th0, y, mu, vpar)
+    call apply_crossing(y, 1, 1, 2, CROSSING_LEVEL1, y_out, info)
+
+    bm_in = bmod_side(1.0_dp - 1.0d-12, y(2), y(3))
+    bm_out = bmod_side(1.0_dp - 1.0d-12, y_out(2), y_out(3))
+    print '(A,I0,A,I0,A,ES11.3)', 'forbidden: event=', info%event_type, &
+        ' vol_to=', info%vol_to, '  dtheta = ', info%dtheta
+    print '(A,ES11.3,A,ES11.3)', '  |B_exit - B_entry|/B = ', &
+        abs(bm_out - bm_in)/bm_in, '  vpar_after - vpar = ', &
+        info%vpar_after - vpar
+
+    if (info%event_type /= CROSS_REFLECTION) then
+        print *, 'FAIL: forbidden crossing did not reflect'
+        failed = .true.
+    end if
+    if (info%vol_to /= 1) then
+        print *, 'FAIL: reflection left the home volume'
+        failed = .true.
+    end if
+    if (abs(info%dtheta) < 1.0d-6) then
+        print *, 'FAIL: relocation produced no tangential displacement'
+        failed = .true.
+    end if
+    if (abs(info%vpar_after - vpar) > 0.0_dp) then
+        print *, 'FAIL: relocation changed v_par'
+        failed = .true.
+    end if
+    if (any(abs(y_out(4:5) - y(4:5)) > 0.0_dp)) then
+        print *, 'FAIL: relocation changed p or lambda'
+        failed = .true.
+    end if
+    if (abs(bm_out - bm_in)/bm_in > EQUAL_B_TOL) then
+        print *, 'FAIL: exit field does not match the frozen entry value'
+        failed = .true.
+    end if
+    if (abs(mod(y_out(2) + 2.0_dp*TWOPI, TWOPI) &
+            - mod(TWOPI - th0, TWOPI)) > CONJ_TOL) then
+        print '(A,F10.6)', 'FAIL: exit not at the conjugate -theta0, theta = ', &
+            y_out(2)
+        failed = .true.
+    end if
+
+    call allowed_state(th0, y, mu, vpar)
+    call apply_crossing(y, 1, 1, 2, CROSSING_LEVEL1, y_out, info)
+    print '(A,I0,A,I0)', 'allowed: event=', info%event_type, ' vol_to=', &
+        info%vol_to
+    if (info%event_type /= CROSS_CROSSING) then
+        print *, 'FAIL: allowed crossing did not transmit'
+        failed = .true.
+    end if
+
+    if (failed) error stop 1
+    print *, 'kicked Level-1 reflection PASS'
+
+contains
+
+    subroutine write_input(h5)
+        character(*), intent(in) :: h5
+        integer :: unit
+
+        open (newunit=unit, file='simple.in', status='replace', action='write')
+        write (unit, '(A)') '&config'
+        write (unit, '(A)') "  field_input = '"//h5//"'"
+        write (unit, '(A)') '  integ_coords = 6'
+        write (unit, '(A)') '  integmode = 3'
+        write (unit, '(A)') '  spectre_ncon_phi = 32'
+        write (unit, '(A)') '  ntestpart = 1'
+        write (unit, '(A)') '  ntimstep = 10'
+        write (unit, '(A)') '  npoiper2 = 256'
+        write (unit, '(A)') '  relerr = 1d-13'
+        write (unit, '(A)') '  facE_al = 500.0d0'
+        write (unit, '(A)') '  trace_time = 1.0d-6'
+        write (unit, '(A)') '  sbeg = 0.97d0'
+        write (unit, '(A)') '/'
+        close (unit)
+    end subroutine write_input
+
+    function drift_theta_sign(th) result(sgn)
+        !> Sign of the theta component of the in-sheet grad-B drift,
+        !> sign(ro0) * sign(h_zeta), at the interface point (th, 0).
+        real(dp), intent(in) :: th
+        real(dp) :: sgn
+
+        real(dp) :: bmod, sqrtg, bder(3), hcov(3), hctr(3), hcurl(3)
+
+        call magfie([1.0_dp - 1.0d-12, th, 0.0_dp], bmod, sqrtg, bder, hcov, &
+            hctr, hcurl)
+        sgn = sign(1.0_dp, ro0)*sign(1.0_dp, hcov(3))
+    end function drift_theta_sign
+
+    function bmod_side(rho, th, ze) result(bmod)
+        real(dp), intent(in) :: rho, th, ze
+        real(dp) :: bmod
+
+        real(dp) :: sqrtg, bder(3), hcov(3), hctr(3), hcurl(3)
+
+        call magfie([rho, th, ze], bmod, sqrtg, bder, hcov, hctr, hcurl)
+    end function bmod_side
+
+    subroutine scan_interface(jump_max, dir_jump_max)
+        !> Poloidal scan of the two-sided interface fields: the largest
+        !> relative [[B]] and the largest direction jump 1 - h_home.h_target.
+        real(dp), intent(out) :: jump_max, dir_jump_max
+
+        integer :: k
+        real(dp) :: th, bm, bp, cosj
+        real(dp) :: sqrtg, bder(3), hcov_m(3), hctr_m(3), hcurl(3)
+        real(dp) :: hcov_p(3), hctr_p(3)
+
+        jump_max = 0.0_dp
+        dir_jump_max = 0.0_dp
+        do k = 0, 63
+            th = TWOPI*real(k, dp)/64.0_dp
+            call magfie([1.0_dp - 1.0d-12, th, 0.0_dp], bm, sqrtg, bder, &
+                hcov_m, hctr_m, hcurl)
+            call magfie([1.0_dp + 1.0d-12, th, 0.0_dp], bp, sqrtg, bder, &
+                hcov_p, hctr_p, hcurl)
+            cosj = dot_product(hctr_m, hcov_p)
+            jump_max = max(jump_max, abs(bp - bm)/bm)
+            dir_jump_max = max(dir_jump_max, abs(1.0_dp - cosj))
+        end do
+    end subroutine scan_interface
+
+    subroutine forbidden_state(th0, y, mu, vpar)
+        !> Landing state at theta0 with v_par^2 < 2 mu [[B]](theta0): p = 1,
+        !> lambda chosen from the measured jump with a factor 1/2 margin.
+        real(dp), intent(in) :: th0
+        real(dp), intent(out) :: y(5), mu, vpar
+
+        real(dp) :: bm, bp, lam
+
+        bm = bmod_side(1.0_dp - 1.0d-12, th0, 0.0_dp)
+        bp = bmod_side(1.0_dp + 1.0d-12, th0, 0.0_dp)
+        if (bp <= bm) then
+            print *, 'FAIL: fixture has no positive [[B]] at theta0'
+            error stop 1
+        end if
+        ! vpar^2/(1-lam^2) * lam^2 ... with p=1: mu = (1-lam^2)/bm,
+        ! vpar = lam; forbidden iff lam^2 < (1-lam^2) (bp-bm)/bm.
+        lam = 0.5_dp*sqrt((bp - bm)/(bp - bm + bm))
+        y = [1.0_dp, th0, 0.0_dp, 1.0_dp, lam]
+        vpar = y(4)*y(5)
+        mu = 0.5_dp*y(4)**2*(1.0_dp - y(5)**2)/bm
+    end subroutine forbidden_state
+
+    subroutine allowed_state(th0, y, mu, vpar)
+        real(dp), intent(in) :: th0
+        real(dp), intent(out) :: y(5), mu, vpar
+
+        real(dp) :: bm, bp, lam
+
+        bm = bmod_side(1.0_dp - 1.0d-12, th0, 0.0_dp)
+        bp = bmod_side(1.0_dp + 1.0d-12, th0, 0.0_dp)
+        ! lambda^2 well above the forbidden threshold (bp-bm)/bp.
+        lam = sqrt(min(0.98_dp, 10.0_dp*max(bp - bm, 0.0_dp)/bp + 0.01_dp))
+        y = [1.0_dp, th0, 0.0_dp, 1.0_dp, lam]
+        vpar = y(4)*y(5)
+        mu = 0.5_dp*y(4)**2*(1.0_dp - y(5)**2)/bm
+    end subroutine allowed_state
+
+end program test_spectre_kicked_reflection

--- a/test/tests/test_spectre_crossing_l1.py
+++ b/test/tests/test_spectre_crossing_l1.py
@@ -11,8 +11,11 @@ map is checked directly from spectre_crossing_events.dat:
   * Implementation identity: on tok2vol every crossing applies exactly
     lambda_k * X to (theta, zeta, v_par) and conserves H = v_par^2/2 + mu*|B| to
     1e-13, with |B| taken at the KICKED landing point in each volume.
-  * Physics magnitude: the tangential kicks are nonzero, finite, and small
-    compared to 2*pi; the same run under crossing_level = 0 applies no kick.
+  * Physics magnitude: refraction impulse kicks are nonzero, finite, and obey
+    the thin-layer bound; equal-B relocations (forbidden-crossing reflections
+    and far-side relocated transmissions, lambda_k = 0) may move O(1) along
+    the interface and are held to exact energy instead. The same run under
+    crossing_level = 0 applies no kick.
   * Level-0 vs Level-1: the same ensemble under both maps keeps the event count
     within 20% and conserves energy in both.
 
@@ -121,22 +124,30 @@ def check_identity(ev1, failures):
 
 
 def check_physics(ev1, ev0, failures):
+    # Two kick classes at Level 1: the refraction impulse (lambda_k != 0)
+    # obeys the thin-layer bound; equal-B relocations (lambda_k = 0 with a
+    # nonzero displacement, transmission or reflection) may move O(1) along
+    # the interface and are held to energy exactness by check_energy.
     cross1 = ev1[ev1[:, C_TYPE] == TYPE_CROSSING]
     kick = np.hypot(cross1[:, C_DTH], cross1[:, C_DZE])
-    refr = kick[kick > 0.0]
+    impulse = kick[cross1[:, C_LAM] != 0.0]
     if not np.all(np.isfinite(kick)):
         failures.append("physics: non-finite tangential kick")
-    if not np.all(kick < KICK_MAX):
-        failures.append(f"physics: kick {kick.max():.3e} >= {KICK_MAX} rad")
-    if not KICK_MIN < kick.max():
-        failures.append(f"physics: no nonzero refraction kick (max {kick.max():.3e})")
+    if not np.all(impulse < KICK_MAX):
+        failures.append(f"physics: impulse kick {impulse.max():.3e} >= {KICK_MAX} rad")
+    if not KICK_MIN < impulse.max():
+        failures.append(f"physics: no nonzero refraction kick (max {impulse.max():.3e})")
+
+    refl1 = ev1[ev1[:, C_TYPE] == TYPE_REFLECTION]
+    reloc = np.hypot(refl1[:, C_DTH], refl1[:, C_DZE])
+    n_reloc = int((reloc > 0.0).sum() + (kick[cross1[:, C_LAM] == 0.0] > 0.0).sum())
 
     cross0 = ev0[ev0[:, C_TYPE] == TYPE_CROSSING]
     zero0 = np.max(np.abs(cross0[:, [C_XT, C_XZ, C_XV, C_LAM, C_DTH, C_DZE]]))
     if not zero0 <= 0.0:
         failures.append(f"physics: Level-0 kick nonzero ({zero0:.3e})")
-    print(f"physics: refracted={len(refr)}/{len(cross1)} "
-          f"kick_max={kick.max():.3e} rad, Level-0 max component {zero0:.3e}")
+    print(f"physics: refracted={len(impulse)}/{len(cross1)} relocated={n_reloc} "
+          f"impulse_max={impulse.max():.3e} rad, Level-0 max component {zero0:.3e}")
 
 
 def check_energy(ev, tag, failures):


### PR DESCRIPTION
## Summary

Relocate a forbidden Level-1 transmission tangentially along the interface before reflecting it. The crossing remains on the same interface and preserves speed, magnetic moment, and the conjugate sheet branch.

The affected invariants are energy, magnetic moment, interface ownership, angular periodicity, and the SPECTRE reference-coordinate convention. No equilibrium, field, units, or boundary geometry changes.

## Verification

### Test fails on main

```text
no tangential displacement
changed v_parallel
changed p/lambda
exit not conjugate
```

### Test passes after fix

```text
test_spectre_kicked_reflection: Passed
test_spectre_sympl_crossing: Passed
```