### PR TITLE
Continue symplectic integrators after finite Newton maxiter

### DIFF
--- a/DOC/config.md
+++ b/DOC/config.md
@@ -11,6 +11,14 @@
   Both default to `-1`, which derives the tolerance from `relerr`. Set positive
   values to refine event location independently of the nonlinear solve.
 
+* `symplectic_newton_warning_mode` defaults to `.true.` and preserves the
+  historical behavior of continuing from the final finite Newton iterate when
+  an implicit solve reaches its iteration limit. Each occurrence is reported
+  by the corresponding `*_maxit` diagnostic. Set it to `.false.` to stop the
+  affected orbit at its last accepted position. Exterior-domain, singular
+  linear-system, non-finite, and unresolved boundary-event states always stop
+  the orbit.
+
 * `canonical_grid_nr`, `canonical_grid_ntheta`, and `canonical_grid_nphi`
   control the Meiss or Albert canonical-map grid. Their defaults are 62, 63,
   and 64. Each dimension must be between 6 and 512, and their product must not

--- a/src/diag_counters.f90
+++ b/src/diag_counters.f90
@@ -15,7 +15,7 @@ module diag_counters
 
     public :: EVT_NEWTON1_MAXIT, EVT_NEWTON2_MAXIT, EVT_RK_GAUSS_MAXIT, &
               EVT_RK_LOBATTO_MAXIT, EVT_FIXPOINT_MAXIT, EVT_R_NEGATIVE, &
-              EVT_FO_LOSS, EVT_FO_FAULT, N_EVENT
+              EVT_FO_LOSS, EVT_FO_FAULT, EVT_MIDPOINT_MAXIT, N_EVENT
     public :: diag_counters_init, count_event, diag_counters_total, &
               diag_counters_reset, event_name
 
@@ -30,11 +30,12 @@ module diag_counters
     ! s >= 1 crossing (physical loss); FAULT = field-inversion non-convergence.
     integer, parameter :: EVT_FO_LOSS = 7
     integer, parameter :: EVT_FO_FAULT = 8
-    integer, parameter :: N_EVENT = 8
+    integer, parameter :: EVT_MIDPOINT_MAXIT = 9
+    integer, parameter :: N_EVENT = 9
 
-    ! One cache line (64 B = 8 int64) per thread column, so neighbouring threads
-    ! never share a line. The event id indexes within a column; STRIDE >= N_EVENT.
-    integer, parameter :: STRIDE = 8
+    ! Whole cache lines per thread column keep neighbouring threads from sharing
+    ! a line. The event id indexes within a column; STRIDE >= N_EVENT.
+    integer, parameter :: STRIDE = 16
     integer(int64), allocatable :: counts(:, :)  ! (STRIDE, 0:nthreads-1)
 
 contains
@@ -95,6 +96,8 @@ contains
             name = 'fo_loss'
         case (EVT_FO_FAULT)
             name = 'fo_fault'
+        case (EVT_MIDPOINT_MAXIT)
+            name = 'midpoint_maxit'
         case default
             name = 'unknown'
         end select

--- a/src/orbit_symplectic.f90
+++ b/src/orbit_symplectic.f90
@@ -1,6 +1,6 @@
 module orbit_symplectic
 
-use, intrinsic :: iso_fortran_env, only: dp => real64
+use, intrinsic :: iso_fortran_env, only: dp => real64, int64
 use util, only: pi, twopi
 use field_can_mod, only: field_can_t, get_val, get_derivatives, get_derivatives2, &
   eval_field => evaluate
@@ -12,7 +12,7 @@ use orbit_symplectic_base, only: symplectic_integrator_t, multistage_integrator_
   SYMPLECTIC_STEP_MAXITER, SYMPLECTIC_STEP_LINEAR_SOLVE, &
   SYMPLECTIC_STEP_BOUNDARY, SYMPLECTIC_STEP_EVENT_NOT_CONVERGED, &
   SYMPLECTIC_STEP_BOUNDARY_LIMITED, boundary_event_fraction_tolerance, &
-  boundary_event_radial_tolerance, symplectic_euler_warning_mode
+  boundary_event_radial_tolerance, symplectic_newton_warning_mode
 use orbit_symplectic_quasi, only: orbit_timestep_quasi, timestep_expl_impl_euler_quasi, &
   timestep_impl_expl_euler_quasi, timestep_midpoint_quasi, orbit_timestep_rk45, &
   timestep_rk_gauss_quasi, timestep_rk_lobatto_quasi
@@ -23,8 +23,8 @@ use orbit_rk_core, only: rk_gauss_residual, rk_gauss_jacobian, MODEL_GC
 use vector_potentail_mod, only: torflux
 use lapack_interfaces, only: dgesv
 use diag_counters, only: count_event, EVT_NEWTON1_MAXIT, EVT_NEWTON2_MAXIT, &
-  EVT_RK_GAUSS_MAXIT, EVT_RK_LOBATTO_MAXIT, EVT_FIXPOINT_MAXIT, EVT_R_NEGATIVE
-use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+  EVT_RK_GAUSS_MAXIT, EVT_RK_LOBATTO_MAXIT, EVT_FIXPOINT_MAXIT, EVT_R_NEGATIVE, &
+  EVT_MIDPOINT_MAXIT
 
 implicit none
 
@@ -32,6 +32,29 @@ procedure(orbit_timestep_sympl_i), pointer :: orbit_timestep_sympl => null()
 procedure(orbit_timestep_sympl_i), pointer, private :: raw_timestep_sympl => null()
 
 contains
+
+pure logical function finite_newton_iterate(x)
+  real(dp), intent(in) :: x(:)
+
+  integer(int64), parameter :: exponent_mask = &
+    int(z'7FF0000000000000', int64)
+  integer(int64) :: bits
+  integer :: i
+
+  finite_newton_iterate = .false.
+  do i = 1, size(x)
+    bits = transfer(x(i), bits)
+    if (iand(bits, exponent_mask) == exponent_mask) return
+  end do
+  finite_newton_iterate = .true.
+end function finite_newton_iterate
+
+logical function accept_finite_maxiter(x)
+  real(dp), intent(in) :: x(:)
+
+  accept_finite_maxiter = symplectic_newton_warning_mode .and. &
+    finite_newton_iterate(x)
+end function accept_finite_maxiter
 
 subroutine apply_axis_chart_switch(radius, theta, crossed, status)
   real(dp), intent(inout) :: radius, theta
@@ -449,9 +472,7 @@ recursive subroutine newton1(si, f, x, maxit, xlast, status)
     end if
   else
     call count_event(EVT_NEWTON1_MAXIT)
-    if (symplectic_euler_warning_mode .and. all(ieee_is_finite(x))) then
-      status = SYMPLECTIC_STEP_OK
-    end if
+    if (accept_finite_maxiter(x)) status = SYMPLECTIC_STEP_OK
   end if
 end subroutine
 
@@ -545,6 +566,7 @@ recursive subroutine newton2(si, f, x, atol, rtol, maxit, xlast, status)
     end if
   else
     call count_event(EVT_NEWTON2_MAXIT)
+    if (accept_finite_maxiter(x)) status = SYMPLECTIC_STEP_OK
   end if
 end subroutine
 
@@ -699,6 +721,9 @@ recursive subroutine newton_midpoint(si, f, x, atol, rtol, maxit, xlast, status)
     else
       status = SYMPLECTIC_STEP_BOUNDARY_LIMITED
     end if
+  else
+    call count_event(EVT_MIDPOINT_MAXIT)
+    if (accept_finite_maxiter(x)) status = SYMPLECTIC_STEP_OK
   end if
 end subroutine
 
@@ -822,6 +847,7 @@ recursive subroutine newton_rk_gauss(si, fs, s, x, atol, rtol, maxit, xlast, sta
     end if
   else
     call count_event(EVT_RK_GAUSS_MAXIT)
+    if (accept_finite_maxiter(x)) status = SYMPLECTIC_STEP_OK
   end if
 end subroutine newton_rk_gauss
 
@@ -1162,6 +1188,7 @@ recursive subroutine newton_rk_lobatto(si, fs, s, x, atol, rtol, maxit, xlast, s
     end if
   else
     call count_event(EVT_RK_LOBATTO_MAXIT)
+    if (accept_finite_maxiter(x)) status = SYMPLECTIC_STEP_OK
   end if
 end subroutine newton_rk_lobatto
 

--- a/src/orbit_symplectic.f90
+++ b/src/orbit_symplectic.f90
@@ -12,7 +12,7 @@ use orbit_symplectic_base, only: symplectic_integrator_t, multistage_integrator_
   SYMPLECTIC_STEP_MAXITER, SYMPLECTIC_STEP_LINEAR_SOLVE, &
   SYMPLECTIC_STEP_BOUNDARY, SYMPLECTIC_STEP_EVENT_NOT_CONVERGED, &
   SYMPLECTIC_STEP_BOUNDARY_LIMITED, boundary_event_fraction_tolerance, &
-  boundary_event_radial_tolerance
+  boundary_event_radial_tolerance, symplectic_euler_warning_mode
 use orbit_symplectic_quasi, only: orbit_timestep_quasi, timestep_expl_impl_euler_quasi, &
   timestep_impl_expl_euler_quasi, timestep_midpoint_quasi, orbit_timestep_rk45, &
   timestep_rk_gauss_quasi, timestep_rk_lobatto_quasi
@@ -24,6 +24,7 @@ use vector_potentail_mod, only: torflux
 use lapack_interfaces, only: dgesv
 use diag_counters, only: count_event, EVT_NEWTON1_MAXIT, EVT_NEWTON2_MAXIT, &
   EVT_RK_GAUSS_MAXIT, EVT_RK_LOBATTO_MAXIT, EVT_FIXPOINT_MAXIT, EVT_R_NEGATIVE
+use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
 
 implicit none
 
@@ -448,6 +449,9 @@ recursive subroutine newton1(si, f, x, maxit, xlast, status)
     end if
   else
     call count_event(EVT_NEWTON1_MAXIT)
+    if (symplectic_euler_warning_mode .and. all(ieee_is_finite(x))) then
+      status = SYMPLECTIC_STEP_OK
+    end if
   end if
 end subroutine
 

--- a/src/orbit_symplectic_base.f90
+++ b/src/orbit_symplectic_base.f90
@@ -26,6 +26,7 @@ use field_can_mod, only: eval_field => evaluate, field_can_t, get_val, get_deriv
     integer, parameter :: SYMPLECTIC_STEP_BOUNDARY = 4
     integer, parameter :: SYMPLECTIC_STEP_EVENT_NOT_CONVERGED = 5
     integer, parameter :: SYMPLECTIC_STEP_BOUNDARY_LIMITED = 6
+    logical :: symplectic_euler_warning_mode = .true.
     real(dp) :: boundary_event_fraction_tolerance = -1d0
     real(dp) :: boundary_event_radial_tolerance = -1d0
 

--- a/src/orbit_symplectic_base.f90
+++ b/src/orbit_symplectic_base.f90
@@ -26,7 +26,7 @@ use field_can_mod, only: eval_field => evaluate, field_can_t, get_val, get_deriv
     integer, parameter :: SYMPLECTIC_STEP_BOUNDARY = 4
     integer, parameter :: SYMPLECTIC_STEP_EVENT_NOT_CONVERGED = 5
     integer, parameter :: SYMPLECTIC_STEP_BOUNDARY_LIMITED = 6
-    logical :: symplectic_euler_warning_mode = .true.
+    logical :: symplectic_newton_warning_mode = .true.
     real(dp) :: boundary_event_fraction_tolerance = -1d0
     real(dp) :: boundary_event_radial_tolerance = -1d0
 

--- a/src/params.f90
+++ b/src/params.f90
@@ -15,7 +15,7 @@ module params
                                      EXPL_IMPL_EULER, &
                                      boundary_event_fraction_tolerance, &
                                      boundary_event_radial_tolerance, &
-                                     symplectic_euler_warning_mode
+                                     symplectic_newton_warning_mode
     use vmecin_sub, only: stevvo
     use callback, only: output_error, output_orbits_macrostep
 
@@ -165,7 +165,7 @@ module params
 	        facE_al, npoiper2, n_e, n_d, netcdffile, ns_s, ns_tp, multharm, &
 	        isw_field_type, generate_start_only, startmode, grid_density, &
 	        special_ants_file, integmode, orbit_model, orbit_coord, relerr, &
-	        symplectic_euler_warning_mode, &
+	        symplectic_newton_warning_mode, &
 	        boundary_event_fraction_tolerance, boundary_event_radial_tolerance, &
 	        canonical_grid_nr, canonical_grid_ntheta, canonical_grid_nphi, &
 	        canonical_ode_relerr, &
@@ -204,10 +204,9 @@ contains
 
         call reset_seed_if_deterministic
 
-        if (integmode == EXPL_IMPL_EULER .and. symplectic_euler_warning_mode) then
-            print *, 'WARNING: explicit-implicit symplectic Euler accepts ', &
-                'finite Newton iterates after the iteration limit; ', &
-                'see newton1_maxit diagnostics'
+        if (integmode > 0 .and. symplectic_newton_warning_mode) then
+            print *, 'WARNING: symplectic integrators accept finite Newton ', &
+                'iterates after the iteration limit; see maxit diagnostics'
         end if
 
         call validate_boundary_event_tolerances

--- a/src/params.f90
+++ b/src/params.f90
@@ -204,9 +204,10 @@ contains
 
         call reset_seed_if_deterministic
 
-        if (symplectic_euler_warning_mode) then
-            print *, 'WARNING: symplectic Euler accepts finite Newton iterates ', &
-                'after the iteration limit; see newton1_maxit diagnostics'
+        if (integmode == EXPL_IMPL_EULER .and. symplectic_euler_warning_mode) then
+            print *, 'WARNING: explicit-implicit symplectic Euler accepts ', &
+                'finite Newton iterates after the iteration limit; ', &
+                'see newton1_maxit diagnostics'
         end if
 
         call validate_boundary_event_tolerances

--- a/src/params.f90
+++ b/src/params.f90
@@ -14,7 +14,8 @@ module params
     use orbit_symplectic_base, only: symplectic_integrator_t, multistage_integrator_t, &
                                      EXPL_IMPL_EULER, &
                                      boundary_event_fraction_tolerance, &
-                                     boundary_event_radial_tolerance
+                                     boundary_event_radial_tolerance, &
+                                     symplectic_euler_warning_mode
     use vmecin_sub, only: stevvo
     use callback, only: output_error, output_orbits_macrostep
 
@@ -164,6 +165,7 @@ module params
 	        facE_al, npoiper2, n_e, n_d, netcdffile, ns_s, ns_tp, multharm, &
 	        isw_field_type, generate_start_only, startmode, grid_density, &
 	        special_ants_file, integmode, orbit_model, orbit_coord, relerr, &
+	        symplectic_euler_warning_mode, &
 	        boundary_event_fraction_tolerance, boundary_event_radial_tolerance, &
 	        canonical_grid_nr, canonical_grid_ntheta, canonical_grid_nphi, &
 	        canonical_ode_relerr, &
@@ -201,6 +203,11 @@ contains
         call apply_config_aliases
 
         call reset_seed_if_deterministic
+
+        if (symplectic_euler_warning_mode) then
+            print *, 'WARNING: symplectic Euler accepts finite Newton iterates ', &
+                'after the iteration limit; see newton1_maxit diagnostics'
+        end if
 
         call validate_boundary_event_tolerances
         if (min(canonical_grid_nr, canonical_grid_ntheta, &

--- a/src/simple_gpu.f90
+++ b/src/simple_gpu.f90
@@ -8,14 +8,14 @@ module simple_gpu
     ! module keeps the device-side field evaluation local and reuses the shared
     ! symplectic-Euler algebra from orbit_symplectic_euler1. Equivalence is
     ! checked against the CPU path by test_gpu_orbit_bench.
-    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use, intrinsic :: iso_fortran_env, only: dp => real64, int64
     use util, only: pi
     use field_can_mod, only: field_can_t, get_derivatives, get_derivatives2
     use field_can_boozer, only: eval_field_booz
     use orbit_symplectic_base, only: symplectic_integrator_t, &
         SYMPLECTIC_STEP_OK, SYMPLECTIC_STEP_OUTSIDE_DOMAIN, &
         SYMPLECTIC_STEP_MAXITER, SYMPLECTIC_STEP_LINEAR_SOLVE, &
-        SYMPLECTIC_STEP_BOUNDARY_LIMITED
+        SYMPLECTIC_STEP_BOUNDARY_LIMITED, symplectic_newton_warning_mode
     use orbit_symplectic_euler1, only: sympl_euler1_newton_iter
     use orbit_symplectic_euler1, only: sympl_euler1_extrapolate_field, sympl_euler1_advance_angles
     use boozer_sub, only: boozer_state
@@ -33,12 +33,30 @@ module simple_gpu
 
 contains
 
-    subroutine gpu_newton1(si, f, x, xlast, status)
+    logical function gpu_finite_iterate(x)
+        !$acc routine seq
+        real(dp), intent(in) :: x(:)
+
+        integer(int64), parameter :: exponent_mask = &
+            int(z'7FF0000000000000', int64)
+        integer(int64) :: bits
+        integer :: i
+
+        gpu_finite_iterate = .false.
+        do i = 1, size(x)
+            bits = transfer(x(i), bits)
+            if (iand(bits, exponent_mask) == exponent_mask) return
+        end do
+        gpu_finite_iterate = .true.
+    end function gpu_finite_iterate
+
+    subroutine gpu_newton1(si, f, x, xlast, warning_mode, status)
         !$acc routine seq
         type(symplectic_integrator_t), intent(inout) :: si
         type(field_can_t), intent(inout) :: f
         real(dp), intent(inout) :: x(2)
         real(dp), intent(out) :: xlast(2)
+        logical, intent(in) :: warning_mode
         integer, intent(out) :: status
 
         real(dp) :: tolref(2)
@@ -87,14 +105,17 @@ contains
             else
                 status = SYMPLECTIC_STEP_BOUNDARY_LIMITED
             end if
+        else if (warning_mode .and. gpu_finite_iterate(x)) then
+            status = SYMPLECTIC_STEP_OK
         end if
         ! Non-convergence diagnostics (CPU writes fort.6601) are omitted on device.
     end subroutine gpu_newton1
 
-    subroutine gpu_timestep_euler(si, f, ierr)
+    subroutine gpu_timestep_euler(si, f, warning_mode, ierr)
         !$acc routine seq
         type(symplectic_integrator_t), intent(inout) :: si
         type(field_can_t), intent(inout) :: f
+        logical, intent(in) :: warning_mode
         integer, intent(out) :: ierr
 
         real(dp) :: x(2), xlast(2)
@@ -113,7 +134,7 @@ contains
             x(1) = si%z(1)
             x(2) = si%z(4)
 
-            call gpu_newton1(si, f, x, xlast, newton_status)
+            call gpu_newton1(si, f, x, xlast, warning_mode, newton_status)
             if (newton_status /= SYMPLECTIC_STEP_OK) then
                 si = accepted_integrator
                 f = accepted_field
@@ -173,17 +194,20 @@ contains
         real(dp), intent(out) :: zend(4, npart)
 
         integer :: i, it, ktau, ierr, lstep
+        logical :: warning_mode
+
+        warning_mode = symplectic_newton_warning_mode
 
         !$acc parallel loop gang vector default(present) &
         !$acc&   copy(si(istart:iend), f(istart:iend)) copyin(ntau_macro) &
         !$acc&   copyout(loss_step(istart:iend), zend(:, istart:iend)) &
-        !$acc&   private(it, ktau, ierr, lstep)
+        !$acc&   private(it, ktau, ierr, lstep) firstprivate(warning_mode)
         do i = istart, iend
             ierr = 0
             lstep = ntimstep
             macro: do it = 2, ntimstep
                 do ktau = 1, ntau_macro(it)
-                    call gpu_timestep_euler(si(i), f(i), ierr)
+                    call gpu_timestep_euler(si(i), f(i), warning_mode, ierr)
                     if (ierr /= 0) exit
                 end do
                 if (ierr /= 0) then

--- a/test/tests/test_newton_solver_status.f90
+++ b/test/tests/test_newton_solver_status.f90
@@ -69,7 +69,7 @@ program test_newton_solver_status
   use linear_radial_field_backend, only: basin_limited_step, &
     evaluate_linear_radial, nonlinear_boundary_step
   use orbit_symplectic, only: guard_lobatto_stage_radii, boundary_event_converged, &
-    advance_symplectic_with_boundary, newton_midpoint, orbit_sympl_init, &
+    advance_symplectic_with_boundary, newton1, newton_midpoint, orbit_sympl_init, &
     orbit_timestep_sympl, matrix3_near_singular, solve_newton_system, &
     get_boundary_event_tolerances
   use orbit_symplectic_base, only: symplectic_integrator_t, &
@@ -78,13 +78,15 @@ program test_newton_solver_status
     SYMPLECTIC_STEP_OK, SYMPLECTIC_STEP_OUTSIDE_DOMAIN, &
     SYMPLECTIC_STEP_MAXITER, SYMPLECTIC_STEP_LINEAR_SOLVE, &
     SYMPLECTIC_STEP_EVENT_NOT_CONVERGED, SYMPLECTIC_STEP_BOUNDARY_LIMITED, &
-    boundary_event_fraction_tolerance, boundary_event_radial_tolerance
+    boundary_event_fraction_tolerance, boundary_event_radial_tolerance, &
+    symplectic_euler_warning_mode
 
   implicit none
 
   type(symplectic_integrator_t) :: integrator
   type(field_can_t) :: field
   real(dp) :: x(5), xlast(5), matrix(2, 2), residual(2), matrix3(3, 3)
+  real(dp) :: euler_x(2), euler_xlast(2)
   real(dp) :: lobatto_state(10), expected_lobatto_state(10)
   integer :: i, status
 
@@ -97,6 +99,19 @@ program test_newton_solver_status
     error stop 'zero-iteration midpoint solve did not report max iterations'
   end if
   if (any(xlast /= x)) error stop 'zero-iteration solve changed the iterate'
+
+  euler_x = [0.5_dp, 0.3_dp]
+  field%ro0 = 1.0_dp
+  symplectic_euler_warning_mode = .false.
+  call newton1(integrator, field, euler_x, 0, euler_xlast, status)
+  if (status /= SYMPLECTIC_STEP_MAXITER) then
+    error stop 'strict Euler mode did not report max iterations'
+  end if
+  symplectic_euler_warning_mode = .true.
+  call newton1(integrator, field, euler_x, 0, euler_xlast, status)
+  if (status /= SYMPLECTIC_STEP_OK) then
+    error stop 'Euler warning mode did not accept the finite iterate'
+  end if
 
   x(1) = 1.1_dp
   call newton_midpoint(integrator, field, x, 1.0e-15_dp, 1.0e-12_dp, &

--- a/test/tests/test_newton_solver_status.f90
+++ b/test/tests/test_newton_solver_status.f90
@@ -64,12 +64,13 @@ contains
 end module linear_radial_field_backend
 
 program test_newton_solver_status
+  use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
   use, intrinsic :: iso_fortran_env, only: dp => real64
   use field_can_mod, only: field_can_t, eval_field => evaluate
   use linear_radial_field_backend, only: basin_limited_step, &
     evaluate_linear_radial, nonlinear_boundary_step
   use orbit_symplectic, only: guard_lobatto_stage_radii, boundary_event_converged, &
-    advance_symplectic_with_boundary, newton1, newton_midpoint, orbit_sympl_init, &
+    advance_symplectic_with_boundary, newton_midpoint, orbit_sympl_init, &
     orbit_timestep_sympl, matrix3_near_singular, solve_newton_system, &
     get_boundary_event_tolerances
   use orbit_symplectic_base, only: symplectic_integrator_t, &
@@ -86,7 +87,6 @@ program test_newton_solver_status
   type(symplectic_integrator_t) :: integrator
   type(field_can_t) :: field
   real(dp) :: x(5), xlast(5), matrix(2, 2), residual(2), matrix3(3, 3)
-  real(dp) :: euler_x(2), euler_xlast(2)
   real(dp) :: lobatto_state(10), expected_lobatto_state(10)
   integer :: i, status
 
@@ -99,19 +99,6 @@ program test_newton_solver_status
     error stop 'zero-iteration midpoint solve did not report max iterations'
   end if
   if (any(xlast /= x)) error stop 'zero-iteration solve changed the iterate'
-
-  euler_x = [0.5_dp, 0.3_dp]
-  field%ro0 = 1.0_dp
-  symplectic_euler_warning_mode = .false.
-  call newton1(integrator, field, euler_x, 0, euler_xlast, status)
-  if (status /= SYMPLECTIC_STEP_MAXITER) then
-    error stop 'strict Euler mode did not report max iterations'
-  end if
-  symplectic_euler_warning_mode = .true.
-  call newton1(integrator, field, euler_x, 0, euler_xlast, status)
-  if (status /= SYMPLECTIC_STEP_OK) then
-    error stop 'Euler warning mode did not accept the finite iterate'
-  end if
 
   x(1) = 1.1_dp
   call newton_midpoint(integrator, field, x, 1.0e-15_dp, 1.0e-12_dp, &
@@ -184,8 +171,49 @@ program test_newton_solver_status
   call test_lcfs_location
   call test_configured_event_tolerances
   call test_solver_basin_is_not_boundary
+  call test_euler_warning_mode
 
 contains
+
+  subroutine test_euler_warning_mode
+    type(symplectic_integrator_t) :: strict_integrator, warning_integrator
+    type(field_can_t) :: strict_field, warning_field
+    real(dp) :: initial_state(4)
+    integer :: euler_status
+
+    eval_field => evaluate_linear_radial
+    strict_field%ro0 = 1.0_dp
+    strict_field%mu = 1.0_dp
+    initial_state = [0.5_dp, 0.0_dp, 0.0_dp, 0.0_dp]
+    call orbit_sympl_init(strict_integrator, strict_field, initial_state, &
+      0.01_dp, 1, 0.0_dp, EXPL_IMPL_EULER)
+    strict_integrator%atol = 0.0_dp
+    symplectic_euler_warning_mode = .false.
+    call orbit_timestep_sympl(strict_integrator, strict_field, euler_status)
+    if (euler_status /= SYMPLECTIC_STEP_MAXITER) then
+      error stop 'strict Euler timestep did not report max iterations'
+    end if
+    if (any(strict_integrator%z /= initial_state)) then
+      error stop 'strict Euler max-iteration failure changed the accepted state'
+    end if
+
+    warning_field%ro0 = 1.0_dp
+    warning_field%mu = 1.0_dp
+    call orbit_sympl_init(warning_integrator, warning_field, initial_state, &
+      0.01_dp, 1, 0.0_dp, EXPL_IMPL_EULER)
+    warning_integrator%atol = 0.0_dp
+    symplectic_euler_warning_mode = .true.
+    call orbit_timestep_sympl(warning_integrator, warning_field, euler_status)
+    if (euler_status /= SYMPLECTIC_STEP_OK) then
+      error stop 'Euler warning mode did not continue the timestep'
+    end if
+    if (.not. all(ieee_is_finite(warning_integrator%z))) then
+      error stop 'Euler warning mode accepted a non-finite state'
+    end if
+    if (all(warning_integrator%z == initial_state)) then
+      error stop 'Euler warning mode did not commit the timestep'
+    end if
+  end subroutine test_euler_warning_mode
 
   subroutine test_configured_event_tolerances
     type(symplectic_integrator_t) :: loose_integrator, tight_integrator

--- a/test/tests/test_newton_solver_status.f90
+++ b/test/tests/test_newton_solver_status.f90
@@ -64,7 +64,8 @@ contains
 end module linear_radial_field_backend
 
 program test_newton_solver_status
-  use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+  use, intrinsic :: ieee_arithmetic, only: ieee_is_finite, ieee_quiet_nan, &
+    ieee_value
   use, intrinsic :: iso_fortran_env, only: dp => real64
   use field_can_mod, only: field_can_t, eval_field => evaluate
   use linear_radial_field_backend, only: basin_limited_step, &
@@ -74,13 +75,14 @@ program test_newton_solver_status
     orbit_timestep_sympl, matrix3_near_singular, solve_newton_system, &
     get_boundary_event_tolerances
   use orbit_symplectic_base, only: symplectic_integrator_t, &
-    EXPL_IMPL_EULER, IMPL_EXPL_EULER, MIDPOINT, LOBATTO3, &
+    EXPL_IMPL_EULER, IMPL_EXPL_EULER, MIDPOINT, GAUSS1, GAUSS2, GAUSS3, &
+    GAUSS4, LOBATTO3, &
     SYMPLECTIC_STEP_BOUNDARY, &
     SYMPLECTIC_STEP_OK, SYMPLECTIC_STEP_OUTSIDE_DOMAIN, &
     SYMPLECTIC_STEP_MAXITER, SYMPLECTIC_STEP_LINEAR_SOLVE, &
     SYMPLECTIC_STEP_EVENT_NOT_CONVERGED, SYMPLECTIC_STEP_BOUNDARY_LIMITED, &
     boundary_event_fraction_tolerance, boundary_event_radial_tolerance, &
-    symplectic_euler_warning_mode
+    symplectic_newton_warning_mode
 
   implicit none
 
@@ -93,12 +95,22 @@ program test_newton_solver_status
   field%Aph = 0.0_dp
   field%ro0 = 1.0_dp
   x = [0.5_dp, 0.1_dp, 0.2_dp, 0.3_dp, 0.5_dp]
+  symplectic_newton_warning_mode = .false.
   call newton_midpoint(integrator, field, x, 1.0e-15_dp, 1.0e-12_dp, &
     0, xlast, status)
   if (status /= SYMPLECTIC_STEP_MAXITER) then
     error stop 'zero-iteration midpoint solve did not report max iterations'
   end if
   if (any(xlast /= x)) error stop 'zero-iteration solve changed the iterate'
+
+  x(1) = ieee_value(0.0_dp, ieee_quiet_nan)
+  symplectic_newton_warning_mode = .true.
+  call newton_midpoint(integrator, field, x, 1.0e-15_dp, 1.0e-12_dp, &
+    0, xlast, status)
+  if (status /= SYMPLECTIC_STEP_MAXITER) then
+    error stop 'warning mode accepted a non-finite Newton iterate'
+  end if
+  symplectic_newton_warning_mode = .false.
 
   x(1) = 1.1_dp
   call newton_midpoint(integrator, field, x, 1.0e-15_dp, 1.0e-12_dp, &
@@ -171,49 +183,56 @@ program test_newton_solver_status
   call test_lcfs_location
   call test_configured_event_tolerances
   call test_solver_basin_is_not_boundary
-  call test_euler_warning_mode
+  call test_newton_warning_mode
 
 contains
 
-  subroutine test_euler_warning_mode
+  subroutine test_newton_warning_mode
+    integer, parameter :: modes(8) = [EXPL_IMPL_EULER, IMPL_EXPL_EULER, &
+      MIDPOINT, GAUSS1, GAUSS2, GAUSS3, GAUSS4, LOBATTO3]
     type(symplectic_integrator_t) :: strict_integrator, warning_integrator
     type(field_can_t) :: strict_field, warning_field
     real(dp) :: initial_state(4)
-    integer :: euler_status
+    integer :: mode_index, step_status
 
     eval_field => evaluate_linear_radial
-    strict_field%ro0 = 1.0_dp
-    strict_field%mu = 1.0_dp
     initial_state = [0.5_dp, 0.0_dp, 0.0_dp, 0.0_dp]
-    call orbit_sympl_init(strict_integrator, strict_field, initial_state, &
-      0.01_dp, 1, 0.0_dp, EXPL_IMPL_EULER)
-    strict_integrator%atol = 0.0_dp
-    symplectic_euler_warning_mode = .false.
-    call orbit_timestep_sympl(strict_integrator, strict_field, euler_status)
-    if (euler_status /= SYMPLECTIC_STEP_MAXITER) then
-      error stop 'strict Euler timestep did not report max iterations'
-    end if
-    if (any(strict_integrator%z /= initial_state)) then
-      error stop 'strict Euler max-iteration failure changed the accepted state'
-    end if
+    do mode_index = 1, size(modes)
+      strict_field%ro0 = 1.0_dp
+      strict_field%mu = 1.0_dp
+      call orbit_sympl_init(strict_integrator, strict_field, initial_state, &
+        0.01_dp, 1, 0.0_dp, modes(mode_index))
+      strict_integrator%atol = 0.0_dp
+      symplectic_newton_warning_mode = .false.
+      call orbit_timestep_sympl(strict_integrator, strict_field, step_status)
+      if (step_status /= SYMPLECTIC_STEP_MAXITER) then
+        print *, 'strict mode, status:', modes(mode_index), step_status
+        error stop 'strict timestep did not report max iterations'
+      end if
+      if (any(strict_integrator%z /= initial_state)) then
+        error stop 'strict max-iteration failure changed the accepted state'
+      end if
 
-    warning_field%ro0 = 1.0_dp
-    warning_field%mu = 1.0_dp
-    call orbit_sympl_init(warning_integrator, warning_field, initial_state, &
-      0.01_dp, 1, 0.0_dp, EXPL_IMPL_EULER)
-    warning_integrator%atol = 0.0_dp
-    symplectic_euler_warning_mode = .true.
-    call orbit_timestep_sympl(warning_integrator, warning_field, euler_status)
-    if (euler_status /= SYMPLECTIC_STEP_OK) then
-      error stop 'Euler warning mode did not continue the timestep'
-    end if
-    if (.not. all(ieee_is_finite(warning_integrator%z))) then
-      error stop 'Euler warning mode accepted a non-finite state'
-    end if
-    if (all(warning_integrator%z == initial_state)) then
-      error stop 'Euler warning mode did not commit the timestep'
-    end if
-  end subroutine test_euler_warning_mode
+      warning_field%ro0 = 1.0_dp
+      warning_field%mu = 1.0_dp
+      call orbit_sympl_init(warning_integrator, warning_field, initial_state, &
+        0.01_dp, 1, 0.0_dp, modes(mode_index))
+      warning_integrator%atol = 0.0_dp
+      symplectic_newton_warning_mode = .true.
+      call orbit_timestep_sympl(warning_integrator, warning_field, step_status)
+      if (step_status /= SYMPLECTIC_STEP_OK) then
+        print *, 'warning mode, status:', modes(mode_index), step_status
+        error stop 'warning mode did not continue the timestep'
+      end if
+      if (.not. all(ieee_is_finite(warning_integrator%z))) then
+        error stop 'warning mode accepted a non-finite state'
+      end if
+      if (modes(mode_index) == EXPL_IMPL_EULER .and. &
+          all(warning_integrator%z == initial_state)) then
+        error stop 'warning mode did not commit the timestep'
+      end if
+    end do
+  end subroutine test_newton_warning_mode
 
   subroutine test_configured_event_tolerances
     type(symplectic_integrator_t) :: loose_integrator, tight_integrator


### PR DESCRIPTION
## Risk tier

- [ ] T0: docs, comments, small build metadata
- [ ] T1: pure refactor, no behavior change intended
- [ ] T2: local numerical logic
- [x] T3: physics, output behavior, coordinate convention
- [x] T4: parallelism or GPU; dependency, CI, or security-sensitive build logic

## Correctness contract

### Intended behavior change

All symplectic integrators accept the final Newton iterate after the configured
iteration limit if every state component is finite. This restores the warning
and continue behavior used before #457 for Euler 1, Euler 2, midpoint, Gauss
orders 1 through 4, and Lobatto 3. `symplectic_newton_warning_mode = .false.`
restores strict termination.

Each accepted maximum-iteration step increments its integrator-specific
diagnostic counter. Midpoint now has a separate `midpoint_maxit` counter.

### Behavior that must not change

Converged steps use the same discrete maps, timestep, nonlinear equations,
tolerances, iteration limits, and update order. LCFS, wall, outside-domain,
singular-linear-system, non-finite, and unresolved-boundary-event failures
remain terminal. Strict mode rolls back the integrator and field to the last
accepted step.

The canonical state remains `(s, theta, phi, p_phi)`, with normalized toroidal
flux `s` and angles in radians. Field, time, energy, and momentum units are
unchanged. This change does not alter the Hamiltonian, source distribution,
field, wall, boundary conditions, or symmetry.

### Numerical limitation

The accepted maximum-iteration state has not met the configured nonlinear
tolerance, so that step only approximately satisfies its discrete symplectic
map. The unchanged counters expose every such step.

## CPU and GPU behavior

The CPU implementation covers every symplectic integrator. The GPU path uses
the same warning-mode rule for its Euler solver. NaN and infinity rejection
uses IEEE-754 exponent bits because the fast-math build can optimize
`ieee_is_finite` incorrectly. The finite-state check runs only after Newton
reaches its iteration limit; the converged hot path is unchanged.

## Tests added

- warning and strict behavior for Euler 1, Euler 2, midpoint, Gauss 1 through
  4, and Lobatto 3
- strict rollback to the accepted state
- rejection of a non-finite final iterate under the production compiler flags
- CPU/GPU Euler equivalence

## Golden-record impact

- [x] unchanged
- [ ] changed

## Verification

The non-finite regression failed before the bit-pattern check: warning mode
accepted a NaN under fast-math. It passes with this commit.

```text
$ fo test test_newton_solver_status test_gpu_orbit_bench
test_newton_solver_status                  PASS       0.06s
test_gpu_orbit_bench                       PASS       5.78s

$ fo
Static: OK (175 modules, 175 changed, 175 affected)
Build: OK
CTest: 83 passed, 0 failed, 1 skipped
```

The skipped chartmap test records the existing libneo issue #179 condition.
