### PR TITLE
Count landing-root evaluations

### DIFF
--- a/src/spectre_sympl_orbit.f90
+++ b/src/spectre_sympl_orbit.f90
@@ -31,7 +31,7 @@ module spectre_sympl_orbit
 
     public :: sympl_spectre_state_t, sympl_spectre_reset, recanon_pphi, &
         orbit_microstep_sympl_spectre, sympl_landing_stats_reset, &
-        sympl_landing_stats, sympl_sheet_stats
+        sympl_landing_stats, sympl_landing_eval_stats, sympl_sheet_stats
     public :: sympl_fo_stats
     public :: SYMPL_SPECTRE_OK, SYMPL_SPECTRE_LOSS, SYMPL_SPECTRE_STOP, &
         SYMPL_SPECTRE_SKIM
@@ -106,6 +106,7 @@ module spectre_sympl_orbit
     end type sympl_spectre_state_t
 
     integer :: n_landings = 0
+    integer :: n_landing_evals = 0
     integer :: n_stops = 0
     integer :: n_sheet_entries = 0
     integer :: n_sheet_exits = 0
@@ -585,7 +586,7 @@ contains
         type(symplectic_integrator_t) :: si_best
         type(field_can_t) :: f_best
         real(dp) :: dir, t_lo, t_hi, f_lo, f_hi, t_mid, g, best
-        integer :: it, ierr_step, last_side
+        integer :: it, ierr_step, last_side, evals
         logical :: hi_valid
 
         dir = real(direction, dp)
@@ -595,6 +596,7 @@ contains
         f_hi = 0.0_dp
         hi_valid = .false.
         last_side = 0
+        evals = 0
 
         best = huge(1.0_dp)
         h_land = h_full
@@ -622,6 +624,7 @@ contains
             f = f0
             si%dt = t_mid
             call orbit_timestep_sympl(si, f, ierr_step)
+            evals = evals + 1
             g = dir*(si%z(1) - rho_k)
             if (ierr_step /= 0 .or. g /= g .or. &
                 step_teleported(si0, f0, si, f)) then
@@ -659,6 +662,9 @@ contains
             si = si_best
             f = f_best
         end if
+        !$omp critical (spectre_sympl_landing)
+        n_landing_evals = n_landing_evals + evals
+        !$omp end critical (spectre_sympl_landing)
     end subroutine locate_landing
 
     subroutine landed_state(si, f, rho_k, direction, y)
@@ -896,6 +902,7 @@ contains
     subroutine sympl_landing_stats_reset
         !$omp critical (spectre_sympl_landing)
         n_landings = 0
+        n_landing_evals = 0
         n_stops = 0
         n_sheet_entries = 0
         n_sheet_exits = 0
@@ -922,6 +929,17 @@ contains
         stops = n_stops
         !$omp end critical (spectre_sympl_landing)
     end subroutine sympl_landing_stats
+
+    subroutine sympl_landing_eval_stats(evals)
+        !> Total implicit-step evaluations spent inside locate_landing since
+        !> the last reset; evaluations/landing is the root-iteration cost the
+        !> seeded bracket shrink is measured by.
+        integer, intent(out) :: evals
+
+        !$omp critical (spectre_sympl_landing)
+        evals = n_landing_evals
+        !$omp end critical (spectre_sympl_landing)
+    end subroutine sympl_landing_eval_stats
 
     subroutine count_sheet_stat(kind, status)
         integer, intent(in) :: kind

--- a/test/tests/field_can/test_spectre_sympl_crossing.f90
+++ b/test/tests/field_can/test_spectre_sympl_crossing.f90
@@ -43,8 +43,8 @@ program test_spectre_sympl_crossing
     use spectre_sympl_orbit, only: sympl_spectre_state_t, sympl_spectre_reset, &
                                    orbit_microstep_sympl_spectre, recanon_pphi, &
                                    sympl_landing_stats_reset, &
-                                   sympl_landing_stats, sympl_fo_stats, &
-                                   SYMPL_SPECTRE_OK
+                                   sympl_landing_stats, sympl_landing_eval_stats, &
+                                   sympl_fo_stats, SYMPL_SPECTRE_OK
     use spectre_fo_hybrid, only: spectre_fo_canonical_pzeta, SPECTRE_FO_OK
     use parmot_mod, only: ro0
     use interface_crossing, only: crossing_log_reset, crossing_log_count_type, &
@@ -76,6 +76,7 @@ program test_spectre_sympl_crossing
     real(dp) :: shell_defect, seg_drift, pphi_walk, max_resid
     integer :: transition_series(NREC), mode_series(NREC)
     integer :: im, nrec_got, n_cross, n_stop, landings, stops, n_crossers
+    integer :: landing_evals
     integer :: n_sheet, n_transitions, n_fo_entries, n_fo_exits, n_fo_losses
     integer :: n_fo_failures, n_fo_status(5)
     logical :: failed, crosser
@@ -166,6 +167,7 @@ program test_spectre_sympl_crossing
     n_sheet = crossing_log_count_type(CROSS_SHEET)
     n_stop = crossing_log_count_type(CROSS_STOP)
     call sympl_landing_stats(landings, max_resid, stops)
+    call sympl_landing_eval_stats(landing_evals)
     call sympl_fo_stats(n_fo_entries, n_fo_exits, n_fo_losses, n_fo_failures, &
         n_fo_status)
     n_transitions = n_cross + n_sheet + n_fo_entries
@@ -173,7 +175,8 @@ program test_spectre_sympl_crossing
     print '(A,I0,A,I0,A,I0,A,I0,A,I0)', 'events: crossings=', n_cross, &
         ' sheet=', n_sheet, ' fo_entries=', n_fo_entries, ' landings=', landings, &
         ' cross_stop=', n_stop
-    print '(A,ES12.4)', 'landing: max |rho_g - k| = ', max_resid
+    print '(A,ES12.4,A,I0)', 'landing: max |rho_g - k| = ', max_resid, &
+        '  evaluations = ', landing_evals
 
     if (n_crossers < 2) then
         print '(A,I0)', 'FAIL: fewer than 2 crossing markers: ', n_crossers


### PR DESCRIPTION
## Summary

Record the number of landing-root evaluations in the existing SPECTRE crossing invariant diagnostic. This makes the landing solve cost observable without changing the solve, acceptance tolerances, map, or trajectory.

## Verification

### Test fails on main

```text
ctest --test-dir build -R ^test_spectre_sympl_crossing_invariants$ -V | rg evaluations\ =
# no matching diagnostic
```

### Test passes after fix

```text
landing root evaluations = 55445
symplectic multi-volume invariants PASS
```