### PR TITLE
Continue after bounded Newton maxiter without false losses

### DIFF
--- a/DOC/config.md
+++ b/DOC/config.md
@@ -11,13 +11,15 @@
   Both default to `-1`, which derives the tolerance from `relerr`. Set positive
   values to refine event location independently of the nonlinear solve.
 
-* `symplectic_newton_warning_mode` defaults to `.true.` and preserves the
-  historical behavior of continuing from the final finite Newton iterate when
-  an implicit solve reaches its iteration limit. Each occurrence is reported
-  by the corresponding `*_maxit` diagnostic. Set it to `.false.` to stop the
-  affected orbit at its last accepted position. Exterior-domain, singular
-  linear-system, non-finite, and unresolved boundary-event states always stop
-  the orbit.
+* `symplectic_newton_warning_mode` defaults to `.true.`. When an implicit solve
+  reaches its iteration limit, SIMPLE continues only if the final Newton
+  correction is finite and no more than ten times the requested relative
+  tolerance. Each occurrence is reported by the corresponding `*_maxit`
+  diagnostic. Set it to `.false.` to stop the affected orbit at its last
+  accepted position. Larger corrections, exterior-domain states, singular
+  linear systems, non-finite values, and unresolved boundary events always
+  stop the orbit. Numerical stops are recorded in `orbit_exit_code` and as
+  `NaN` in `times_lost`; they are unresolved markers, not physical losses.
 
 * `canonical_grid_nr`, `canonical_grid_ntheta`, and `canonical_grid_nphi`
   control the Meiss or Albert canonical-map grid. Their defaults are 62, 63,

--- a/DOC/config.md
+++ b/DOC/config.md
@@ -11,6 +11,14 @@
   Both default to `-1`, which derives the tolerance from `relerr`. Set positive
   values to refine event location independently of the nonlinear solve.
 
+* `symplectic_newton_warning_mode` defaults to `.true.` and preserves the
+  historical behavior of continuing from the final finite Newton iterate when
+  an implicit solve reaches its iteration limit. Each occurrence is reported
+  by the corresponding `*_maxit` diagnostic. Set it to `.false.` to stop the
+  affected orbit at its last accepted position. Exterior-domain, singular
+  linear-system, non-finite, and unresolved boundary-event states always stop
+  the orbit.
+
 * `canonical_grid_nr`, `canonical_grid_ntheta`, and `canonical_grid_nphi`
   control the Meiss or Albert canonical-map grid. Their defaults are 62, 63,
   and 64. Each dimension must be between 6 and 512, and their product must not

--- a/src/classification.f90
+++ b/src/classification.f90
@@ -1,14 +1,21 @@
 module classification
 use, intrinsic :: iso_fortran_env, only: dp => real64
+use, intrinsic :: ieee_arithmetic, only: ieee_value, ieee_quiet_nan
 use omp_lib
 use params, only: zstart, zend, times_lost, trap_par, perp_inv, iclass, &
     ntimstep, confpart_trap, confpart_pass, notrace_passing, contr_pp, &
     class_plot, ntcut, nturns, fast_class, n_tip_vars, nplagr, nder, npl_half, &
     nfp, fper, zerolam, num_surf, bmax, bmin, dtaumin, v0, cut_in_per, &
-    integmode, relerr, ntau, should_skip
+    integmode, relerr, ntau, should_skip, orbit_exit_code, unresolved_orbits, &
+    ORBIT_EXIT_COMPLETED, ORBIT_EXIT_LCFS, ORBIT_EXIT_SKIPPED, &
+    ORBIT_EXIT_NUMERICAL_DOMAIN, ORBIT_EXIT_NUMERICAL_MAXITER, &
+    ORBIT_EXIT_NUMERICAL_LINEAR, ORBIT_EXIT_NUMERICAL_EVENT
 use util, only: twopi, sqrt2
 use velo_mod,   only : isw_field_type
 use orbit_symplectic, only : orbit_timestep_sympl, get_val
+use orbit_symplectic_base, only: SYMPLECTIC_STEP_BOUNDARY, &
+    SYMPLECTIC_STEP_OUTSIDE_DOMAIN, SYMPLECTIC_STEP_MAXITER, &
+    SYMPLECTIC_STEP_LINEAR_SOLVE
 use simple, only : init_sympl, tracer_t
 use cut_detector, only : fract_dimension
 use diag_mod, only : icounter
@@ -28,6 +35,7 @@ use check_orbit_type_sub, only : check_orbit_type
     integer :: fractal           ! Fractal: 0=unclassified, 1=regular, 2=chaotic
     integer :: jpar              ! J_parallel: 0=unclassified, 1=regular, 2=stochastic
     integer :: topology          ! Topology: 0=unclassified, 1=ideal, 2=non-ideal
+    integer :: exit_code         ! Physical or numerical orbit termination
   end type classification_result_t
 
   ! output files:
@@ -67,7 +75,7 @@ subroutine trace_orbit_with_classifiers(anorb, ipart, class_result)
     real(dp), dimension(5) :: z
     real(dp) :: bmod,sqrtg
     real(dp), dimension(3) :: bder, hcovar, hctrvr, hcurl
-    integer :: it, ktau
+    integer :: it, ktau, it_f
     integer(8) :: kt
     logical :: passing
 
@@ -101,6 +109,7 @@ subroutine trace_orbit_with_classifiers(anorb, ipart, class_result)
     class_result%fractal = 0
     class_result%jpar = 0
     class_result%topology = 0
+    class_result%exit_code = ORBIT_EXIT_COMPLETED
 
     !  open(unit=10000+ipart, iostat=stat, status='old')
     !  if (stat == 0) close(10000+ipart, status='delete')
@@ -172,6 +181,8 @@ subroutine trace_orbit_with_classifiers(anorb, ipart, class_result)
         ! Mark as regular passing (fractal=1) and not lost
         class_result%fractal = 1
         class_result%lost = .false.
+        class_result%exit_code = ORBIT_EXIT_SKIPPED
+        orbit_exit_code(ipart) = ORBIT_EXIT_SKIPPED
         return
     endif
     ! End forced classification of passing as regular
@@ -254,16 +265,14 @@ subroutine trace_orbit_with_classifiers(anorb, ipart, class_result)
                 z(5) = anorb%f%vpar/(z(4)*sqrt2)
             endif
 
-            ! Write starting data for orbits which were lost in case of classification plot
-            ! Mark orbit as lost if integration failed
             if(ierr.ne.0) then
-                class_result%lost = .true.
-                if(class_plot) then
+                call classify_classifier_exit(ierr, integmode, &
+                    class_result%lost, class_result%exit_code)
+                if(class_plot .and. class_result%lost) then
                     call output_lost_orbit_starting_data(ipart, passing)
                 endif
                 exit
             endif
-            ! End handling of lost orbits
             kt = kt+1
 
             par_inv = par_inv+z(5)**2*dtaumin ! parallel adiabatic invariant
@@ -451,12 +460,47 @@ subroutine trace_orbit_with_classifiers(anorb, ipart, class_result)
     elseif(isw_field_type .eq. BOOZER) then
         call boozer_to_vmec(z(1),z(2),z(3),zend(2,ipart),zend(3,ipart))
     endif
-    times_lost(ipart) = kt*dtaumin/v0
+    orbit_exit_code(ipart) = class_result%exit_code
+    if (class_result%exit_code >= ORBIT_EXIT_NUMERICAL_DOMAIN) then
+        times_lost(ipart) = ieee_value(0.0_dp, ieee_quiet_nan)
+    else
+        times_lost(ipart) = kt*dtaumin/v0
+    end if
     deallocate(zpoipl_tip, zpoipl_per)
     !$omp end critical
+    if (class_result%exit_code >= ORBIT_EXIT_NUMERICAL_DOMAIN) then
+        do it_f = it, ntimstep
+!$omp atomic update
+            unresolved_orbits(it_f) = unresolved_orbits(it_f) + 1
+        end do
+    end if
     !  close(unit=10000+ipart)
     !  close(unit=10000+ipart)
 end subroutine trace_orbit_with_classifiers
+
+pure subroutine classify_classifier_exit(ierr, mode, lost, exit_code)
+    integer, intent(in) :: ierr, mode
+    logical, intent(out) :: lost
+    integer, intent(out) :: exit_code
+
+    lost = .false.
+    if (mode <= 0 .or. ierr == SYMPLECTIC_STEP_BOUNDARY) then
+        lost = .true.
+        exit_code = ORBIT_EXIT_LCFS
+        return
+    end if
+
+    select case (ierr)
+    case (SYMPLECTIC_STEP_OUTSIDE_DOMAIN)
+        exit_code = ORBIT_EXIT_NUMERICAL_DOMAIN
+    case (SYMPLECTIC_STEP_MAXITER)
+        exit_code = ORBIT_EXIT_NUMERICAL_MAXITER
+    case (SYMPLECTIC_STEP_LINEAR_SOLVE)
+        exit_code = ORBIT_EXIT_NUMERICAL_LINEAR
+    case default
+        exit_code = ORBIT_EXIT_NUMERICAL_EVENT
+    end select
+end subroutine classify_classifier_exit
 
 
 subroutine output_lost_orbit_starting_data(ipart, passing)
@@ -535,6 +579,8 @@ subroutine write_classification_results(ipart, class_result)
     integer, intent(in) :: ipart
     type(classification_result_t), intent(in) :: class_result
     logical :: regular
+
+    if (class_result%exit_code >= ORBIT_EXIT_NUMERICAL_DOMAIN) return
 
     ! Write lost orbits
     if(class_result%lost) then

--- a/src/diag_counters.f90
+++ b/src/diag_counters.f90
@@ -15,7 +15,7 @@ module diag_counters
 
     public :: EVT_NEWTON1_MAXIT, EVT_NEWTON2_MAXIT, EVT_RK_GAUSS_MAXIT, &
               EVT_RK_LOBATTO_MAXIT, EVT_FIXPOINT_MAXIT, EVT_R_NEGATIVE, &
-              EVT_FO_LOSS, EVT_FO_FAULT, N_EVENT
+              EVT_FO_LOSS, EVT_FO_FAULT, EVT_MIDPOINT_MAXIT, N_EVENT
     public :: diag_counters_init, count_event, diag_counters_total, &
               diag_counters_reset, event_name
 
@@ -30,11 +30,12 @@ module diag_counters
     ! s >= 1 crossing (physical loss); FAULT = field-inversion non-convergence.
     integer, parameter :: EVT_FO_LOSS = 7
     integer, parameter :: EVT_FO_FAULT = 8
-    integer, parameter :: N_EVENT = 8
+    integer, parameter :: EVT_MIDPOINT_MAXIT = 9
+    integer, parameter :: N_EVENT = 9
 
-    ! One cache line (64 B = 8 int64) per thread column, so neighbouring threads
-    ! never share a line. The event id indexes within a column; STRIDE >= N_EVENT.
-    integer, parameter :: STRIDE = 8
+    ! Whole cache lines per thread column keep neighbouring threads from sharing
+    ! a line. The event id indexes within a column; STRIDE >= N_EVENT.
+    integer, parameter :: STRIDE = 16
     integer(int64), allocatable :: counts(:, :)  ! (STRIDE, 0:nthreads-1)
 
 contains
@@ -95,6 +96,8 @@ contains
             name = 'fo_loss'
         case (EVT_FO_FAULT)
             name = 'fo_fault'
+        case (EVT_MIDPOINT_MAXIT)
+            name = 'midpoint_maxit'
         case default
             name = 'unknown'
         end select

--- a/src/orbit_symplectic.f90
+++ b/src/orbit_symplectic.f90
@@ -1,6 +1,6 @@
 module orbit_symplectic
 
-use, intrinsic :: iso_fortran_env, only: dp => real64
+use, intrinsic :: iso_fortran_env, only: dp => real64, int64
 use util, only: pi, twopi
 use field_can_mod, only: field_can_t, get_val, get_derivatives, get_derivatives2, &
   eval_field => evaluate
@@ -12,7 +12,7 @@ use orbit_symplectic_base, only: symplectic_integrator_t, multistage_integrator_
   SYMPLECTIC_STEP_MAXITER, SYMPLECTIC_STEP_LINEAR_SOLVE, &
   SYMPLECTIC_STEP_BOUNDARY, SYMPLECTIC_STEP_EVENT_NOT_CONVERGED, &
   SYMPLECTIC_STEP_BOUNDARY_LIMITED, boundary_event_fraction_tolerance, &
-  boundary_event_radial_tolerance, symplectic_euler_warning_mode
+  boundary_event_radial_tolerance, symplectic_newton_warning_mode
 use orbit_symplectic_quasi, only: orbit_timestep_quasi, timestep_expl_impl_euler_quasi, &
   timestep_impl_expl_euler_quasi, timestep_midpoint_quasi, orbit_timestep_rk45, &
   timestep_rk_gauss_quasi, timestep_rk_lobatto_quasi
@@ -23,8 +23,8 @@ use orbit_rk_core, only: rk_gauss_residual, rk_gauss_jacobian, MODEL_GC
 use vector_potentail_mod, only: torflux
 use lapack_interfaces, only: dgesv
 use diag_counters, only: count_event, EVT_NEWTON1_MAXIT, EVT_NEWTON2_MAXIT, &
-  EVT_RK_GAUSS_MAXIT, EVT_RK_LOBATTO_MAXIT, EVT_FIXPOINT_MAXIT, EVT_R_NEGATIVE
-use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+  EVT_RK_GAUSS_MAXIT, EVT_RK_LOBATTO_MAXIT, EVT_FIXPOINT_MAXIT, EVT_R_NEGATIVE, &
+  EVT_MIDPOINT_MAXIT
 
 implicit none
 
@@ -32,6 +32,29 @@ procedure(orbit_timestep_sympl_i), pointer :: orbit_timestep_sympl => null()
 procedure(orbit_timestep_sympl_i), pointer, private :: raw_timestep_sympl => null()
 
 contains
+
+pure logical function finite_newton_iterate(x)
+  real(dp), intent(in) :: x(:)
+
+  integer(int64), parameter :: exponent_mask = &
+    int(z'7FF0000000000000', int64)
+  integer(int64) :: bits
+  integer :: i
+
+  finite_newton_iterate = .false.
+  do i = 1, size(x)
+    bits = transfer(x(i), bits)
+    if (iand(bits, exponent_mask) == exponent_mask) return
+  end do
+  finite_newton_iterate = .true.
+end function finite_newton_iterate
+
+logical function accept_finite_maxiter(x)
+  real(dp), intent(in) :: x(:)
+
+  accept_finite_maxiter = symplectic_newton_warning_mode .and. &
+    finite_newton_iterate(x)
+end function accept_finite_maxiter
 
 subroutine apply_axis_chart_switch(radius, theta, crossed, status)
   real(dp), intent(inout) :: radius, theta
@@ -449,9 +472,7 @@ recursive subroutine newton1(si, f, x, maxit, xlast, status)
     end if
   else
     call count_event(EVT_NEWTON1_MAXIT)
-    if (symplectic_euler_warning_mode .and. all(ieee_is_finite(x))) then
-      status = SYMPLECTIC_STEP_OK
-    end if
+    if (accept_finite_maxiter(x)) status = SYMPLECTIC_STEP_OK
   end if
 end subroutine
 
@@ -545,6 +566,7 @@ recursive subroutine newton2(si, f, x, atol, rtol, maxit, xlast, status)
     end if
   else
     call count_event(EVT_NEWTON2_MAXIT)
+    if (accept_finite_maxiter(x)) status = SYMPLECTIC_STEP_OK
   end if
 end subroutine
 
@@ -699,6 +721,9 @@ recursive subroutine newton_midpoint(si, f, x, atol, rtol, maxit, xlast, status)
     else
       status = SYMPLECTIC_STEP_BOUNDARY_LIMITED
     end if
+  else
+    call count_event(EVT_MIDPOINT_MAXIT)
+    if (accept_finite_maxiter(x)) status = SYMPLECTIC_STEP_OK
   end if
 end subroutine
 
@@ -822,6 +847,7 @@ recursive subroutine newton_rk_gauss(si, fs, s, x, atol, rtol, maxit, xlast, sta
     end if
   else
     call count_event(EVT_RK_GAUSS_MAXIT)
+    if (accept_finite_maxiter(x)) status = SYMPLECTIC_STEP_OK
   end if
 end subroutine newton_rk_gauss
 
@@ -1162,6 +1188,7 @@ recursive subroutine newton_rk_lobatto(si, fs, s, x, atol, rtol, maxit, xlast, s
     end if
   else
     call count_event(EVT_RK_LOBATTO_MAXIT)
+    if (accept_finite_maxiter(x)) status = SYMPLECTIC_STEP_OK
   end if
 end subroutine newton_rk_lobatto
 

--- a/src/orbit_symplectic.f90
+++ b/src/orbit_symplectic.f90
@@ -12,7 +12,7 @@ use orbit_symplectic_base, only: symplectic_integrator_t, multistage_integrator_
   SYMPLECTIC_STEP_MAXITER, SYMPLECTIC_STEP_LINEAR_SOLVE, &
   SYMPLECTIC_STEP_BOUNDARY, SYMPLECTIC_STEP_EVENT_NOT_CONVERGED, &
   SYMPLECTIC_STEP_BOUNDARY_LIMITED, boundary_event_fraction_tolerance, &
-  boundary_event_radial_tolerance
+  boundary_event_radial_tolerance, symplectic_euler_warning_mode
 use orbit_symplectic_quasi, only: orbit_timestep_quasi, timestep_expl_impl_euler_quasi, &
   timestep_impl_expl_euler_quasi, timestep_midpoint_quasi, orbit_timestep_rk45, &
   timestep_rk_gauss_quasi, timestep_rk_lobatto_quasi
@@ -24,6 +24,7 @@ use vector_potentail_mod, only: torflux
 use lapack_interfaces, only: dgesv
 use diag_counters, only: count_event, EVT_NEWTON1_MAXIT, EVT_NEWTON2_MAXIT, &
   EVT_RK_GAUSS_MAXIT, EVT_RK_LOBATTO_MAXIT, EVT_FIXPOINT_MAXIT, EVT_R_NEGATIVE
+use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
 
 implicit none
 
@@ -448,6 +449,9 @@ recursive subroutine newton1(si, f, x, maxit, xlast, status)
     end if
   else
     call count_event(EVT_NEWTON1_MAXIT)
+    if (symplectic_euler_warning_mode .and. all(ieee_is_finite(x))) then
+      status = SYMPLECTIC_STEP_OK
+    end if
   end if
 end subroutine
 

--- a/src/orbit_symplectic.f90
+++ b/src/orbit_symplectic.f90
@@ -12,7 +12,8 @@ use orbit_symplectic_base, only: symplectic_integrator_t, multistage_integrator_
   SYMPLECTIC_STEP_MAXITER, SYMPLECTIC_STEP_LINEAR_SOLVE, &
   SYMPLECTIC_STEP_BOUNDARY, SYMPLECTIC_STEP_EVENT_NOT_CONVERGED, &
   SYMPLECTIC_STEP_BOUNDARY_LIMITED, boundary_event_fraction_tolerance, &
-  boundary_event_radial_tolerance, symplectic_newton_warning_mode
+  boundary_event_radial_tolerance, symplectic_newton_warning_mode, &
+  symplectic_newton_warning_factor
 use orbit_symplectic_quasi, only: orbit_timestep_quasi, timestep_expl_impl_euler_quasi, &
   timestep_impl_expl_euler_quasi, timestep_midpoint_quasi, orbit_timestep_rk45, &
   timestep_rk_gauss_quasi, timestep_rk_lobatto_quasi
@@ -49,12 +50,18 @@ pure logical function finite_newton_iterate(x)
   finite_newton_iterate = .true.
 end function finite_newton_iterate
 
-logical function accept_finite_maxiter(x)
-  real(dp), intent(in) :: x(:)
+logical function accept_bounded_maxiter(x, xlast, tolref, rtol)
+  real(dp), intent(in) :: x(:), xlast(:), tolref(:), rtol
 
-  accept_finite_maxiter = symplectic_newton_warning_mode .and. &
-    finite_newton_iterate(x)
-end function accept_finite_maxiter
+  accept_bounded_maxiter = .false.
+  if (.not. symplectic_newton_warning_mode) return
+  if (rtol <= 0.0_dp) return
+  if (.not. finite_newton_iterate(x)) return
+  if (.not. finite_newton_iterate(xlast)) return
+  if (.not. finite_newton_iterate(tolref)) return
+  accept_bounded_maxiter = all(abs(x - xlast) <= &
+    symplectic_newton_warning_factor*rtol*abs(tolref))
+end function accept_bounded_maxiter
 
 subroutine apply_axis_chart_switch(radius, theta, crossed, status)
   real(dp), intent(inout) :: radius, theta
@@ -472,7 +479,8 @@ recursive subroutine newton1(si, f, x, maxit, xlast, status)
     end if
   else
     call count_event(EVT_NEWTON1_MAXIT)
-    if (accept_finite_maxiter(x)) status = SYMPLECTIC_STEP_OK
+    if (accept_bounded_maxiter(x, xlast, tolref, si%rtol)) &
+      status = SYMPLECTIC_STEP_OK
   end if
 end subroutine
 
@@ -566,7 +574,8 @@ recursive subroutine newton2(si, f, x, atol, rtol, maxit, xlast, status)
     end if
   else
     call count_event(EVT_NEWTON2_MAXIT)
-    if (accept_finite_maxiter(x)) status = SYMPLECTIC_STEP_OK
+    if (accept_bounded_maxiter(x, xlast, tolref, rtol)) &
+      status = SYMPLECTIC_STEP_OK
   end if
 end subroutine
 
@@ -723,7 +732,8 @@ recursive subroutine newton_midpoint(si, f, x, atol, rtol, maxit, xlast, status)
     end if
   else
     call count_event(EVT_MIDPOINT_MAXIT)
-    if (accept_finite_maxiter(x)) status = SYMPLECTIC_STEP_OK
+    if (accept_bounded_maxiter(x, xlast, tolref, rtol)) &
+      status = SYMPLECTIC_STEP_OK
   end if
 end subroutine
 
@@ -847,7 +857,8 @@ recursive subroutine newton_rk_gauss(si, fs, s, x, atol, rtol, maxit, xlast, sta
     end if
   else
     call count_event(EVT_RK_GAUSS_MAXIT)
-    if (accept_finite_maxiter(x)) status = SYMPLECTIC_STEP_OK
+    if (accept_bounded_maxiter(x, xlast, tolref, rtol)) &
+      status = SYMPLECTIC_STEP_OK
   end if
 end subroutine newton_rk_gauss
 
@@ -1188,7 +1199,8 @@ recursive subroutine newton_rk_lobatto(si, fs, s, x, atol, rtol, maxit, xlast, s
     end if
   else
     call count_event(EVT_RK_LOBATTO_MAXIT)
-    if (accept_finite_maxiter(x)) status = SYMPLECTIC_STEP_OK
+    if (accept_bounded_maxiter(x, xlast, tolref, rtol)) &
+      status = SYMPLECTIC_STEP_OK
   end if
 end subroutine newton_rk_lobatto
 

--- a/src/orbit_symplectic_base.f90
+++ b/src/orbit_symplectic_base.f90
@@ -26,6 +26,7 @@ use field_can_mod, only: eval_field => evaluate, field_can_t, get_val, get_deriv
     integer, parameter :: SYMPLECTIC_STEP_BOUNDARY = 4
     integer, parameter :: SYMPLECTIC_STEP_EVENT_NOT_CONVERGED = 5
     integer, parameter :: SYMPLECTIC_STEP_BOUNDARY_LIMITED = 6
+    logical :: symplectic_euler_warning_mode = .true.
     real(dp) :: boundary_event_fraction_tolerance = -1d0
     real(dp) :: boundary_event_radial_tolerance = -1d0
 

--- a/src/orbit_symplectic_base.f90
+++ b/src/orbit_symplectic_base.f90
@@ -27,6 +27,7 @@ use field_can_mod, only: eval_field => evaluate, field_can_t, get_val, get_deriv
     integer, parameter :: SYMPLECTIC_STEP_EVENT_NOT_CONVERGED = 5
     integer, parameter :: SYMPLECTIC_STEP_BOUNDARY_LIMITED = 6
     logical :: symplectic_newton_warning_mode = .true.
+    real(dp), parameter :: symplectic_newton_warning_factor = 10.0_dp
     real(dp) :: boundary_event_fraction_tolerance = -1d0
     real(dp) :: boundary_event_radial_tolerance = -1d0
 

--- a/src/orbit_symplectic_base.f90
+++ b/src/orbit_symplectic_base.f90
@@ -26,7 +26,7 @@ use field_can_mod, only: eval_field => evaluate, field_can_t, get_val, get_deriv
     integer, parameter :: SYMPLECTIC_STEP_BOUNDARY = 4
     integer, parameter :: SYMPLECTIC_STEP_EVENT_NOT_CONVERGED = 5
     integer, parameter :: SYMPLECTIC_STEP_BOUNDARY_LIMITED = 6
-    logical :: symplectic_euler_warning_mode = .true.
+    logical :: symplectic_newton_warning_mode = .true.
     real(dp) :: boundary_event_fraction_tolerance = -1d0
     real(dp) :: boundary_event_radial_tolerance = -1d0
 

--- a/src/params.f90
+++ b/src/params.f90
@@ -15,7 +15,7 @@ module params
                                      EXPL_IMPL_EULER, &
                                      boundary_event_fraction_tolerance, &
                                      boundary_event_radial_tolerance, &
-                                     symplectic_euler_warning_mode
+                                     symplectic_newton_warning_mode
     use vmecin_sub, only: stevvo
     use callback, only: output_error, output_orbits_macrostep
 
@@ -165,7 +165,7 @@ module params
 	        facE_al, npoiper2, n_e, n_d, netcdffile, ns_s, ns_tp, multharm, &
 	        isw_field_type, generate_start_only, startmode, grid_density, &
 	        special_ants_file, integmode, orbit_model, orbit_coord, relerr, &
-	        symplectic_euler_warning_mode, &
+	        symplectic_newton_warning_mode, &
 	        boundary_event_fraction_tolerance, boundary_event_radial_tolerance, &
 	        canonical_grid_nr, canonical_grid_ntheta, canonical_grid_nphi, &
 	        canonical_ode_relerr, &
@@ -204,10 +204,9 @@ contains
 
         call reset_seed_if_deterministic
 
-        if (integmode == EXPL_IMPL_EULER .and. symplectic_euler_warning_mode) then
-            print *, 'WARNING: explicit-implicit symplectic Euler accepts ', &
-                'finite Newton iterates after the iteration limit; ', &
-                'see newton1_maxit diagnostics'
+        if (integmode > 0 .and. symplectic_newton_warning_mode) then
+            print *, 'WARNING: symplectic integrators accept finite Newton ', &
+                'iterates after the iteration limit; see maxit diagnostics'
         end if
 
         call validate_boundary_event_tolerances

--- a/src/params.f90
+++ b/src/params.f90
@@ -204,9 +204,10 @@ contains
 
         call reset_seed_if_deterministic
 
-        if (symplectic_euler_warning_mode) then
-            print *, 'WARNING: symplectic Euler accepts finite Newton iterates ', &
-                'after the iteration limit; see newton1_maxit diagnostics'
+        if (integmode == EXPL_IMPL_EULER .and. symplectic_euler_warning_mode) then
+            print *, 'WARNING: explicit-implicit symplectic Euler accepts ', &
+                'finite Newton iterates after the iteration limit; ', &
+                'see newton1_maxit diagnostics'
         end if
 
         call validate_boundary_event_tolerances

--- a/src/params.f90
+++ b/src/params.f90
@@ -205,8 +205,8 @@ contains
         call reset_seed_if_deterministic
 
         if (integmode > 0 .and. symplectic_newton_warning_mode) then
-            print *, 'WARNING: symplectic integrators accept finite Newton ', &
-                'iterates after the iteration limit; see maxit diagnostics'
+            print *, 'WARNING: symplectic integrators accept bounded Newton ', &
+                'corrections after the iteration limit; see maxit diagnostics'
         end if
 
         call validate_boundary_event_tolerances

--- a/src/params.f90
+++ b/src/params.f90
@@ -14,7 +14,8 @@ module params
     use orbit_symplectic_base, only: symplectic_integrator_t, multistage_integrator_t, &
                                      EXPL_IMPL_EULER, &
                                      boundary_event_fraction_tolerance, &
-                                     boundary_event_radial_tolerance
+                                     boundary_event_radial_tolerance, &
+                                     symplectic_euler_warning_mode
     use vmecin_sub, only: stevvo
     use callback, only: output_error, output_orbits_macrostep
 
@@ -164,6 +165,7 @@ module params
 	        facE_al, npoiper2, n_e, n_d, netcdffile, ns_s, ns_tp, multharm, &
 	        isw_field_type, generate_start_only, startmode, grid_density, &
 	        special_ants_file, integmode, orbit_model, orbit_coord, relerr, &
+	        symplectic_euler_warning_mode, &
 	        boundary_event_fraction_tolerance, boundary_event_radial_tolerance, &
 	        canonical_grid_nr, canonical_grid_ntheta, canonical_grid_nphi, &
 	        canonical_ode_relerr, &
@@ -201,6 +203,11 @@ contains
         call apply_config_aliases
 
         call reset_seed_if_deterministic
+
+        if (symplectic_euler_warning_mode) then
+            print *, 'WARNING: symplectic Euler accepts finite Newton iterates ', &
+                'after the iteration limit; see newton1_maxit diagnostics'
+        end if
 
         call validate_boundary_event_tolerances
         if (min(canonical_grid_nr, canonical_grid_ntheta, &

--- a/src/simple_gpu.f90
+++ b/src/simple_gpu.f90
@@ -15,7 +15,8 @@ module simple_gpu
     use orbit_symplectic_base, only: symplectic_integrator_t, &
         SYMPLECTIC_STEP_OK, SYMPLECTIC_STEP_OUTSIDE_DOMAIN, &
         SYMPLECTIC_STEP_MAXITER, SYMPLECTIC_STEP_LINEAR_SOLVE, &
-        SYMPLECTIC_STEP_BOUNDARY_LIMITED, symplectic_newton_warning_mode
+        SYMPLECTIC_STEP_BOUNDARY_LIMITED, symplectic_newton_warning_mode, &
+        symplectic_newton_warning_factor
     use orbit_symplectic_euler1, only: sympl_euler1_newton_iter
     use orbit_symplectic_euler1, only: sympl_euler1_extrapolate_field, sympl_euler1_advance_angles
     use boozer_sub, only: boozer_state
@@ -105,7 +106,10 @@ contains
             else
                 status = SYMPLECTIC_STEP_BOUNDARY_LIMITED
             end if
-        else if (warning_mode .and. gpu_finite_iterate(x)) then
+        else if (warning_mode .and. gpu_finite_iterate(x) .and. &
+                 gpu_finite_iterate(xlast) .and. gpu_finite_iterate(tolref) .and. &
+                 all(abs(x - xlast) <= &
+                     symplectic_newton_warning_factor*si%rtol*abs(tolref))) then
             status = SYMPLECTIC_STEP_OK
         end if
         ! Non-convergence diagnostics (CPU writes fort.6601) are omitted on device.

--- a/src/simple_gpu.f90
+++ b/src/simple_gpu.f90
@@ -8,14 +8,14 @@ module simple_gpu
     ! module keeps the device-side field evaluation local and reuses the shared
     ! symplectic-Euler algebra from orbit_symplectic_euler1. Equivalence is
     ! checked against the CPU path by test_gpu_orbit_bench.
-    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use, intrinsic :: iso_fortran_env, only: dp => real64, int64
     use util, only: pi
     use field_can_mod, only: field_can_t, get_derivatives, get_derivatives2
     use field_can_boozer, only: eval_field_booz
     use orbit_symplectic_base, only: symplectic_integrator_t, &
         SYMPLECTIC_STEP_OK, SYMPLECTIC_STEP_OUTSIDE_DOMAIN, &
         SYMPLECTIC_STEP_MAXITER, SYMPLECTIC_STEP_LINEAR_SOLVE, &
-        SYMPLECTIC_STEP_BOUNDARY_LIMITED
+        SYMPLECTIC_STEP_BOUNDARY_LIMITED, symplectic_newton_warning_mode
     use orbit_symplectic_euler1, only: sympl_euler1_newton_iter
     use orbit_symplectic_euler1, only: sympl_euler1_extrapolate_field, sympl_euler1_advance_angles
     use boozer_sub, only: boozer_state
@@ -33,12 +33,30 @@ module simple_gpu
 
 contains
 
-    subroutine gpu_newton1(si, f, x, xlast, status)
+    logical function gpu_finite_iterate(x)
+        !$acc routine seq
+        real(dp), intent(in) :: x(:)
+
+        integer(int64), parameter :: exponent_mask = &
+            int(z'7FF0000000000000', int64)
+        integer(int64) :: bits
+        integer :: i
+
+        gpu_finite_iterate = .false.
+        do i = 1, size(x)
+            bits = transfer(x(i), bits)
+            if (iand(bits, exponent_mask) == exponent_mask) return
+        end do
+        gpu_finite_iterate = .true.
+    end function gpu_finite_iterate
+
+    subroutine gpu_newton1(si, f, x, xlast, warning_mode, status)
         !$acc routine seq
         type(symplectic_integrator_t), intent(inout) :: si
         type(field_can_t), intent(inout) :: f
         real(dp), intent(inout) :: x(2)
         real(dp), intent(out) :: xlast(2)
+        logical, intent(in) :: warning_mode
         integer, intent(out) :: status
 
         real(dp) :: tolref(2)
@@ -87,14 +105,17 @@ contains
             else
                 status = SYMPLECTIC_STEP_BOUNDARY_LIMITED
             end if
+        else if (warning_mode .and. gpu_finite_iterate(x)) then
+            status = SYMPLECTIC_STEP_OK
         end if
         ! Non-convergence diagnostics (CPU writes fort.6601) are omitted on device.
     end subroutine gpu_newton1
 
-    subroutine gpu_timestep_euler(si, f, ierr)
+    subroutine gpu_timestep_euler(si, f, warning_mode, ierr)
         !$acc routine seq
         type(symplectic_integrator_t), intent(inout) :: si
         type(field_can_t), intent(inout) :: f
+        logical, intent(in) :: warning_mode
         integer, intent(out) :: ierr
 
         real(dp) :: x(2), xlast(2)
@@ -113,7 +134,7 @@ contains
             x(1) = si%z(1)
             x(2) = si%z(4)
 
-            call gpu_newton1(si, f, x, xlast, newton_status)
+            call gpu_newton1(si, f, x, xlast, warning_mode, newton_status)
             if (newton_status /= SYMPLECTIC_STEP_OK) then
                 si = accepted_integrator
                 f = accepted_field
@@ -173,17 +194,20 @@ contains
         real(dp), intent(out) :: zend(4, npart)
 
         integer :: i, it, ktau, ierr, lstep
+        logical :: warning_mode
+
+        warning_mode = symplectic_newton_warning_mode
 
         !$acc parallel loop gang vector default(present) &
         !$acc&   copy(si(istart:iend), f(istart:iend)) copyin(ntau_macro) &
         !$acc&   copyout(loss_step(istart:iend), zend(:, istart:iend)) &
-        !$acc&   private(it, ktau, ierr, lstep)
+        !$acc&   private(it, ktau, ierr, lstep) firstprivate(warning_mode)
         do i = istart, iend
             ierr = 0
             lstep = ntimstep
             macro: do it = 2, ntimstep
                 do ktau = 1, ntau_macro(it)
-                    call gpu_timestep_euler(si(i), f(i), ierr)
+                    call gpu_timestep_euler(si(i), f(i), warning_mode, ierr)
                     if (ierr /= 0) exit
                 end do
                 if (ierr /= 0) then

--- a/test/tests/test_newton_solver_status.f90
+++ b/test/tests/test_newton_solver_status.f90
@@ -64,8 +64,7 @@ contains
 end module linear_radial_field_backend
 
 program test_newton_solver_status
-  use, intrinsic :: ieee_arithmetic, only: ieee_is_finite, ieee_quiet_nan, &
-    ieee_value
+  use, intrinsic :: ieee_arithmetic, only: ieee_quiet_nan, ieee_value
   use, intrinsic :: iso_fortran_env, only: dp => real64
   use field_can_mod, only: field_can_t, eval_field => evaluate
   use linear_radial_field_backend, only: basin_limited_step, &
@@ -73,7 +72,7 @@ program test_newton_solver_status
   use orbit_symplectic, only: guard_lobatto_stage_radii, boundary_event_converged, &
     advance_symplectic_with_boundary, newton_midpoint, orbit_sympl_init, &
     orbit_timestep_sympl, matrix3_near_singular, solve_newton_system, &
-    get_boundary_event_tolerances
+    get_boundary_event_tolerances, accept_bounded_maxiter
   use orbit_symplectic_base, only: symplectic_integrator_t, &
     EXPL_IMPL_EULER, IMPL_EXPL_EULER, MIDPOINT, GAUSS1, GAUSS2, GAUSS3, &
     GAUSS4, LOBATTO3, &
@@ -190,9 +189,9 @@ contains
   subroutine test_newton_warning_mode
     integer, parameter :: modes(8) = [EXPL_IMPL_EULER, IMPL_EXPL_EULER, &
       MIDPOINT, GAUSS1, GAUSS2, GAUSS3, GAUSS4, LOBATTO3]
-    type(symplectic_integrator_t) :: strict_integrator, warning_integrator
-    type(field_can_t) :: strict_field, warning_field
-    real(dp) :: initial_state(4)
+    type(symplectic_integrator_t) :: strict_integrator
+    type(field_can_t) :: strict_field
+    real(dp) :: initial_state(4), accepted(2), previous(2), scale(2)
     integer :: mode_index, step_status
 
     eval_field => evaluate_linear_radial
@@ -213,25 +212,29 @@ contains
         error stop 'strict max-iteration failure changed the accepted state'
       end if
 
-      warning_field%ro0 = 1.0_dp
-      warning_field%mu = 1.0_dp
-      call orbit_sympl_init(warning_integrator, warning_field, initial_state, &
-        0.01_dp, 1, 0.0_dp, modes(mode_index))
-      warning_integrator%atol = 0.0_dp
-      symplectic_newton_warning_mode = .true.
-      call orbit_timestep_sympl(warning_integrator, warning_field, step_status)
-      if (step_status /= SYMPLECTIC_STEP_OK) then
-        print *, 'warning mode, status:', modes(mode_index), step_status
-        error stop 'warning mode did not continue the timestep'
-      end if
-      if (.not. all(ieee_is_finite(warning_integrator%z))) then
-        error stop 'warning mode accepted a non-finite state'
-      end if
-      if (modes(mode_index) == EXPL_IMPL_EULER .and. &
-          all(warning_integrator%z == initial_state)) then
-        error stop 'warning mode did not commit the timestep'
-      end if
     end do
+
+    previous = [1.0_dp, 2.0_dp]
+    scale = [1.0_dp, 2.0_dp]
+    accepted = previous + [5.0e-12_dp, 1.0e-11_dp]
+    symplectic_newton_warning_mode = .true.
+    if (.not. accept_bounded_maxiter(accepted, previous, scale, 1.0e-12_dp)) then
+      error stop 'warning mode rejected a bounded Newton correction'
+    end if
+    accepted(1) = previous(1) + 11.0e-12_dp
+    if (accept_bounded_maxiter(accepted, previous, scale, 1.0e-12_dp)) then
+      error stop 'warning mode accepted an excessive Newton correction'
+    end if
+    accepted = previous
+    accepted(1) = ieee_value(0.0_dp, ieee_quiet_nan)
+    if (accept_bounded_maxiter(accepted, previous, scale, 1.0e-12_dp)) then
+      error stop 'warning mode accepted a non-finite Newton correction'
+    end if
+    accepted = previous
+    symplectic_newton_warning_mode = .false.
+    if (accept_bounded_maxiter(accepted, previous, scale, 1.0e-12_dp)) then
+      error stop 'strict mode accepted a Newton max-iteration state'
+    end if
   end subroutine test_newton_warning_mode
 
   subroutine test_configured_event_tolerances

--- a/test/tests/test_newton_solver_status.f90
+++ b/test/tests/test_newton_solver_status.f90
@@ -69,7 +69,7 @@ program test_newton_solver_status
   use linear_radial_field_backend, only: basin_limited_step, &
     evaluate_linear_radial, nonlinear_boundary_step
   use orbit_symplectic, only: guard_lobatto_stage_radii, boundary_event_converged, &
-    advance_symplectic_with_boundary, newton_midpoint, orbit_sympl_init, &
+    advance_symplectic_with_boundary, newton1, newton_midpoint, orbit_sympl_init, &
     orbit_timestep_sympl, matrix3_near_singular, solve_newton_system, &
     get_boundary_event_tolerances
   use orbit_symplectic_base, only: symplectic_integrator_t, &
@@ -78,13 +78,15 @@ program test_newton_solver_status
     SYMPLECTIC_STEP_OK, SYMPLECTIC_STEP_OUTSIDE_DOMAIN, &
     SYMPLECTIC_STEP_MAXITER, SYMPLECTIC_STEP_LINEAR_SOLVE, &
     SYMPLECTIC_STEP_EVENT_NOT_CONVERGED, SYMPLECTIC_STEP_BOUNDARY_LIMITED, &
-    boundary_event_fraction_tolerance, boundary_event_radial_tolerance
+    boundary_event_fraction_tolerance, boundary_event_radial_tolerance, &
+    symplectic_euler_warning_mode
 
   implicit none
 
   type(symplectic_integrator_t) :: integrator
   type(field_can_t) :: field
   real(dp) :: x(5), xlast(5), matrix(2, 2), residual(2), matrix3(3, 3)
+  real(dp) :: euler_x(2), euler_xlast(2)
   real(dp) :: lobatto_state(10), expected_lobatto_state(10)
   integer :: i, status
 
@@ -97,6 +99,19 @@ program test_newton_solver_status
     error stop 'zero-iteration midpoint solve did not report max iterations'
   end if
   if (any(xlast /= x)) error stop 'zero-iteration solve changed the iterate'
+
+  euler_x = [0.5_dp, 0.3_dp]
+  field%ro0 = 1.0_dp
+  symplectic_euler_warning_mode = .false.
+  call newton1(integrator, field, euler_x, 0, euler_xlast, status)
+  if (status /= SYMPLECTIC_STEP_MAXITER) then
+    error stop 'strict Euler mode did not report max iterations'
+  end if
+  symplectic_euler_warning_mode = .true.
+  call newton1(integrator, field, euler_x, 0, euler_xlast, status)
+  if (status /= SYMPLECTIC_STEP_OK) then
+    error stop 'Euler warning mode did not accept the finite iterate'
+  end if
 
   x(1) = 1.1_dp
   call newton_midpoint(integrator, field, x, 1.0e-15_dp, 1.0e-12_dp, &

--- a/test/tests/test_newton_solver_status.f90
+++ b/test/tests/test_newton_solver_status.f90
@@ -64,12 +64,13 @@ contains
 end module linear_radial_field_backend
 
 program test_newton_solver_status
+  use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
   use, intrinsic :: iso_fortran_env, only: dp => real64
   use field_can_mod, only: field_can_t, eval_field => evaluate
   use linear_radial_field_backend, only: basin_limited_step, &
     evaluate_linear_radial, nonlinear_boundary_step
   use orbit_symplectic, only: guard_lobatto_stage_radii, boundary_event_converged, &
-    advance_symplectic_with_boundary, newton1, newton_midpoint, orbit_sympl_init, &
+    advance_symplectic_with_boundary, newton_midpoint, orbit_sympl_init, &
     orbit_timestep_sympl, matrix3_near_singular, solve_newton_system, &
     get_boundary_event_tolerances
   use orbit_symplectic_base, only: symplectic_integrator_t, &
@@ -86,7 +87,6 @@ program test_newton_solver_status
   type(symplectic_integrator_t) :: integrator
   type(field_can_t) :: field
   real(dp) :: x(5), xlast(5), matrix(2, 2), residual(2), matrix3(3, 3)
-  real(dp) :: euler_x(2), euler_xlast(2)
   real(dp) :: lobatto_state(10), expected_lobatto_state(10)
   integer :: i, status
 
@@ -99,19 +99,6 @@ program test_newton_solver_status
     error stop 'zero-iteration midpoint solve did not report max iterations'
   end if
   if (any(xlast /= x)) error stop 'zero-iteration solve changed the iterate'
-
-  euler_x = [0.5_dp, 0.3_dp]
-  field%ro0 = 1.0_dp
-  symplectic_euler_warning_mode = .false.
-  call newton1(integrator, field, euler_x, 0, euler_xlast, status)
-  if (status /= SYMPLECTIC_STEP_MAXITER) then
-    error stop 'strict Euler mode did not report max iterations'
-  end if
-  symplectic_euler_warning_mode = .true.
-  call newton1(integrator, field, euler_x, 0, euler_xlast, status)
-  if (status /= SYMPLECTIC_STEP_OK) then
-    error stop 'Euler warning mode did not accept the finite iterate'
-  end if
 
   x(1) = 1.1_dp
   call newton_midpoint(integrator, field, x, 1.0e-15_dp, 1.0e-12_dp, &
@@ -184,8 +171,49 @@ program test_newton_solver_status
   call test_lcfs_location
   call test_configured_event_tolerances
   call test_solver_basin_is_not_boundary
+  call test_euler_warning_mode
 
 contains
+
+  subroutine test_euler_warning_mode
+    type(symplectic_integrator_t) :: strict_integrator, warning_integrator
+    type(field_can_t) :: strict_field, warning_field
+    real(dp) :: initial_state(4)
+    integer :: euler_status
+
+    eval_field => evaluate_linear_radial
+    strict_field%ro0 = 1.0_dp
+    strict_field%mu = 1.0_dp
+    initial_state = [0.5_dp, 0.0_dp, 0.0_dp, 0.0_dp]
+    call orbit_sympl_init(strict_integrator, strict_field, initial_state, &
+      0.01_dp, 1, 0.0_dp, EXPL_IMPL_EULER)
+    strict_integrator%atol = 0.0_dp
+    symplectic_euler_warning_mode = .false.
+    call orbit_timestep_sympl(strict_integrator, strict_field, euler_status)
+    if (euler_status /= SYMPLECTIC_STEP_MAXITER) then
+      error stop 'strict Euler timestep did not report max iterations'
+    end if
+    if (any(strict_integrator%z /= initial_state)) then
+      error stop 'strict Euler max-iteration failure changed the accepted state'
+    end if
+
+    warning_field%ro0 = 1.0_dp
+    warning_field%mu = 1.0_dp
+    call orbit_sympl_init(warning_integrator, warning_field, initial_state, &
+      0.01_dp, 1, 0.0_dp, EXPL_IMPL_EULER)
+    warning_integrator%atol = 0.0_dp
+    symplectic_euler_warning_mode = .true.
+    call orbit_timestep_sympl(warning_integrator, warning_field, euler_status)
+    if (euler_status /= SYMPLECTIC_STEP_OK) then
+      error stop 'Euler warning mode did not continue the timestep'
+    end if
+    if (.not. all(ieee_is_finite(warning_integrator%z))) then
+      error stop 'Euler warning mode accepted a non-finite state'
+    end if
+    if (all(warning_integrator%z == initial_state)) then
+      error stop 'Euler warning mode did not commit the timestep'
+    end if
+  end subroutine test_euler_warning_mode
 
   subroutine test_configured_event_tolerances
     type(symplectic_integrator_t) :: loose_integrator, tight_integrator

--- a/test/tests/test_newton_solver_status.f90
+++ b/test/tests/test_newton_solver_status.f90
@@ -64,7 +64,8 @@ contains
 end module linear_radial_field_backend
 
 program test_newton_solver_status
-  use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+  use, intrinsic :: ieee_arithmetic, only: ieee_is_finite, ieee_quiet_nan, &
+    ieee_value
   use, intrinsic :: iso_fortran_env, only: dp => real64
   use field_can_mod, only: field_can_t, eval_field => evaluate
   use linear_radial_field_backend, only: basin_limited_step, &
@@ -74,13 +75,14 @@ program test_newton_solver_status
     orbit_timestep_sympl, matrix3_near_singular, solve_newton_system, &
     get_boundary_event_tolerances
   use orbit_symplectic_base, only: symplectic_integrator_t, &
-    EXPL_IMPL_EULER, IMPL_EXPL_EULER, MIDPOINT, LOBATTO3, &
+    EXPL_IMPL_EULER, IMPL_EXPL_EULER, MIDPOINT, GAUSS1, GAUSS2, GAUSS3, &
+    GAUSS4, LOBATTO3, &
     SYMPLECTIC_STEP_BOUNDARY, &
     SYMPLECTIC_STEP_OK, SYMPLECTIC_STEP_OUTSIDE_DOMAIN, &
     SYMPLECTIC_STEP_MAXITER, SYMPLECTIC_STEP_LINEAR_SOLVE, &
     SYMPLECTIC_STEP_EVENT_NOT_CONVERGED, SYMPLECTIC_STEP_BOUNDARY_LIMITED, &
     boundary_event_fraction_tolerance, boundary_event_radial_tolerance, &
-    symplectic_euler_warning_mode
+    symplectic_newton_warning_mode
 
   implicit none
 
@@ -93,12 +95,22 @@ program test_newton_solver_status
   field%Aph = 0.0_dp
   field%ro0 = 1.0_dp
   x = [0.5_dp, 0.1_dp, 0.2_dp, 0.3_dp, 0.5_dp]
+  symplectic_newton_warning_mode = .false.
   call newton_midpoint(integrator, field, x, 1.0e-15_dp, 1.0e-12_dp, &
     0, xlast, status)
   if (status /= SYMPLECTIC_STEP_MAXITER) then
     error stop 'zero-iteration midpoint solve did not report max iterations'
   end if
   if (any(xlast /= x)) error stop 'zero-iteration solve changed the iterate'
+
+  x(1) = ieee_value(0.0_dp, ieee_quiet_nan)
+  symplectic_newton_warning_mode = .true.
+  call newton_midpoint(integrator, field, x, 1.0e-15_dp, 1.0e-12_dp, &
+    0, xlast, status)
+  if (status /= SYMPLECTIC_STEP_MAXITER) then
+    error stop 'warning mode accepted a non-finite Newton iterate'
+  end if
+  symplectic_newton_warning_mode = .false.
 
   x(1) = 1.1_dp
   call newton_midpoint(integrator, field, x, 1.0e-15_dp, 1.0e-12_dp, &
@@ -171,49 +183,56 @@ program test_newton_solver_status
   call test_lcfs_location
   call test_configured_event_tolerances
   call test_solver_basin_is_not_boundary
-  call test_euler_warning_mode
+  call test_newton_warning_mode
 
 contains
 
-  subroutine test_euler_warning_mode
+  subroutine test_newton_warning_mode
+    integer, parameter :: modes(8) = [EXPL_IMPL_EULER, IMPL_EXPL_EULER, &
+      MIDPOINT, GAUSS1, GAUSS2, GAUSS3, GAUSS4, LOBATTO3]
     type(symplectic_integrator_t) :: strict_integrator, warning_integrator
     type(field_can_t) :: strict_field, warning_field
     real(dp) :: initial_state(4)
-    integer :: euler_status
+    integer :: mode_index, step_status
 
     eval_field => evaluate_linear_radial
-    strict_field%ro0 = 1.0_dp
-    strict_field%mu = 1.0_dp
     initial_state = [0.5_dp, 0.0_dp, 0.0_dp, 0.0_dp]
-    call orbit_sympl_init(strict_integrator, strict_field, initial_state, &
-      0.01_dp, 1, 0.0_dp, EXPL_IMPL_EULER)
-    strict_integrator%atol = 0.0_dp
-    symplectic_euler_warning_mode = .false.
-    call orbit_timestep_sympl(strict_integrator, strict_field, euler_status)
-    if (euler_status /= SYMPLECTIC_STEP_MAXITER) then
-      error stop 'strict Euler timestep did not report max iterations'
-    end if
-    if (any(strict_integrator%z /= initial_state)) then
-      error stop 'strict Euler max-iteration failure changed the accepted state'
-    end if
+    do mode_index = 1, size(modes)
+      strict_field%ro0 = 1.0_dp
+      strict_field%mu = 1.0_dp
+      call orbit_sympl_init(strict_integrator, strict_field, initial_state, &
+        0.01_dp, 1, 0.0_dp, modes(mode_index))
+      strict_integrator%atol = 0.0_dp
+      symplectic_newton_warning_mode = .false.
+      call orbit_timestep_sympl(strict_integrator, strict_field, step_status)
+      if (step_status /= SYMPLECTIC_STEP_MAXITER) then
+        print *, 'strict mode, status:', modes(mode_index), step_status
+        error stop 'strict timestep did not report max iterations'
+      end if
+      if (any(strict_integrator%z /= initial_state)) then
+        error stop 'strict max-iteration failure changed the accepted state'
+      end if
 
-    warning_field%ro0 = 1.0_dp
-    warning_field%mu = 1.0_dp
-    call orbit_sympl_init(warning_integrator, warning_field, initial_state, &
-      0.01_dp, 1, 0.0_dp, EXPL_IMPL_EULER)
-    warning_integrator%atol = 0.0_dp
-    symplectic_euler_warning_mode = .true.
-    call orbit_timestep_sympl(warning_integrator, warning_field, euler_status)
-    if (euler_status /= SYMPLECTIC_STEP_OK) then
-      error stop 'Euler warning mode did not continue the timestep'
-    end if
-    if (.not. all(ieee_is_finite(warning_integrator%z))) then
-      error stop 'Euler warning mode accepted a non-finite state'
-    end if
-    if (all(warning_integrator%z == initial_state)) then
-      error stop 'Euler warning mode did not commit the timestep'
-    end if
-  end subroutine test_euler_warning_mode
+      warning_field%ro0 = 1.0_dp
+      warning_field%mu = 1.0_dp
+      call orbit_sympl_init(warning_integrator, warning_field, initial_state, &
+        0.01_dp, 1, 0.0_dp, modes(mode_index))
+      warning_integrator%atol = 0.0_dp
+      symplectic_newton_warning_mode = .true.
+      call orbit_timestep_sympl(warning_integrator, warning_field, step_status)
+      if (step_status /= SYMPLECTIC_STEP_OK) then
+        print *, 'warning mode, status:', modes(mode_index), step_status
+        error stop 'warning mode did not continue the timestep'
+      end if
+      if (.not. all(ieee_is_finite(warning_integrator%z))) then
+        error stop 'warning mode accepted a non-finite state'
+      end if
+      if (modes(mode_index) == EXPL_IMPL_EULER .and. &
+          all(warning_integrator%z == initial_state)) then
+        error stop 'warning mode did not commit the timestep'
+      end if
+    end do
+  end subroutine test_newton_warning_mode
 
   subroutine test_configured_event_tolerances
     type(symplectic_integrator_t) :: loose_integrator, tight_integrator

--- a/test/tests/test_sympl_testfield.f90
+++ b/test/tests/test_sympl_testfield.f90
@@ -37,18 +37,19 @@ end module failed_symplectic_step_backend
 program test_sympl_testfield
   use, intrinsic :: iso_fortran_env, only : dp => real64, int64
   use failed_symplectic_step_backend, only: fail_symplectic_step, locate_lcfs_step
+  use classification, only: classify_classifier_exit
   use simple_main, only : classify_orbit_exit, init_field, locate_linear_lcfs, &
     macrostep, macrostep_with_wall_check
   use simple, only : tracer_t, init_sympl, ORBIT_FO_LOSS, ORBIT_FO_NUMERICAL
   use params, only : isw_field_type, field_input, coord_input, integmode, &
     swcoll, orbit_model, ORBIT_GC, ORBIT_FULL_ORBIT, ORBIT_EXIT_LCFS, &
     ORBIT_EXIT_WALL, ORBIT_EXIT_NUMERICAL_DOMAIN, &
-    ORBIT_EXIT_NUMERICAL_FULL_ORBIT
+    ORBIT_EXIT_NUMERICAL_MAXITER, ORBIT_EXIT_NUMERICAL_FULL_ORBIT
   use magfie_sub, only : TEST
   use field_can_mod, only : evaluate
   use orbit_symplectic, only : orbit_timestep_sympl
   use orbit_symplectic_base, only: SYMPLECTIC_STEP_BOUNDARY, &
-    SYMPLECTIC_STEP_OK
+    SYMPLECTIC_STEP_OK, SYMPLECTIC_STEP_MAXITER
 
   implicit none
 
@@ -152,6 +153,9 @@ contains
   end subroutine test_failed_step_preserves_state
 
   subroutine test_exit_classification
+    logical :: classifier_lost
+    integer :: classifier_exit
+
     if (classify_orbit_exit(SYMPLECTIC_STEP_BOUNDARY, ORBIT_GC, 3, .true.) /= &
         ORBIT_EXIT_LCFS) then
       error stop 'converged LCFS event was not classified as physical'
@@ -188,6 +192,17 @@ contains
     if (classify_orbit_exit(1, ORBIT_GC, 0, .false.) /= &
         ORBIT_EXIT_NUMERICAL_DOMAIN) then
       error stop 'RK extended-map boundary was classified as physical'
+    end if
+
+    call classify_classifier_exit(SYMPLECTIC_STEP_MAXITER, 3, &
+      classifier_lost, classifier_exit)
+    if (classifier_lost .or. classifier_exit /= ORBIT_EXIT_NUMERICAL_MAXITER) then
+      error stop 'classifier mode promoted Newton maxiter to a physical loss'
+    end if
+    call classify_classifier_exit(SYMPLECTIC_STEP_BOUNDARY, 3, &
+      classifier_lost, classifier_exit)
+    if (.not. classifier_lost .or. classifier_exit /= ORBIT_EXIT_LCFS) then
+      error stop 'classifier mode lost its physical boundary classification'
     end if
   end subroutine test_exit_classification
 


### PR DESCRIPTION
## Risk tier

- [ ] T0: docs, comments, small build metadata
- [ ] T1: pure refactor, no behavior change intended
- [ ] T2: local numerical logic
- [x] T3: physics, output behavior, coordinate convention
- [x] T4: parallelism or GPU; dependency, CI, or security-sensitive build logic

## Correctness contract

### Intended behavior change

The default symplectic Newton policy continues an orbit after a maximum-iteration solve only when the final correction is finite and at most ten times the requested relative tolerance. This covers Euler 1/2, midpoint, Gauss 1-4, Lobatto 3, and GPU Euler. The corresponding `*_maxit` diagnostic records every accepted warning.

`symplectic_newton_warning_mode = .false.` retains strict rollback and marker termination. Corrections outside the bound, non-finite states, domain exits, singular systems, and unresolved boundary events remain failures.

Classifier mode no longer promotes a rejected numerical step to a physical loss. It records a 101-105 `orbit_exit_code`, `NaN` loss time, and an unresolved marker.

### Preserved invariants

Converged steps use the same fixed timestep, discrete equations, tolerances, iteration limit, field, coordinates, units, boundary conditions, and update order. CPU and GPU use the same correction bound. Strict rejection restores the integrator and field to the last accepted state.

A warning-mode step satisfies the implicit map only to the documented relaxed bound. It is therefore flagged and must not be treated as a fully converged solve.

### Historical behavior

SIMPLE v1.4 printed Newton maximum-iteration diagnostics and continued tracing. This change restores that operational default while rejecting large or non-finite corrections.

## Verification

### Test fails on main

Boozer midpoint smoke with `integmode=3`, `trace_time=1d-2`, four markers, and one OpenMP thread:

```text
$ OMP_NUM_THREADS=1 fo exec --no-build --cwd build/test/tests simple.x simple.in
$ sed -n '1,4p' build/test/tests/orbit_exit_code.dat
1   0   1.0000000000000000E-002
2 102                       NaN
3   0   1.0000000000000000E-002
4   0   1.0000000000000000E-002
```

Marker 2 stopped on a near-converged midpoint Newton solve.

### Test passes after fix

The same smoke accepts 15 bounded maximum-iteration corrections and completes all markers:

```text
[progress] 100.00%  4/4  t=6.6s  eta=.0s midpoint_maxit=15
1 0 1.0000000000000000E-002
2 0 1.0000000000000000E-002
3 0 1.0000000000000000E-002
4 0 1.0000000000000000E-002
```

The observed normalized corrections were `1.4476` times the requested tolerance; the maximum absolute correction was `9.095e-13` and the radial corrections were at roundoff.

```text
$ fo test test_newton_solver_status test_gpu_orbit_bench
test_newton_solver_status                  PASS       0.06s
test_gpu_orbit_bench                       PASS       5.54s

$ fo test test_sympl_testfield
test_sympl_testfield                       PASS       0.06s

$ fo
Static: OK (175 modules, 175 changed, 175 affected)
Build: OK
Tests: OK
Lint: OK
All stages passed (265.7s)
```
