### PR TITLE
Retry failed symplectic steps in warning mode

### DIFF
--- a/src/orbit_symplectic.f90
+++ b/src/orbit_symplectic.f90
@@ -89,7 +89,8 @@ recursive subroutine advance_retry_interval(si, f, stepper, interval, depth, &
   initial_field = f
   si%dt = interval
   call stepper(si, f, status)
-  if (status == SYMPLECTIC_STEP_OK) then
+  if (status == SYMPLECTIC_STEP_OK .or. &
+      status == SYMPLECTIC_STEP_BOUNDARY) then
     si%dt = interval
     return
   end if
@@ -107,9 +108,22 @@ recursive subroutine advance_retry_interval(si, f, stepper, interval, depth, &
   ! recovery path, not a globally fixed symplectic map.
   call advance_retry_interval(si, f, stepper, 0.5_dp*interval, depth + 1, &
     status)
-  if (status == SYMPLECTIC_STEP_OK) &
+  if (status == SYMPLECTIC_STEP_BOUNDARY) then
+    si%last_step_fraction = 0.5_dp*si%last_step_fraction
+    si%last_event_fraction_width = 0.5_dp*si%last_event_fraction_width
+    si%dt = interval
+    return
+  end if
+  if (status == SYMPLECTIC_STEP_OK) then
     call advance_retry_interval(si, f, stepper, 0.5_dp*interval, depth + 1, &
       status)
+    if (status == SYMPLECTIC_STEP_BOUNDARY) then
+      si%last_step_fraction = 0.5_dp + 0.5_dp*si%last_step_fraction
+      si%last_event_fraction_width = 0.5_dp*si%last_event_fraction_width
+      si%dt = interval
+      return
+    end if
+  end if
   if (status /= SYMPLECTIC_STEP_OK) then
     si = initial_integrator
     f = initial_field

--- a/src/orbit_symplectic.f90
+++ b/src/orbit_symplectic.f90
@@ -63,6 +63,60 @@ logical function accept_bounded_maxiter(x, xlast, tolref, rtol)
     symplectic_newton_warning_factor*rtol*abs(tolref))
 end function accept_bounded_maxiter
 
+subroutine advance_symplectic_with_retry(si, f, stepper, status)
+  type(symplectic_integrator_t), intent(inout) :: si
+  type(field_can_t), intent(inout) :: f
+  procedure(orbit_timestep_sympl_i) :: stepper
+  integer, intent(out) :: status
+
+  call advance_retry_interval(si, f, stepper, si%dt, 0, status)
+end subroutine advance_symplectic_with_retry
+
+recursive subroutine advance_retry_interval(si, f, stepper, interval, depth, &
+    status)
+  integer, parameter :: max_retry_depth = 8
+  type(symplectic_integrator_t), intent(inout) :: si
+  type(field_can_t), intent(inout) :: f
+  procedure(orbit_timestep_sympl_i) :: stepper
+  real(dp), intent(in) :: interval
+  integer, intent(in) :: depth
+  integer, intent(out) :: status
+  type(symplectic_integrator_t) :: initial_integrator
+  type(field_can_t) :: initial_field
+  logical :: recoverable
+
+  initial_integrator = si
+  initial_field = f
+  si%dt = interval
+  call stepper(si, f, status)
+  if (status == SYMPLECTIC_STEP_OK) then
+    si%dt = interval
+    return
+  end if
+
+  si = initial_integrator
+  f = initial_field
+  si%dt = interval
+  recoverable = status == SYMPLECTIC_STEP_MAXITER .or. &
+    status == SYMPLECTIC_STEP_LINEAR_SOLVE
+  if (.not. symplectic_newton_warning_mode .or. .not. recoverable .or. &
+      depth >= max_retry_depth) return
+
+  ! For a fixed subdivision, the two accepted maps remain symplectic and cover
+  ! the original interval exactly. State-dependent subdivision is a warning-mode
+  ! recovery path, not a globally fixed symplectic map.
+  call advance_retry_interval(si, f, stepper, 0.5_dp*interval, depth + 1, &
+    status)
+  if (status == SYMPLECTIC_STEP_OK) &
+    call advance_retry_interval(si, f, stepper, 0.5_dp*interval, depth + 1, &
+      status)
+  if (status /= SYMPLECTIC_STEP_OK) then
+    si = initial_integrator
+    f = initial_field
+  end if
+  si%dt = interval
+end subroutine advance_retry_interval
+
 subroutine apply_axis_chart_switch(radius, theta, crossed, status)
   real(dp), intent(inout) :: radius, theta
   logical, intent(out) :: crossed

--- a/src/params.f90
+++ b/src/params.f90
@@ -206,7 +206,8 @@ contains
 
         if (integmode > 0 .and. symplectic_newton_warning_mode) then
             print *, 'WARNING: symplectic integrators accept bounded Newton ', &
-                'corrections after the iteration limit; see maxit diagnostics'
+                'corrections and retry failed smooth-field steps by halving; ', &
+                'see maxit diagnostics'
         end if
 
         call validate_boundary_event_tolerances

--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -1316,7 +1316,8 @@ contains
 
     subroutine macrostep(anorb, z, kt, ierr_orbit, ntau_local, exit_step)
         use alpha_lifetime_sub, only: orbit_timestep_axis
-        use orbit_symplectic, only: orbit_timestep_sympl
+        use orbit_symplectic, only: advance_symplectic_with_retry, &
+            orbit_timestep_sympl
 
         type(tracer_t), intent(inout) :: anorb
         real(dp), intent(inout) :: z(5)
@@ -1361,7 +1362,8 @@ contains
                 end if
             else
                 if (swcoll) call update_momentum(anorb, z)
-                call orbit_timestep_sympl(anorb%si, anorb%f, ierr_orbit)
+                call advance_symplectic_with_retry(anorb%si, anorb%f, &
+                    orbit_timestep_sympl, ierr_orbit)
                 if (ierr_orbit == SYMPLECTIC_STEP_BOUNDARY) then
                     call to_standard_z_coordinates(anorb, z)
                     if (present(exit_step)) exit_step = real(kt, dp) + &
@@ -1442,7 +1444,8 @@ contains
     subroutine macrostep_with_wall_check(anorb, z, kt, ierr_orbit, ntau_local, &
             ipart, x_prev_m, exit_step)
         use alpha_lifetime_sub, only: orbit_timestep_axis
-        use orbit_symplectic, only: orbit_timestep_sympl
+        use orbit_symplectic, only: advance_symplectic_with_retry, &
+            orbit_timestep_sympl
 
         type(tracer_t), intent(inout) :: anorb
         real(dp), intent(inout) :: z(5)
@@ -1489,7 +1492,8 @@ contains
                 end if
             else
                 if (swcoll) call update_momentum(anorb, z)
-                call orbit_timestep_sympl(anorb%si, anorb%f, ierr_orbit)
+                call advance_symplectic_with_retry(anorb%si, anorb%f, &
+                    orbit_timestep_sympl, ierr_orbit)
                 if (ierr_orbit == SYMPLECTIC_STEP_BOUNDARY) then
                     call to_standard_z_coordinates(anorb, z)
                     call integ_to_ref(z(1:3), u_ref_cur)

--- a/test/tests/test_newton_solver_status.f90
+++ b/test/tests/test_newton_solver_status.f90
@@ -3,9 +3,11 @@ module linear_radial_field_backend
   use field_can_base, only: field_can_t
   use orbit_symplectic_base, only: symplectic_integrator_t, &
     SYMPLECTIC_STEP_BOUNDARY_LIMITED, SYMPLECTIC_STEP_OK, &
-    SYMPLECTIC_STEP_OUTSIDE_DOMAIN
+    SYMPLECTIC_STEP_OUTSIDE_DOMAIN, SYMPLECTIC_STEP_MAXITER
 
   implicit none
+
+  integer :: retry_calls = 0
 
 contains
 
@@ -61,6 +63,34 @@ contains
       step_status = SYMPLECTIC_STEP_OK
     end if
   end subroutine nonlinear_boundary_step
+
+  subroutine retryable_step(si, f, step_status)
+    type(symplectic_integrator_t), intent(inout) :: si
+    type(field_can_t), intent(inout) :: f
+    integer, intent(out) :: step_status
+
+    retry_calls = retry_calls + 1
+    if (si%dt > 0.5_dp) then
+      si%z = 99.0_dp
+      f%H = 99.0_dp
+      step_status = SYMPLECTIC_STEP_MAXITER
+      return
+    end if
+    si%z(1) = si%z(1) + si%dt
+    f%H = f%H + si%dt
+    step_status = SYMPLECTIC_STEP_OK
+  end subroutine retryable_step
+
+  subroutine failed_boundary_step(si, f, step_status)
+    type(symplectic_integrator_t), intent(inout) :: si
+    type(field_can_t), intent(inout) :: f
+    integer, intent(out) :: step_status
+
+    retry_calls = retry_calls + 1
+    si%z = 99.0_dp
+    f%H = 99.0_dp
+    step_status = SYMPLECTIC_STEP_OUTSIDE_DOMAIN
+  end subroutine failed_boundary_step
 end module linear_radial_field_backend
 
 program test_newton_solver_status
@@ -68,9 +98,11 @@ program test_newton_solver_status
   use, intrinsic :: iso_fortran_env, only: dp => real64
   use field_can_mod, only: field_can_t, eval_field => evaluate
   use linear_radial_field_backend, only: basin_limited_step, &
-    evaluate_linear_radial, nonlinear_boundary_step
+    evaluate_linear_radial, failed_boundary_step, nonlinear_boundary_step, &
+    retryable_step, retry_calls
   use orbit_symplectic, only: guard_lobatto_stage_radii, boundary_event_converged, &
-    advance_symplectic_with_boundary, newton_midpoint, orbit_sympl_init, &
+    advance_symplectic_with_boundary, advance_symplectic_with_retry, &
+    newton_midpoint, orbit_sympl_init, &
     orbit_timestep_sympl, matrix3_near_singular, solve_newton_system, &
     get_boundary_event_tolerances, accept_bounded_maxiter
   use orbit_symplectic_base, only: symplectic_integrator_t, &
@@ -183,6 +215,7 @@ program test_newton_solver_status
   call test_configured_event_tolerances
   call test_solver_basin_is_not_boundary
   call test_newton_warning_mode
+  call test_step_retry
 
 contains
 
@@ -236,6 +269,60 @@ contains
       error stop 'strict mode accepted a Newton max-iteration state'
     end if
   end subroutine test_newton_warning_mode
+
+  subroutine test_step_retry
+    type(symplectic_integrator_t) :: retry_integrator
+    type(field_can_t) :: retry_field
+    real(dp) :: initial_state(4)
+    integer :: step_status
+
+    initial_state = [0.5_dp, 0.0_dp, 0.0_dp, 0.0_dp]
+    retry_integrator%z = initial_state
+    retry_integrator%dt = 1.0_dp
+    retry_field%H = 0.0_dp
+    retry_calls = 0
+    symplectic_newton_warning_mode = .true.
+    call advance_symplectic_with_retry(retry_integrator, retry_field, &
+      retryable_step, step_status)
+    if (step_status /= SYMPLECTIC_STEP_OK) then
+      error stop 'warning mode did not recover a failed full step'
+    end if
+    if (retry_calls /= 3) error stop 'warning mode used the wrong retry sequence'
+    if (abs(retry_integrator%z(1) - 1.5_dp) > 1.0e-14_dp) then
+      error stop 'recovered step did not advance the full interval'
+    end if
+    if (abs(retry_field%H - 1.0_dp) > 1.0e-14_dp) then
+      error stop 'recovered field state did not advance the full interval'
+    end if
+    if (retry_integrator%dt /= 1.0_dp) then
+      error stop 'recovered step did not restore the configured timestep'
+    end if
+
+    retry_integrator%z = initial_state
+    retry_integrator%dt = 1.0_dp
+    retry_field%H = 0.0_dp
+    retry_calls = 0
+    symplectic_newton_warning_mode = .false.
+    call advance_symplectic_with_retry(retry_integrator, retry_field, &
+      retryable_step, step_status)
+    if (step_status /= SYMPLECTIC_STEP_MAXITER .or. retry_calls /= 1) then
+      error stop 'strict mode retried a failed step'
+    end if
+    if (any(retry_integrator%z /= initial_state) .or. retry_field%H /= 0.0_dp) then
+      error stop 'failed strict step changed the accepted state'
+    end if
+
+    retry_calls = 0
+    symplectic_newton_warning_mode = .true.
+    call advance_symplectic_with_retry(retry_integrator, retry_field, &
+      failed_boundary_step, step_status)
+    if (step_status /= SYMPLECTIC_STEP_OUTSIDE_DOMAIN .or. retry_calls /= 1) then
+      error stop 'warning mode retried a physical boundary status'
+    end if
+    if (any(retry_integrator%z /= initial_state) .or. retry_field%H /= 0.0_dp) then
+      error stop 'failed boundary step changed the accepted state'
+    end if
+  end subroutine test_step_retry
 
   subroutine test_configured_event_tolerances
     type(symplectic_integrator_t) :: loose_integrator, tight_integrator

--- a/test/tests/test_newton_solver_status.f90
+++ b/test/tests/test_newton_solver_status.f90
@@ -3,7 +3,8 @@ module linear_radial_field_backend
   use field_can_base, only: field_can_t
   use orbit_symplectic_base, only: symplectic_integrator_t, &
     SYMPLECTIC_STEP_BOUNDARY_LIMITED, SYMPLECTIC_STEP_OK, &
-    SYMPLECTIC_STEP_OUTSIDE_DOMAIN, SYMPLECTIC_STEP_MAXITER
+    SYMPLECTIC_STEP_OUTSIDE_DOMAIN, SYMPLECTIC_STEP_MAXITER, &
+    SYMPLECTIC_STEP_BOUNDARY
 
   implicit none
 
@@ -91,6 +92,29 @@ contains
     f%H = 99.0_dp
     step_status = SYMPLECTIC_STEP_OUTSIDE_DOMAIN
   end subroutine failed_boundary_step
+
+  subroutine retryable_boundary_step(si, f, step_status)
+    type(symplectic_integrator_t), intent(inout) :: si
+    type(field_can_t), intent(inout) :: f
+    integer, intent(out) :: step_status
+
+    retry_calls = retry_calls + 1
+    if (si%dt > 0.5_dp) then
+      step_status = SYMPLECTIC_STEP_MAXITER
+      return
+    end if
+    if (retry_calls == 2) then
+      si%z(1) = si%z(1) + si%dt
+      f%H = f%H + si%dt
+      step_status = SYMPLECTIC_STEP_OK
+      return
+    end if
+    si%z(1) = si%z(1) + 0.25_dp*si%dt
+    f%H = f%H + 0.25_dp*si%dt
+    si%last_step_fraction = 0.25_dp
+    si%last_event_fraction_width = 0.02_dp
+    step_status = SYMPLECTIC_STEP_BOUNDARY
+  end subroutine retryable_boundary_step
 end module linear_radial_field_backend
 
 program test_newton_solver_status
@@ -99,7 +123,7 @@ program test_newton_solver_status
   use field_can_mod, only: field_can_t, eval_field => evaluate
   use linear_radial_field_backend, only: basin_limited_step, &
     evaluate_linear_radial, failed_boundary_step, nonlinear_boundary_step, &
-    retryable_step, retry_calls
+    retryable_boundary_step, retryable_step, retry_calls
   use orbit_symplectic, only: guard_lobatto_stage_radii, boundary_event_converged, &
     advance_symplectic_with_boundary, advance_symplectic_with_retry, &
     newton_midpoint, orbit_sympl_init, &
@@ -321,6 +345,22 @@ contains
     end if
     if (any(retry_integrator%z /= initial_state) .or. retry_field%H /= 0.0_dp) then
       error stop 'failed boundary step changed the accepted state'
+    end if
+
+    retry_calls = 0
+    call advance_symplectic_with_retry(retry_integrator, retry_field, &
+      retryable_boundary_step, step_status)
+    if (step_status /= SYMPLECTIC_STEP_BOUNDARY .or. retry_calls /= 3) then
+      error stop 'retry path lost a converged boundary event'
+    end if
+    if (abs(retry_integrator%z(1) - 1.125_dp) > 1.0e-14_dp .or. &
+        abs(retry_field%H - 0.625_dp) > 1.0e-14_dp) then
+      error stop 'retry path lost the boundary event state'
+    end if
+    if (abs(retry_integrator%last_step_fraction - 0.625_dp) > 1.0e-14_dp .or. &
+        abs(retry_integrator%last_event_fraction_width - 0.01_dp) > &
+        1.0e-14_dp) then
+      error stop 'retry path reported the wrong boundary event time'
     end if
   end subroutine test_step_retry
 


### PR DESCRIPTION
## Risk tier

- [ ] T0: docs, comments, small build metadata
- [ ] T1: pure refactor, no behavior change intended
- [ ] T2: local numerical logic
- [x] T3: physics, output behavior, coordinate convention
- [ ] T4: parallelism, GPU, dependency, CI, or security-sensitive build logic

## Correctness contract

### Intended behavior change

In Newton warning mode, retry a failed smooth-field symplectic microstep as two
half-steps. Recursively subdivide only maximum-iteration and linear-solve
failures. Restore the pre-step state if recovery fails.

### Behavior that must not change

Successful fixed steps take the existing path and produce the existing state.
Strict mode performs no retry. Converged physical boundary events remain
committed and are not retried. Domain and unresolved-event failures are rolled
back. The dedicated SPECTRE interface-crossing pipeline is unchanged.

### Coordinate / unit conventions

No coordinate or unit convention changes. The retry intervals use the
integrator's existing normalized timestep and sum exactly to the original
microstep interval. Boundary event fractions and widths are rescaled from a
retry subinterval to the original microstep interval.

### Numerical invariants

- Failed trial steps cannot modify the accepted integrator or field state.
- A successful retry advances the complete configured time interval.
- A converged boundary event preserves its endpoint, radial residual, and time.
- For any fixed subdivision, the result is a composition of the existing
  symplectic maps. State-dependent subdivision is explicitly restricted to
  warning-mode recovery and is not claimed to be one globally fixed symplectic
  map.
- No energy projection, tolerance change, or unconverged Newton iterate is
  introduced.

## Tests added

- unit: forced full-step failure followed by two successful half-steps; strict
  mode; state rollback; direct physical-boundary commit; boundary event after a
  successful retry half-step, including composed event fraction and width
- integration: complete non-regression test suite
- system: four-marker VMEC midpoint trace with iteration-limit events
- golden record: unchanged

## Golden-record impact

- [x] unchanged
- [ ] changed

Successful fixed-step trajectories are unchanged. Runs that previously stopped
on a numerical solver status can now continue through warning-mode subdivision.

## Failure modes considered

Maximum-iteration and linear-solve failures are recoverable. A converged LCFS
event remains an accepted physical endpoint. Domain and unresolved-event
statuses are not retried and restore the accepted state. Exhausting eight
subdivision levels returns the original failure with the accepted state
restored. Strict mode remains fail-fast.

## Manual validation

A smooth-field midpoint benchmark previously produced 206 numerical
maximum-iteration exits among 256 markers. Re-running its first four markers
with this change completed all four, recorded zero unresolved markers, and
encountered 630 midpoint iteration-limit events without terminating a trace.

## Verification

Failing before the boundary-event fix:

```text
test_sympl_testfield ... Failed
ERROR STOP LCFS event time lost its step fraction
99% tests passed, 1 tests failed out of 86
```

Passing after the fix:

```text
fo
Static: OK (175 modules, 175 changed, 175 affected)
Build: OK
Tests: OK
Lint: OK
All stages passed (339.7s)
```
