### PR TITLE
Order pyplot module before SIMPLE compilation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,6 +103,11 @@ list(APPEND SOURCES
 
 # Link pyplot library to SIMPLE
 target_link_libraries(simple PUBLIC pyplot)
+# `diag_albert.f90` consumes pyplot_module.mod while `pyplot` is a separate
+# target. A link edge alone does not order compilation of the dependent target
+# under Ninja, so a clean parallel build can compile diag_albert before the
+# module file exists.
+add_dependencies(simple pyplot)
 
 # Apply SIMPLE-specific compile options
 target_compile_options(simple PRIVATE ${SIMPLE_COMPILE_OPTIONS})


### PR DESCRIPTION
## Summary

- add the explicit target-order dependency required when `diag_albert.f90` consumes `pyplot_module.mod` from the separate `pyplot` target
- prevent clean parallel Ninja builds from compiling `diag_albert` before the module file exists

## Evidence

The CGAL wall CI job on PR #499 failed in a clean parallel build with:

```
Fatal Error: Cannot open module file ‘pyplot_module.mod’
```

The existing link edge orders final linking but did not reliably order compilation across targets. This PR adds no source or runtime behavior change.

## Validation

- clean `fo build` passed
- `fo` passed all stages in 308.3 s
