### PR TITLE
Serialize tests that share result files

### DIFF
--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -826,6 +826,7 @@ add_test(NAME test_restart_io
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 set_tests_properties(test_restart_io PROPERTIES
     LABELS "unit"
+    RESOURCE_LOCK simple_result_files
     TIMEOUT 15)
 
 add_executable(test_result_accounting.x test_result_accounting.f90)
@@ -835,6 +836,7 @@ add_test(NAME test_result_accounting
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 set_tests_properties(test_result_accounting PROPERTIES
     LABELS "unit"
+    RESOURCE_LOCK simple_result_files
     TIMEOUT 15)
 
 # Restart integration test (TEST field, deterministic)


### PR DESCRIPTION
## Summary

- give the restart-I/O and result-accounting tests the same CTest resource lock
- prevent their shared `times_lost.dat` and related files from racing under parallel `fo`

This is a test-infrastructure-only PR stacked on #497. It does not change the runtime binary.

## Validation

- reproduced the race as simultaneous failures of both tests
- each failed test passed immediately when rerun alone
- generated CTest metadata contains the shared resource lock
- complete `fo` pipeline passed: static analysis, build, tests, and lint (460.9 s)
