### PR TITLE
Honor explicit SPECTRE starting points

### DIFF
--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -125,7 +125,11 @@ contains
             call init_magfie(SPECTRE)
             call print_phase_time('SPECTRE magfie initialization completed')
 
-            call sample_spectre_surface(zstart)
+            if (startmode == 1) then
+                call sample_spectre_surface(zstart)
+            else
+                call sample_particles(.true.)
+            end if
             call print_phase_time('SPECTRE particle sampling completed')
 
             if (generate_start_only) stop 'stopping after generating start.dat'

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -847,6 +847,16 @@ set_tests_properties(test_spectre_gc_rk45 PROPERTIES
     LABELS "integration;python"
     TIMEOUT 120)
 
+add_test(NAME test_spectre_startmode2
+    COMMAND ${BOOZER_CHARTMAP_PYTHON}
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_spectre_startmode2.py
+        $<TARGET_FILE:simple.x>
+        ${libneo_SOURCE_DIR}/test/spectre/data/spectre_test.h5
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+set_tests_properties(test_spectre_startmode2 PROPERTIES
+    LABELS "integration;python"
+    TIMEOUT 120)
+
 # SPECTRE per-volume symplectic guiding-center tracing (#439): bounded non-secular
 # energy, cross-scheme consistency, and RK45 cross-check on the committed fixture.
 add_test(NAME test_spectre_sympl_volume

--- a/test/tests/test_spectre_startmode2.py
+++ b/test/tests/test_spectre_startmode2.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""SPECTRE startmode=2 must preserve explicit starting points."""
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+
+STARTS = np.array([
+    [0.25, 0.1, 0.2, 1.0, 0.3],
+    [1.25, 1.1, 0.7, 2.0, -0.2],
+    [2.25, 2.2, 0.4, 0.5, 0.8],
+])
+
+
+def config(field):
+    return f"""&config
+field_input = '{field}'
+integ_coords = 6
+integmode = 0
+ntestpart = {len(STARTS)}
+startmode = 2
+generate_start_only = .True.
+spectre_ncon_r = 8
+spectre_ncon_th = 8
+spectre_ncon_phi = 8
+/
+"""
+
+
+def main():
+    binary, field = map(Path, sys.argv[1:])
+    with tempfile.TemporaryDirectory() as tmp:
+        work = Path(tmp)
+        np.savetxt(work / "start.dat", STARTS, fmt="%.17g")
+        (work / "simple.in").write_text(config(field.resolve()))
+        proc = subprocess.run([binary.resolve(), "simple.in"], cwd=work,
+                              capture_output=True, text=True, timeout=120)
+        if proc.returncode != 0:
+            raise RuntimeError(proc.stdout + proc.stderr)
+        actual = np.loadtxt(work / "start.dat")
+        if not np.array_equal(actual, STARTS):
+            raise AssertionError(f"explicit starts were replaced:\n{actual}")
+    print("SPECTRE startmode=2 explicit starts PASS")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Risk tier

- [x] T3: physics, output behavior, coordinate convention

## Correctness contract

### Intended behavior change

SPECTRE runs with `startmode=2` read and preserve the explicit `start.dat` particle states. Previously the SPECTRE initialization path always called the surface sampler and replaced them.

### Behavior that must not change

`startmode=1` retains the existing deterministic SPECTRE surface sampler. Field construction, orbit integration, interface crossing, and all non-SPECTRE sampling paths are unchanged.

### Coordinate / unit conventions

The five `start.dat` columns remain stacked SPECTRE radius, poloidal angle in radians, toroidal angle in radians, speed normalized by the configured reference speed, and pitch `v_parallel/v`.

### Numerical invariants

No numerical algorithm changes. Explicit inputs are preserved bit-for-bit through particle initialization, and the existing SPECTRE RK45 energy, boundary-accounting, and deterministic-sampler checks remain green.

## Tests added

- unit: none
- integration: `test_spectre_startmode2`
- system: none
- golden record: unchanged

## Golden-record impact

- [x] unchanged
- [ ] changed

## Failure modes considered

Malformed or incomplete `start.dat` input retains the existing reader failure. Other explicit start modes continue through the shared sampler dispatcher. `startmode=1` remains on the SPECTRE-specific surface sampler.

## Manual validation

Three explicit states in different SPECTRE volumes, with distinct angles, speeds, and pitches, remain exact after initialization.

## Verification

Failing before:

```text
AssertionError: explicit starts were replaced:
[[ 0.5 ... 1. ...]
 [ 0.5 ... 1. ...]
 [ 0.5 ... 1. ...]]
```

Passing after:

```text
test_spectre_startmode2                    PASS       0.15s
test_spectre_gc_rk45                       PASS       0.54s
Summary: 2 passed, 0 failed, 0 skipped (  0.69s)
```

Complete gate:

```text
Static: OK (172 modules, 172 changed, 172 affected)
Build: OK
Tests: OK
Lint: OK
Fmt: WARN
All stages passed
```

The formatter warning is pre-existing file-wide drift; applying it would rewrite 214 unrelated lines, so this PR keeps the production diff to the sampler dispatch.
