### PR TITLE
Record passing-orbit filters in NetCDF results

### DIFF
--- a/src/netcdf_results_output.f90
+++ b/src/netcdf_results_output.f90
@@ -50,6 +50,7 @@ contains
                           canonical_grid_nr, canonical_grid_ntheta, &
                           canonical_grid_nphi, canonical_ode_relerr, &
                           ntimstep, startmode, num_surf, sbeg, &
+                          contr_pp, notrace_passing, &
                           isw_field_type, swcoll, deterministic, ran_seed, &
                           netcdffile, field_input, coord_input, &
                           wall_input, wall_units, wall_hit, wall_hit_cart, &
@@ -336,6 +337,11 @@ contains
         call check_nc(status, 'put_att num_surf')
         status = nf90_put_att(ncid, nf90_global, 'sbeg', sbeg)
         call check_nc(status, 'put_att sbeg')
+        status = nf90_put_att(ncid, nf90_global, 'contr_pp', contr_pp)
+        call check_nc(status, 'put_att contr_pp')
+        status = nf90_put_att(ncid, nf90_global, 'notrace_passing', &
+                              notrace_passing)
+        call check_nc(status, 'put_att notrace_passing')
         status = nf90_put_att(ncid, nf90_global, 'isw_field_type', isw_field_type)
         call check_nc(status, 'put_att isw_field_type')
         status = nf90_put_att(ncid, nf90_global, 'swcoll', merge(1, 0, swcoll))

--- a/test/python/test_netcdf_results.py
+++ b/test/python/test_netcdf_results.py
@@ -43,6 +43,8 @@ class TestNetCDFResultsOutput:
                 ntestpart=8,
                 output_results_netcdf=True,
                 isw_field_type=3,
+                contr_pp=-1e10,
+                notrace_passing=0,
             )
             particles = pysimple.sample_surface(8, s=0.5)
             pysimple.trace_parallel(particles)
@@ -89,6 +91,8 @@ class TestNetCDFResultsOutput:
                 assert ds.canonical_grid_nphi == 64
                 assert ds.canonical_ode_relerr == 1e-11
                 assert ds.multharm == 5
+                assert ds.contr_pp == -1e10
+                assert ds.notrace_passing == 0
 
         finally:
             os.chdir(original_dir)


### PR DESCRIPTION
## Summary

- write `contr_pp` and `notrace_passing` as global attributes in `results.nc`
- verify an explicit nondefault threshold and the integer trace switch through the Python NetCDF test

## Review path

1. Review the two additive `nf90_put_att` calls in `src/netcdf_results_output.f90`.
2. Review the four test lines in `test/python/test_netcdf_results.py`.
3. Confirm that the output schema change is additive and metadata-only.

## Preserved invariants

This does not change the Hamiltonian, particle source, field, boundary event,
integration, convergence criteria, orbit classification, memory layout, ABI,
or generated trajectory data. It only records two existing run controls so a
downstream analysis can distinguish traced and intentionally skipped passing
orbits without recovering the input namelist.

## Verification

### Failing before

After adding the assertions but before writing the attributes:

```text
$ ctest --test-dir build-python -R '^test_netcdf_results$' --output-on-failure
TestNetCDFResultsOutput::test_results_netcdf_created FAILED
E   AttributeError: NetCDF: Attribute not found
```

### Passing after

```text
$ uv run --with-requirements requirements.txt --no-project bash -c \
  'export PYTHONPATH="$PWD/build-python/python:$PWD/build-python:$PWD/python"; \
   python -m pytest test/python/test_netcdf_results.py::TestNetCDFResultsOutput::test_results_netcdf_created -v'
1 passed in 17.87s

$ FO_TEST_TIMEOUT=600 fo
Static: OK (192 modules, 192 changed, 192 affected)
Build: OK
Tests: OK
Lint: OK
All stages passed
```

`fo` also reports the pre-existing whole-file formatting warning for
`netcdf_results_output.f90`; this focused PR does not reindent unrelated lines.
