### PR TITLE
Use one NetCDF/HDF5 link stack

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -121,7 +121,7 @@ if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
 endif()
 
 target_link_libraries(simple PUBLIC
-    netcdf netcdff BLAS::BLAS LAPACK::LAPACK
+    BLAS::BLAS LAPACK::LAPACK
 )
 
 target_link_libraries(simple PUBLIC


### PR DESCRIPTION
## Summary

- remove redundant bare NetCDF library names from the SIMPLE target
- use the NetCDF link stack already resolved and exported by libneo
- prevent fetched static and host shared NetCDF/HDF5 libraries from entering the same executable

This replacement for #497 targets merged `main` directly. Its Git tree is byte-identical to the prior stacked head, whose full CI passed.