### PR TITLE
Add invariant initial conditions

### DIFF
--- a/DOC/coordinates-and-fields.md
+++ b/DOC/coordinates-and-fields.md
@@ -1222,7 +1222,95 @@ The flat wrapper in `simple_main` accepts the public reference-coordinate
 state, performs `ref_to_integ`, and is the boundary used by f90wrap and
 `pysimple.compute_canonical_frequencies`.
 
-### 10.6 Integration
+### 10.6 Guiding-center invariant initial conditions
+
+`src/orbit_invariants.f90` provides an axisymmetric preprocessing path from the
+three guiding-center invariants `(H0, J_perp, p_phi)` to SIMPLE's standard
+initial state `[s, theta, phi, p, lambda]`. The existing state remains the
+integrator input, so this API adds no branch or unit checks to the orbit hot
+loop.
+
+SIMPLE uses
+
+```
+p       = |momentum|/(m v0)
+lambda  = v_parallel/v
+H0      = p^2
+J_perp  = p^2 (1 - lambda^2)/B
+```
+
+for the current magnetic Hamiltonian. Electrostatic potential energy is not
+included. With `rho0 = m c v0/q`, the native flux-normalized canonical
+toroidal momentum is
+
+```
+psi_star_native = A_phi + rho0 p lambda h_phi = (c/q) P_phi.
+```
+
+It has magnetic-flux units; it is not the dimensionless VMEC label `s`.
+`A_phi` is the toroidal covariant vector-potential component, hence the
+poloidal flux contribution. For a VMEC field, `A_theta` is toroidal flux and
+`A_phi` is minus poloidal flux.
+
+The public `p_phi` value uses a portable POTATO-facing gauge:
+
+```
+p_phi = epsilon_psi (psi_star_native - A_phi_axis),
+epsilon_psi = sign(A_phi_edge - A_phi_axis).
+```
+
+The magnetic-flux contribution is therefore zero on axis and positive in the
+equilibrium's outward flux direction. The total `p_phi` also contains the
+parallel-momentum term and need not vanish on axis. Raw POTATO `psi_star`
+values retain the g-eqdsk gauge. Convert them with
+
+```
+p_phi = sign(psi_edge - psi_axis) (psi_star_POTATO - psi_axis).
+```
+
+If POTATO and SIMPLE use different reference velocities, set
+`a = v0_POTATO/v0_SIMPLE` and convert `H0_SIMPLE = a^2 H0_POTATO` and
+`J_perp_SIMPLE = a^2 J_perp_POTATO`. The default `a = 1` requires the same
+reference energy, mass, and charge state. The physical flux-normalized
+`p_phi` needs no velocity rescaling when both codes describe the same physical
+species and toroidal orientation.
+
+The symplectic integrator uses a private normalization. `init_sympl`,
+`reseed_sympl`, and the invariant API share `encode_symplectic_state`, which
+sets
+
+```
+mu_bar    = J_perp
+rho0_bar  = rho0/sqrt(2)
+vpar_bar  = sqrt(2) p lambda
+z(4)      = sqrt(2) psi_star_native/rho0
+dt_bar    = dtau/sqrt(2).
+```
+
+The paired `sqrt(2)` factors do not change the public time convention:
+`tau = v0 t`. They stay inside the symplectic implementation.
+
+The inverse routine constructs the coordinate-independent Poincare cut
+`grad(psi) x grad(B) = 0`. In axisymmetry this is the set of `B` extrema on
+each flux surface. It scans both `sigma = sign(v_parallel)` branches and
+returns every regular root. Results from the flat/Python API are ordered by
+cylindrical major radius from HFS to LFS, matching POTATO's `R_c` direction.
+The metadata identifies the velocity sign, section branch, and whether the
+point is a `B` minimum or maximum.
+
+No root is selected as the representative orbit. Several cut points can map
+to one physical orbit, and a non-monotone `psi_star(R_c)` can repeat an orbit
+within one branch. Likewise, “outer” and “inner” describe whether an orbit
+encircles the central forbidden region; they are topological classes, not HFS
+and LFS labels. This multiplicity follows the POTATO construction described by
+[Buchholz et al. (2022)](https://doi.org/10.1088/1742-6596/2397/1/012012).
+
+The source-level entry points are `invariants_from_state`,
+`states_from_invariants`, and `potato_to_simple_invariants`. The flat wrappers
+in `simple_main` convert between reference and integration coordinates and
+provide cylindrical `R_c` metadata for Python.
+
+### 10.7 Integration
 
 | File | Purpose |
 |------|---------|
@@ -1278,5 +1366,5 @@ New name `integ_coords` is more descriptive but less documented.
 
 ---
 
-*Document last updated: 2025-12-29*
+*Document last updated: 2026-07-18*
 *Corresponding code version: Post v1.5.1*

--- a/python/README.md
+++ b/python/README.md
@@ -97,6 +97,55 @@ The same event machinery is available as ``pysimple.trace_to_cut``. Select
 back to public reference coordinates. This driver currently requires one of
 SIMPLE's symplectic integrators.
 
+Invariant initial conditions
+----------------------------
+
+``invariants_from_state`` converts the existing public state to the magnetic
+invariant set used by NEO-RT/POTATO:
+
+.. code-block:: python
+
+    invariant = pysimple.invariants_from_state(
+        np.array([0.4, 0.7, 0.0, 1.0, 0.3])
+    )
+    starts = pysimple.states_from_invariants(
+        invariant["h0"], invariant["j_perp"], invariant["p_phi"]
+    )
+
+``H0 = (v/v0)^2`` and
+``J_perp = H0 * (1 - lambda**2) / B``. ``p_phi`` is
+``psi_star = (c/q) P_phi`` in magnetic-flux units. The public convention is
+axis-zero and outward-positive for the magnetic-flux contribution; the total
+also contains parallel momentum. It is not the VMEC radial label ``s`` and it
+is not SIMPLE's private symplectic fourth coordinate.
+
+The inverse is defined for axisymmetric fields. It uses the section
+``grad(psi) x grad(B) = 0`` and returns all regular roots on both
+``sign(v_parallel)`` branches. The rows in ``starts["states"]`` are standard
+SIMPLE states. They are ordered by cylindrical major radius from HFS to LFS,
+the direction used for POTATO's ``R_c``. Multiple rows can represent the same
+physical orbit. The routine does not choose an outer or inner topological
+class.
+
+Raw POTATO ``psi_star`` retains the equilibrium flux gauge. Supply the axis
+and edge flux to convert it:
+
+.. code-block:: python
+
+    starts = pysimple.states_from_potato_invariants(
+        h0,
+        j_perp,
+        psi_star,
+        psi_axis=psi_axis,
+        psi_edge=psi_edge,
+        v0_ratio=v0_potato / v0_simple,
+    )
+
+``v0_ratio`` defaults to one. That default requires the same reference energy,
+particle mass, and charge state in both codes. SIMPLE's public time remains
+``tau = v0 * t``; the symplectic integrator's internal ``sqrt(2)`` rescaling
+does not change this interface.
+
 Legacy script note
 ------------------
 

--- a/python/pysimple/__init__.py
+++ b/python/pysimple/__init__.py
@@ -73,6 +73,17 @@ FREQ_ORBIT_LOST = 2
 FREQ_INTEGRATOR_ERROR = 3
 FREQ_MAX_STEPS = 4
 
+INVARIANT_SUCCESS = 0
+INVARIANT_INVALID_INPUT = 1
+INVARIANT_NOT_AXISYMMETRIC = 2
+INVARIANT_NO_INTERSECTION = 3
+INVARIANT_ROOT_FAILURE = 4
+INVARIANT_CAPACITY = 5
+
+SECTION_EXTREMUM_UNKNOWN = 0
+SECTION_B_MINIMUM = 1
+SECTION_B_MAXIMUM = 2
+
 CUT_TIP = 0
 CUT_TOROIDAL = 1
 
@@ -708,6 +719,140 @@ def compute_canonical_frequencies(
         "n_periods": int(metadata[3]),
         "n_steps": int(metadata[4]),
     }
+
+
+def invariants_from_state(position: np.ndarray) -> dict[str, float | int | str]:
+    """Convert one public GC state to ``(H0, J_perp, p_phi)``.
+
+    ``H0=(v/v0)^2`` and ``J_perp=H0*(1-lambda**2)/B`` use the same
+    normalization as POTATO when both codes use the same reference velocity.
+    ``p_phi`` is the flux-normalized canonical toroidal momentum
+    ``psi*=(c/q)P_phi``. It is axis-zero and positive in the outward flux
+    direction. The magnetic-flux term is zero on axis, while the total also
+    contains the parallel-momentum term. It is not a dimensionless flux label.
+    """
+    if not _initialized:
+        raise RuntimeError("SIMPLE not initialized. Call pysimple.init() first.")
+
+    position = np.ascontiguousarray(position, dtype=np.float64)
+    if position.shape != (5,):
+        raise ValueError(f"position must have shape (5,), got {position.shape}")
+
+    _ensure_trace_initialized()
+    values = np.zeros(5, dtype=np.float64)
+    status = _simple_main.invariants_from_state_flat(_tracer, position, values)
+    return {
+        "h0": float(values[0]),
+        "j_perp": float(values[1]),
+        "p_phi": float(values[2]),
+        "psi_star": float(values[2]),
+        "axis_flux_native": float(values[3]),
+        "outward_sign": float(values[4]),
+        "status": int(status),
+        "p_phi_convention": "axis-zero, outward-positive flux gauge for (c/q)P_phi",
+        "time_convention": "tau=v0*t",
+    }
+
+
+def states_from_invariants(
+    h0: float,
+    j_perp: float,
+    p_phi: float,
+    *,
+    max_solutions: int = 64,
+) -> dict[str, np.ndarray | int | str]:
+    """Return all regular cut states matching ``(H0, J_perp, p_phi)``.
+
+    The axisymmetric cut is ``grad(psi) x grad(B) = 0``. Results are ordered
+    by cylindrical major radius, matching POTATO's HFS-to-LFS ``R_c``
+    convention. Multiple entries may represent the same physical orbit;
+    no outer/inner topological class is selected implicitly.
+    """
+    if not _initialized:
+        raise RuntimeError("SIMPLE not initialized. Call pysimple.init() first.")
+    if not np.isfinite([h0, j_perp, p_phi]).all():
+        raise ValueError("invariants must be finite")
+    if h0 <= 0.0:
+        raise ValueError("h0 must be positive")
+    if j_perp < 0.0:
+        raise ValueError("j_perp must be non-negative")
+    if max_solutions < 1:
+        raise ValueError("max_solutions must be at least one")
+
+    _ensure_trace_initialized()
+    values = np.ascontiguousarray([h0, j_perp, p_phi], dtype=np.float64)
+    states = np.zeros((5, max_solutions), dtype=np.float64, order="F")
+    metadata = np.zeros((3, max_solutions), dtype=np.int32, order="F")
+    residuals = np.zeros(max_solutions, dtype=np.float64)
+    cylindrical = np.zeros((3, max_solutions), dtype=np.float64, order="F")
+    n_solutions, status = _simple_main.states_from_invariants_flat(
+        _tracer,
+        values,
+        int(max_solutions),
+        states,
+        metadata,
+        residuals,
+        cylindrical,
+    )
+    count = int(n_solutions)
+    kind_names = {
+        SECTION_EXTREMUM_UNKNOWN: "unknown",
+        SECTION_B_MINIMUM: "B_min",
+        SECTION_B_MAXIMUM: "B_max",
+    }
+    kinds = metadata[2, :count].copy()
+    return {
+        "states": np.ascontiguousarray(states[:, :count].T),
+        "cylindrical": np.ascontiguousarray(cylindrical[:, :count].T),
+        "sigma": np.ascontiguousarray(metadata[0, :count]),
+        "section_branch": np.ascontiguousarray(metadata[1, :count]),
+        "section_kind_code": np.ascontiguousarray(kinds),
+        "section_kind": np.asarray(
+            [kind_names.get(int(kind), "unknown") for kind in kinds]
+        ),
+        "residual": np.ascontiguousarray(residuals[:count]),
+        "n_solutions": count,
+        "status": int(status),
+        "ordering": "POTATO R_c (HFS to LFS)",
+    }
+
+
+def states_from_potato_invariants(
+    h0: float,
+    j_perp: float,
+    psi_star: float,
+    *,
+    psi_axis: float,
+    psi_edge: float,
+    v0_ratio: float = 1.0,
+    max_solutions: int = 64,
+) -> dict[str, np.ndarray | int | str]:
+    """Convert raw POTATO invariants and return matching SIMPLE starts.
+
+    ``v0_ratio`` is ``v0_POTATO/v0_SIMPLE``. The default is correct only when
+    both runs use the same reference energy, species mass, and charge state.
+    ``psi_axis`` and ``psi_edge`` are in the same flux units and gauge as the
+    raw POTATO ``psi_star``.
+    """
+    if v0_ratio <= 0.0 or not np.isfinite(v0_ratio):
+        raise ValueError("v0_ratio must be finite and positive")
+    if not np.isfinite([psi_axis, psi_edge]).all():
+        raise ValueError("psi_axis and psi_edge must be finite")
+    if psi_edge == psi_axis:
+        raise ValueError("psi_edge must differ from psi_axis")
+    raw = np.ascontiguousarray([h0, j_perp, psi_star], dtype=np.float64)
+    converted = np.zeros(3, dtype=np.float64)
+    _simple_main.potato_invariants_to_simple_flat(
+        raw, float(psi_axis), float(psi_edge), float(v0_ratio), converted
+    )
+    result = states_from_invariants(
+        float(converted[0]),
+        float(converted[1]),
+        float(converted[2]),
+        max_solutions=max_solutions,
+    )
+    result["simple_invariants"] = converted
+    return result
 
 
 def trace_to_cut(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,7 @@
     cut_detector.f90
     classification.f90
     simple.f90
+    orbit_invariants.f90
     orbit_frequencies.f90
     parse_ants.f90
     profiles.f90

--- a/src/orbit_invariants.f90
+++ b/src/orbit_invariants.f90
@@ -1,0 +1,606 @@
+module orbit_invariants
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+    use field_can_mod, only: evaluate_field => evaluate, integ_to_ref
+    use parmot_mod, only: rho0 => ro0
+    use simple, only: tracer_t, encode_symplectic_state
+    use util, only: twopi
+    use velo_mod, only: isw_field_type
+    use magfie_sub, only: TEST
+
+    implicit none
+    private
+
+    integer, parameter, public :: INVARIANT_SUCCESS = 0
+    integer, parameter, public :: INVARIANT_INVALID_INPUT = 1
+    integer, parameter, public :: INVARIANT_NOT_AXISYMMETRIC = 2
+    integer, parameter, public :: INVARIANT_NO_INTERSECTION = 3
+    integer, parameter, public :: INVARIANT_ROOT_FAILURE = 4
+    integer, parameter, public :: INVARIANT_CAPACITY = 5
+
+    integer, parameter, public :: SECTION_EXTREMUM_UNKNOWN = 0
+    integer, parameter, public :: SECTION_B_MINIMUM = 1
+    integer, parameter, public :: SECTION_B_MAXIMUM = 2
+
+    integer, parameter :: N_THETA_SCAN = 128
+    integer, parameter :: N_RADIAL_SCAN = 257
+    integer, parameter :: MAX_SECTION_BRANCHES = 16
+    integer, parameter :: MAX_ROOT_ITERATIONS = 80
+    real(dp), parameter :: R_MIN = 1.0e-6_dp
+    real(dp), parameter :: UNIT_RADIAL_MAX = 1.0_dp - 1.0e-8_dp
+    real(dp), parameter :: TEST_RADIAL_MAX = 0.5_dp - 1.0e-8_dp
+    real(dp), parameter :: AXISYM_TOL = 1.0e-10_dp
+    real(dp), parameter :: ROOT_TOL = 1.0e-11_dp
+
+    type, public :: guiding_center_invariants_t
+        real(dp) :: h0 = 0.0_dp
+        real(dp) :: j_perp = 0.0_dp
+        real(dp) :: p_phi = 0.0_dp
+    end type guiding_center_invariants_t
+
+    type, public :: invariant_start_t
+        real(dp) :: state(5) = 0.0_dp
+        integer :: sigma = 0
+        integer :: section_branch = 0
+        integer :: section_kind = SECTION_EXTREMUM_UNKNOWN
+        real(dp) :: residual = 0.0_dp
+    end type invariant_start_t
+
+    type, public :: invariant_start_result_t
+        integer :: status = INVARIANT_INVALID_INPUT
+        type(invariant_start_t), allocatable :: starts(:)
+    end type invariant_start_result_t
+
+    public :: invariants_from_state, states_from_invariants
+    public :: potato_to_simple_invariants, invariant_flux_convention
+
+contains
+
+    subroutine invariants_from_state(tracer, state, invariants, status)
+        type(tracer_t), intent(in) :: tracer
+        real(dp), intent(in) :: state(5)
+        type(guiding_center_invariants_t), intent(out) :: invariants
+        integer, intent(out) :: status
+
+        type(tracer_t) :: work
+        real(dp) :: axis_flux, outward_sign, psi_star_native, zsympl(4)
+
+        invariants = guiding_center_invariants_t()
+        status = INVARIANT_INVALID_INPUT
+        if (.not. all(ieee_is_finite(state))) return
+        if (rho0 <= 0.0_dp) return
+        if (state(4) <= 0.0_dp) return
+        if (abs(state(5)) > 1.0_dp) return
+
+        work = tracer
+        if (.not. field_is_axisymmetric(work)) then
+            status = INVARIANT_NOT_AXISYMMETRIC
+            return
+        end if
+        call flux_convention(work, axis_flux, outward_sign)
+        call encode_symplectic_state(work%f, state, zsympl, invariants%h0, &
+            invariants%j_perp, psi_star_native)
+        invariants%p_phi = outward_sign*(psi_star_native - axis_flux)
+        status = INVARIANT_SUCCESS
+    end subroutine invariants_from_state
+
+    pure subroutine potato_to_simple_invariants(potato, psi_axis, psi_edge, &
+            v0_ratio, simple_invariants)
+        !> Convert raw POTATO invariants to SIMPLE's portable convention.
+        !>
+        !> POTATO stores psi*=(c/q)P_phi in the equilibrium flux gauge. SIMPLE's
+        !> public invariant uses an axis-zero, outward-positive flux gauge. v0_ratio
+        !> is v0_POTATO/v0_SIMPLE; it is one when both runs use the same E_ref,
+        !> particle mass, and charge state.
+        type(guiding_center_invariants_t), intent(in) :: potato
+        real(dp), intent(in) :: psi_axis, psi_edge, v0_ratio
+        type(guiding_center_invariants_t), intent(out) :: simple_invariants
+
+        real(dp) :: direction, velocity_scale2
+
+        direction = sign(1.0_dp, psi_edge - psi_axis)
+        velocity_scale2 = v0_ratio**2
+        simple_invariants%h0 = velocity_scale2*potato%h0
+        simple_invariants%j_perp = velocity_scale2*potato%j_perp
+        simple_invariants%p_phi = direction*(potato%p_phi - psi_axis)
+    end subroutine potato_to_simple_invariants
+
+    subroutine invariant_flux_convention(tracer, axis_flux, outward_sign)
+        type(tracer_t), intent(in) :: tracer
+        real(dp), intent(out) :: axis_flux, outward_sign
+
+        call flux_convention(tracer, axis_flux, outward_sign)
+    end subroutine invariant_flux_convention
+
+    subroutine states_from_invariants(tracer, invariants, result)
+        type(tracer_t), intent(in) :: tracer
+        type(guiding_center_invariants_t), intent(in) :: invariants
+        type(invariant_start_result_t), intent(out) :: result
+
+        type(invariant_start_t) :: candidate
+        type(invariant_start_t), allocatable :: buffer(:)
+        real(dp) :: residuals(N_RADIAL_SCAN, MAX_SECTION_BRANCHES)
+        real(dp) :: thetas(N_RADIAL_SCAN, MAX_SECTION_BRANCHES)
+        logical :: valid(N_RADIAL_SCAN, MAX_SECTION_BRANCHES)
+        integer :: kinds(N_RADIAL_SCAN, MAX_SECTION_BRANCHES)
+        real(dp) :: axis_flux, outward_sign, radius, radial_max, step_radius
+        integer :: counts(N_RADIAL_SCAN)
+        integer :: branch, branch_right, i, nfound, sigma, solve_status
+
+        result%status = INVARIANT_INVALID_INPUT
+        if (allocated(result%starts)) deallocate (result%starts)
+        allocate (result%starts(0))
+        if (.not. ieee_is_finite(invariants%h0)) return
+        if (.not. ieee_is_finite(invariants%j_perp)) return
+        if (.not. ieee_is_finite(invariants%p_phi)) return
+        if (rho0 <= 0.0_dp) return
+        if (invariants%h0 <= 0.0_dp) return
+        if (invariants%j_perp < 0.0_dp) return
+        if (.not. field_is_axisymmetric(tracer)) then
+            result%status = INVARIANT_NOT_AXISYMMETRIC
+            return
+        end if
+        call flux_convention(tracer, axis_flux, outward_sign)
+
+        residuals = 0.0_dp
+        thetas = 0.0_dp
+        valid = .false.
+        kinds = SECTION_EXTREMUM_UNKNOWN
+        counts = 0
+        radial_max = radial_upper_bound()
+        step_radius = (radial_max - R_MIN)/real(N_RADIAL_SCAN - 1, dp)
+
+        do i = 1, N_RADIAL_SCAN
+            radius = R_MIN + real(i - 1, dp)*step_radius
+            call section_geometry_at_radius(tracer, radius, thetas(i, :), &
+                kinds(i, :), counts(i))
+        end do
+
+        allocate (buffer(2*MAX_SECTION_BRANCHES*N_RADIAL_SCAN))
+        nfound = 0
+        do sigma = -1, 1, 2
+            do i = 1, N_RADIAL_SCAN
+                radius = R_MIN + real(i - 1, dp)*step_radius
+                call section_residuals_at_radius(tracer, invariants, axis_flux, &
+                    outward_sign, radius, sigma, thetas(i, :), counts(i), &
+                    residuals(i, :), valid(i, :))
+            end do
+
+            do i = 1, N_RADIAL_SCAN - 1
+                do branch = 1, counts(i)
+                    if (.not. valid(i, branch)) cycle
+                    branch_right = matching_branch(thetas(i, branch), &
+                        kinds(i, branch), thetas(i + 1, :), kinds(i + 1, :), &
+                        valid(i + 1, :), counts(i + 1))
+                    if (branch_right == 0) cycle
+                    if (residuals(i, branch)*residuals(i + 1, branch_right) > &
+                        0.0_dp) cycle
+
+                    call refine_invariant_root(tracer, invariants, axis_flux, &
+                        outward_sign, sigma, branch, &
+                        R_MIN + real(i - 1, dp)*step_radius, &
+                        R_MIN + real(i, dp)*step_radius, thetas(i, branch), &
+                        thetas(i + 1, branch_right), candidate, solve_status)
+                    if (solve_status /= INVARIANT_SUCCESS) cycle
+                    if (is_duplicate(buffer, nfound, candidate)) cycle
+                    nfound = nfound + 1
+                    buffer(nfound) = candidate
+                end do
+            end do
+        end do
+
+        deallocate (result%starts)
+        allocate (result%starts(nfound))
+        if (nfound > 0) result%starts = buffer(1:nfound)
+        if (nfound > 0) then
+            result%status = INVARIANT_SUCCESS
+        else
+            result%status = INVARIANT_NO_INTERSECTION
+        end if
+    end subroutine states_from_invariants
+
+    logical function field_is_axisymmetric(tracer)
+        type(tracer_t), intent(in) :: tracer
+
+        real(dp), parameter :: RADII(3) = [0.19_dp, 0.51_dp, 0.83_dp]
+        real(dp), parameter :: THETAS(3) = [0.17_dp, 1.31_dp, 4.73_dp]
+        real(dp), parameter :: PHI_TEST = 0.731_dp
+        type(tracer_t) :: left, right
+        real(dp) :: scale
+        integer :: i
+
+        field_is_axisymmetric = .false.
+        do i = 1, size(RADII)
+            left = tracer
+            right = tracer
+            call evaluate_field(left%f, RADII(i)*radial_upper_bound(), &
+                THETAS(i), 0.0_dp, 0)
+            call evaluate_field(right%f, RADII(i)*radial_upper_bound(), &
+                THETAS(i), PHI_TEST, 0)
+            scale = max(1.0_dp, abs(left%f%Bmod), abs(right%f%Bmod))
+            if (abs(left%f%Bmod - right%f%Bmod) > AXISYM_TOL*scale) return
+            if (abs(left%f%dBmod(3)) > AXISYM_TOL*scale) return
+            if (abs(right%f%dBmod(3)) > AXISYM_TOL*scale) return
+            scale = max(1.0_dp, abs(left%f%Aph), abs(right%f%Aph))
+            if (abs(left%f%Aph - right%f%Aph) > AXISYM_TOL*scale) return
+            if (abs(left%f%dAph(3)) > AXISYM_TOL*scale) return
+            if (abs(right%f%dAph(3)) > AXISYM_TOL*scale) return
+            scale = max(1.0_dp, abs(left%f%hph), abs(right%f%hph))
+            if (abs(left%f%hph - right%f%hph) > AXISYM_TOL*scale) return
+            if (abs(left%f%dhph(3)) > AXISYM_TOL*scale) return
+            if (abs(right%f%dhph(3)) > AXISYM_TOL*scale) return
+        end do
+        field_is_axisymmetric = .true.
+    end function field_is_axisymmetric
+
+    subroutine section_geometry_at_radius(tracer, radius, thetas, kinds, count)
+        type(tracer_t), intent(in) :: tracer
+        real(dp), intent(in) :: radius
+        real(dp), intent(out) :: thetas(MAX_SECTION_BRANCHES)
+        integer, intent(out) :: kinds(MAX_SECTION_BRANCHES)
+        integer, intent(out) :: count
+
+        integer :: branch
+
+        call find_section_extrema(tracer, radius, thetas, count)
+        kinds = SECTION_EXTREMUM_UNKNOWN
+        do branch = 1, count
+            kinds(branch) = extremum_kind(tracer, radius, thetas(branch))
+        end do
+    end subroutine section_geometry_at_radius
+
+    subroutine section_residuals_at_radius(tracer, invariants, axis_flux, &
+            outward_sign, radius, sigma, &
+            thetas, count, residuals, valid)
+        type(tracer_t), intent(in) :: tracer
+        type(guiding_center_invariants_t), intent(in) :: invariants
+        real(dp), intent(in) :: axis_flux, outward_sign, radius
+        integer, intent(in) :: sigma
+        real(dp), intent(in) :: thetas(MAX_SECTION_BRANCHES)
+        integer, intent(in) :: count
+        real(dp), intent(out) :: residuals(MAX_SECTION_BRANCHES)
+        logical, intent(out) :: valid(MAX_SECTION_BRANCHES)
+
+        type(tracer_t) :: work
+        real(dp) :: lambda2
+        integer :: branch
+
+        residuals = 0.0_dp
+        valid = .false.
+        do branch = 1, count
+            work = tracer
+            call evaluate_field(work%f, radius, thetas(branch), 0.0_dp, 0)
+            if (work%f%Bmod <= 0.0_dp) cycle
+            lambda2 = 1.0_dp - invariants%j_perp*work%f%Bmod/invariants%h0
+            if (lambda2 < 0.0_dp) cycle
+            residuals(branch) = outward_sign*(work%f%Aph - axis_flux + &
+                rho0*sqrt(invariants%h0)*real(sigma, dp)* &
+                sqrt(max(0.0_dp, lambda2))*work%f%hph) - invariants%p_phi
+            valid(branch) = .true.
+        end do
+    end subroutine section_residuals_at_radius
+
+    integer function matching_branch(theta, kind, candidates, candidate_kinds, &
+            candidate_valid, count)
+        real(dp), intent(in) :: theta
+        integer, intent(in) :: kind, count
+        real(dp), intent(in) :: candidates(MAX_SECTION_BRANCHES)
+        integer, intent(in) :: candidate_kinds(MAX_SECTION_BRANCHES)
+        logical, intent(in) :: candidate_valid(MAX_SECTION_BRANCHES)
+
+        real(dp) :: distance, best_distance
+        integer :: i
+
+        matching_branch = 0
+        best_distance = huge(1.0_dp)
+        do i = 1, count
+            if (.not. candidate_valid(i)) cycle
+            if (candidate_kinds(i) /= kind) cycle
+            distance = angular_distance(candidates(i), theta)
+            if (distance >= best_distance) cycle
+            matching_branch = i
+            best_distance = distance
+        end do
+    end function matching_branch
+
+    subroutine find_section_extrema(tracer, radius, roots, count)
+        type(tracer_t), intent(in) :: tracer
+        real(dp), intent(in) :: radius
+        real(dp), intent(out) :: roots(MAX_SECTION_BRANCHES)
+        integer, intent(out) :: count
+
+        real(dp) :: dtheta, left, right, fleft, fright, root
+        integer :: i
+
+        roots = 0.0_dp
+        count = 0
+        dtheta = twopi/real(N_THETA_SCAN, dp)
+        left = 0.5_dp*dtheta
+        fleft = theta_derivative(tracer, radius, left)
+        do i = 0, N_THETA_SCAN - 1
+            left = (real(i, dp) + 0.5_dp)*dtheta
+            right = left + dtheta
+            fright = theta_derivative(tracer, radius, right)
+            if (fleft*fright <= 0.0_dp) then
+                call bisect_theta_extremum(tracer, radius, left, right, root)
+                root = modulo(root, twopi)
+                if (.not. root_is_duplicate(roots, count, root)) then
+                    if (count == MAX_SECTION_BRANCHES) exit
+                    count = count + 1
+                    roots(count) = root
+                end if
+            end if
+            fleft = fright
+        end do
+        call sort_roots(roots, count)
+    end subroutine find_section_extrema
+
+    subroutine bisect_theta_extremum(tracer, radius, left_in, right_in, root)
+        type(tracer_t), intent(in) :: tracer
+        real(dp), intent(in) :: radius, left_in, right_in
+        real(dp), intent(out) :: root
+
+        real(dp) :: left, right, middle, fleft, fmiddle
+        integer :: iteration
+
+        left = left_in
+        right = right_in
+        fleft = theta_derivative(tracer, radius, left)
+        do iteration = 1, MAX_ROOT_ITERATIONS
+            middle = 0.5_dp*(left + right)
+            fmiddle = theta_derivative(tracer, radius, middle)
+            if (abs(fmiddle) <= ROOT_TOL) exit
+            if (right - left <= ROOT_TOL) exit
+            if (fleft*fmiddle <= 0.0_dp) then
+                right = middle
+            else
+                left = middle
+                fleft = fmiddle
+            end if
+        end do
+        root = 0.5_dp*(left + right)
+    end subroutine bisect_theta_extremum
+
+    real(dp) function theta_derivative(tracer, radius, theta)
+        type(tracer_t), intent(in) :: tracer
+        real(dp), intent(in) :: radius, theta
+
+        type(tracer_t) :: work
+
+        work = tracer
+        call evaluate_field(work%f, radius, theta, 0.0_dp, 0)
+        theta_derivative = work%f%dBmod(2)
+    end function theta_derivative
+
+    subroutine refine_invariant_root(tracer, invariants, axis_flux, outward_sign, &
+            sigma, branch, &
+            left_in, right_in, theta_left_in, &
+            theta_right_in, solution, status)
+        type(tracer_t), intent(in) :: tracer
+        type(guiding_center_invariants_t), intent(in) :: invariants
+        real(dp), intent(in) :: axis_flux, outward_sign
+        integer, intent(in) :: sigma, branch
+        real(dp), intent(in) :: left_in, right_in, theta_left_in, theta_right_in
+        type(invariant_start_t), intent(out) :: solution
+        integer, intent(out) :: status
+
+        real(dp) :: left, right, middle, fleft, fmiddle
+        real(dp) :: theta_left, theta_right, theta_middle, theta_guess
+        real(dp) :: z_integ(5), z_ref(3)
+        integer :: iteration, kind
+        logical :: ok
+
+        solution = invariant_start_t()
+        status = INVARIANT_ROOT_FAILURE
+        left = left_in
+        right = right_in
+        theta_left = theta_left_in
+        theta_right = theta_right_in
+        theta_guess = theta_left
+        call residual_near_theta(tracer, invariants, axis_flux, outward_sign, &
+            left, theta_guess, sigma, fleft, theta_left, kind, ok)
+        if (.not. ok) return
+
+        do iteration = 1, MAX_ROOT_ITERATIONS
+            middle = 0.5_dp*(left + right)
+            theta_middle = angular_midpoint(theta_left, theta_right)
+            theta_guess = theta_middle
+            call residual_near_theta(tracer, invariants, axis_flux, outward_sign, &
+                middle, theta_guess, sigma, fmiddle, theta_middle, kind, ok)
+            if (.not. ok) return
+            if (abs(fmiddle) <= ROOT_TOL*max(1.0_dp, abs(invariants%p_phi))) exit
+            if (right - left <= ROOT_TOL) exit
+            if (fleft*fmiddle <= 0.0_dp) then
+                right = middle
+                theta_right = theta_middle
+            else
+                left = middle
+                theta_left = theta_middle
+                fleft = fmiddle
+            end if
+        end do
+
+        z_integ(1:3) = [middle, theta_middle, 0.0_dp]
+        z_integ(4) = sqrt(invariants%h0)
+        call pitch_at_position(tracer, invariants, z_integ(1:3), sigma, &
+            z_integ(5), ok)
+        if (.not. ok) return
+        call integ_to_ref(z_integ(1:3), z_ref)
+        solution%state(1:3) = z_ref
+        solution%state(4:5) = z_integ(4:5)
+        solution%sigma = sigma
+        solution%section_branch = branch
+        solution%section_kind = kind
+        solution%residual = fmiddle
+        status = INVARIANT_SUCCESS
+    end subroutine refine_invariant_root
+
+    subroutine residual_near_theta(tracer, invariants, axis_flux, outward_sign, &
+            radius, theta_guess, sigma, &
+            residual, theta, kind, ok)
+        type(tracer_t), intent(in) :: tracer
+        type(guiding_center_invariants_t), intent(in) :: invariants
+        real(dp), intent(in) :: axis_flux, outward_sign, radius, theta_guess
+        integer, intent(in) :: sigma
+        real(dp), intent(out) :: residual, theta
+        integer, intent(out) :: kind
+        logical, intent(out) :: ok
+
+        type(tracer_t) :: work
+        real(dp) :: roots(MAX_SECTION_BRANCHES), distance, best_distance
+        real(dp) :: lambda2
+        integer :: count, i, best
+
+        residual = 0.0_dp
+        theta = 0.0_dp
+        kind = SECTION_EXTREMUM_UNKNOWN
+        ok = .false.
+        call find_section_extrema(tracer, radius, roots, count)
+        if (count == 0) return
+        best = 1
+        best_distance = angular_distance(roots(1), theta_guess)
+        do i = 2, count
+            distance = angular_distance(roots(i), theta_guess)
+            if (distance < best_distance) then
+                best = i
+                best_distance = distance
+            end if
+        end do
+        theta = roots(best)
+        work = tracer
+        call evaluate_field(work%f, radius, theta, 0.0_dp, 0)
+        lambda2 = 1.0_dp - invariants%j_perp*work%f%Bmod/invariants%h0
+        if (lambda2 < 0.0_dp) return
+        residual = outward_sign*(work%f%Aph - axis_flux + &
+            rho0*sqrt(invariants%h0)*real(sigma, dp)*sqrt(lambda2)*work%f%hph) - &
+            invariants%p_phi
+        kind = extremum_kind(tracer, radius, theta)
+        ok = .true.
+    end subroutine residual_near_theta
+
+    integer function extremum_kind(tracer, radius, theta)
+        type(tracer_t), intent(in) :: tracer
+        real(dp), intent(in) :: radius, theta
+
+        real(dp), parameter :: ANGLE_STEP = 1.0e-5_dp
+        real(dp) :: slope
+
+        slope = theta_derivative(tracer, radius, theta + ANGLE_STEP) - &
+            theta_derivative(tracer, radius, theta - ANGLE_STEP)
+        extremum_kind = SECTION_EXTREMUM_UNKNOWN
+        if (slope > 0.0_dp) extremum_kind = SECTION_B_MINIMUM
+        if (slope < 0.0_dp) extremum_kind = SECTION_B_MAXIMUM
+    end function extremum_kind
+
+    subroutine pitch_at_position(tracer, invariants, position, sigma, pitch, ok)
+        type(tracer_t), intent(in) :: tracer
+        type(guiding_center_invariants_t), intent(in) :: invariants
+        real(dp), intent(in) :: position(3)
+        integer, intent(in) :: sigma
+        real(dp), intent(out) :: pitch
+        logical, intent(out) :: ok
+
+        type(tracer_t) :: work
+        real(dp) :: lambda2
+
+        work = tracer
+        call evaluate_field(work%f, position(1), position(2), position(3), 0)
+        lambda2 = 1.0_dp - invariants%j_perp*work%f%Bmod/invariants%h0
+        ok = lambda2 >= 0.0_dp
+        if (ok) then
+            pitch = real(sigma, dp)*sqrt(max(0.0_dp, lambda2))
+        else
+            pitch = 0.0_dp
+        end if
+    end subroutine pitch_at_position
+
+    subroutine flux_convention(tracer, axis_flux, outward_sign)
+        type(tracer_t), intent(in) :: tracer
+        real(dp), intent(out) :: axis_flux, outward_sign
+
+        type(tracer_t) :: axis_field, edge_field
+        real(dp) :: delta_flux
+
+        axis_field = tracer
+        edge_field = tracer
+        call evaluate_field(axis_field%f, R_MIN, 0.0_dp, 0.0_dp, 0)
+        call evaluate_field(edge_field%f, radial_upper_bound(), 0.0_dp, 0.0_dp, 0)
+        axis_flux = axis_field%f%Aph
+        delta_flux = edge_field%f%Aph - axis_flux
+        outward_sign = sign(1.0_dp, delta_flux)
+    end subroutine flux_convention
+
+    pure real(dp) function radial_upper_bound()
+        if (isw_field_type == TEST) then
+            radial_upper_bound = TEST_RADIAL_MAX
+        else
+            radial_upper_bound = UNIT_RADIAL_MAX
+        end if
+    end function radial_upper_bound
+
+    logical function root_is_duplicate(roots, count, root)
+        real(dp), intent(in) :: roots(MAX_SECTION_BRANCHES), root
+        integer, intent(in) :: count
+
+        integer :: i
+
+        root_is_duplicate = .false.
+        do i = 1, count
+            if (angular_distance(roots(i), root) < 1.0e-8_dp) then
+                root_is_duplicate = .true.
+                return
+            end if
+        end do
+    end function root_is_duplicate
+
+    logical function is_duplicate(buffer, count, candidate)
+        type(invariant_start_t), intent(in) :: buffer(:), candidate
+        integer, intent(in) :: count
+
+        integer :: i
+
+        is_duplicate = .false.
+        do i = 1, count
+            if (buffer(i)%sigma /= candidate%sigma) cycle
+            if (abs(buffer(i)%state(1) - candidate%state(1)) > 1.0e-7_dp) cycle
+            if (angular_distance(buffer(i)%state(2), candidate%state(2)) > &
+                1.0e-7_dp) cycle
+            is_duplicate = .true.
+            return
+        end do
+    end function is_duplicate
+
+    subroutine sort_roots(roots, count)
+        real(dp), intent(inout) :: roots(MAX_SECTION_BRANCHES)
+        integer, intent(in) :: count
+
+        real(dp) :: value
+        integer :: i, j
+
+        do i = 2, count
+            value = roots(i)
+            j = i - 1
+            do while (j >= 1)
+                if (roots(j) <= value) exit
+                roots(j + 1) = roots(j)
+                j = j - 1
+            end do
+            roots(j + 1) = value
+        end do
+    end subroutine sort_roots
+
+    pure real(dp) function angular_distance(left, right)
+        real(dp), intent(in) :: left, right
+
+        angular_distance = abs(modulo(left - right + 0.5_dp*twopi, twopi) - &
+            0.5_dp*twopi)
+    end function angular_distance
+
+    pure real(dp) function angular_midpoint(left, right)
+        real(dp), intent(in) :: left, right
+
+        angular_midpoint = modulo(left + 0.5_dp* &
+            (modulo(right - left + 0.5_dp*twopi, twopi) - 0.5_dp*twopi), twopi)
+    end function angular_midpoint
+
+end module orbit_invariants

--- a/src/simple.f90
+++ b/src/simple.f90
@@ -45,7 +45,35 @@ public
       module procedure timestep_sympl_z
    end interface tstep
 
+  public :: encode_symplectic_state
+
 contains
+
+  subroutine encode_symplectic_state(f, z0, zsympl, h0, jperp, psi_star)
+    !> Convert the public GC state to the normalization used by the symplectic
+    !> Hamiltonian. This is the single source of truth used by initialization,
+    !> reseeding, and the invariant API.
+    type(field_can_t), intent(inout) :: f
+    real(dp), intent(in) :: z0(:)
+    real(dp), intent(out) :: zsympl(4)
+    real(dp), intent(out), optional :: h0, jperp, psi_star
+
+    real(dp) :: jperp_local, psi_star_local
+
+    call eval_field(f, z0(1), z0(2), z0(3), 0)
+    jperp_local = z0(4)**2*(1.0_dp - z0(5)**2)/f%Bmod
+    psi_star_local = f%Aph + ro0*z0(4)*z0(5)*f%hph
+
+    f%mu = jperp_local
+    f%ro0 = ro0/sqrt(2.0_dp)
+    f%vpar = z0(4)*z0(5)*sqrt(2.0_dp)
+    zsympl(1:3) = z0(1:3)
+    zsympl(4) = f%vpar*f%hph + f%Aph/f%ro0
+
+    if (present(h0)) h0 = z0(4)**2
+    if (present(jperp)) jperp = jperp_local
+    if (present(psi_star)) psi_star = psi_star_local
+  end subroutine encode_symplectic_state
 
 
   subroutine init_vmec(vmec_file, ans_s, ans_tp, amultharm, fper)
@@ -137,16 +165,8 @@ contains
     endif
 
     ! Initialize symplectic integrator
-    call eval_field(f, z0(1), z0(2), z0(3), 0)
-
     si%pabs = z0(4)
-
-    f%mu = .5d0*z0(4)**2*(1.d0-z0(5)**2)/f%Bmod*2d0 ! mu by factor 2 from other modules
-    f%ro0 = ro0/dsqrt(2d0) ! ro0 = mc/e*v0, different by sqrt(2) from other modules
-    f%vpar = z0(4)*z0(5)*dsqrt(2d0) ! vpar_bar = vpar/sqrt(T/m), different by sqrt(2) from other modules
-
-    z(1:3) = z0(1:3)  ! s, th, ph
-    z(4) = f%vpar*f%hph + f%Aph/f%ro0 ! pphi
+    call encode_symplectic_state(f, z0, z)
 
     ! factor 1/sqrt(2) due to velocity normalisation different from other modules
     call orbit_sympl_init(si, f, z, dtaumin/dsqrt(2d0), nint(dtau/dtaumin), &
@@ -164,13 +184,8 @@ contains
     type(field_can_t), intent(inout) :: f
     real(dp), intent(in) :: z0(:)
 
-    call eval_field(f, z0(1), z0(2), z0(3), 0)
     si%pabs = z0(4)
-    f%mu = z0(4)**2*(1.d0 - z0(5)**2)/f%Bmod
-    f%ro0 = ro0/dsqrt(2.d0)
-    f%vpar = z0(4)*z0(5)*dsqrt(2.d0)
-    si%z(1:3) = z0(1:3)
-    si%z(4) = f%vpar*f%hph + f%Aph/f%ro0
+    call encode_symplectic_state(f, z0, si%z)
     call get_val(f, si%z(4))
     si%pthold = f%pth
     si%last_step_fraction = 1.d0

--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -1007,6 +1007,121 @@ contains
         metadata(5) = result%n_steps
     end subroutine compute_canonical_frequencies_flat
 
+    subroutine invariants_from_state_flat(anorb, initial_state, values, status)
+        use orbit_invariants, only: guiding_center_invariants_t, &
+            invariants_from_state, invariant_flux_convention
+
+        type(tracer_t), intent(in) :: anorb
+        real(dp), intent(in) :: initial_state(5)
+        real(dp), intent(out) :: values(5)
+        integer, intent(out) :: status
+
+        type(guiding_center_invariants_t) :: invariants
+        real(dp) :: state(5)
+
+        call ref_to_integ(initial_state(1:3), state(1:3))
+        state(4:5) = initial_state(4:5)
+        call invariants_from_state(anorb, state, invariants, status)
+        values(1:3) = [invariants%h0, invariants%j_perp, invariants%p_phi]
+        call invariant_flux_convention(anorb, values(4), values(5))
+    end subroutine invariants_from_state_flat
+
+    subroutine potato_invariants_to_simple_flat(potato_values, psi_axis, &
+            psi_edge, v0_ratio, simple_values)
+        use orbit_invariants, only: guiding_center_invariants_t, &
+            potato_to_simple_invariants
+
+        real(dp), intent(in) :: potato_values(3)
+        real(dp), intent(in) :: psi_axis, psi_edge, v0_ratio
+        real(dp), intent(out) :: simple_values(3)
+
+        type(guiding_center_invariants_t) :: potato, converted
+
+        potato%h0 = potato_values(1)
+        potato%j_perp = potato_values(2)
+        potato%p_phi = potato_values(3)
+        call potato_to_simple_invariants(potato, psi_axis, psi_edge, v0_ratio, &
+                                         converted)
+        simple_values = [converted%h0, converted%j_perp, converted%p_phi]
+    end subroutine potato_invariants_to_simple_flat
+
+    subroutine states_from_invariants_flat(anorb, values, max_solutions, &
+            states, metadata, residuals, cylindrical, n_solutions, status)
+        use orbit_invariants, only: guiding_center_invariants_t, &
+            invariant_start_result_t, states_from_invariants, &
+            INVARIANT_CAPACITY
+
+        type(tracer_t), intent(in) :: anorb
+        real(dp), intent(in) :: values(3)
+        integer, intent(in) :: max_solutions
+        real(dp), intent(out) :: states(5, max_solutions)
+        integer, intent(out) :: metadata(3, max_solutions)
+        real(dp), intent(out) :: residuals(max_solutions)
+        real(dp), intent(out) :: cylindrical(3, max_solutions)
+        integer, intent(out) :: n_solutions, status
+
+        type(guiding_center_invariants_t) :: invariants
+        type(invariant_start_result_t) :: result
+        integer :: i
+
+        states = 0.0_dp
+        metadata = 0
+        residuals = 0.0_dp
+        cylindrical = 0.0_dp
+        n_solutions = 0
+        invariants%h0 = values(1)
+        invariants%j_perp = values(2)
+        invariants%p_phi = values(3)
+        call states_from_invariants(anorb, invariants, result)
+        status = result%status
+        n_solutions = min(size(result%starts), max_solutions)
+        do i = 1, n_solutions
+            states(:, i) = result%starts(i)%state
+            metadata(:, i) = [result%starts(i)%sigma, &
+                result%starts(i)%section_branch, result%starts(i)%section_kind]
+            residuals(i) = result%starts(i)%residual
+            if (allocated(ref_coords)) then
+                call ref_coords%evaluate_cyl(states(1:3, i), cylindrical(:, i))
+            end if
+        end do
+        call sort_invariant_starts(states, metadata, residuals, cylindrical, &
+                                   n_solutions)
+        if (size(result%starts) > max_solutions) status = INVARIANT_CAPACITY
+    end subroutine states_from_invariants_flat
+
+    subroutine sort_invariant_starts(states, metadata, residuals, cylindrical, &
+                                     count)
+        real(dp), intent(inout) :: states(:, :), residuals(:), cylindrical(:, :)
+        integer, intent(inout) :: metadata(:, :)
+        integer, intent(in) :: count
+
+        real(dp) :: state_tmp(size(states, 1)), residual_tmp
+        real(dp) :: cylindrical_tmp(size(cylindrical, 1))
+        integer :: metadata_tmp(size(metadata, 1))
+        integer :: i, j
+
+        if (.not. allocated(ref_coords)) return
+        do i = 2, count
+            state_tmp = states(:, i)
+            metadata_tmp = metadata(:, i)
+            residual_tmp = residuals(i)
+            cylindrical_tmp = cylindrical(:, i)
+            j = i - 1
+            do while (j >= 1)
+                if (cylindrical(1, j) <= cylindrical_tmp(1)) exit
+                states(:, j + 1) = states(:, j)
+                metadata(:, j + 1) = metadata(:, j)
+                residuals(j + 1) = residuals(j)
+                cylindrical(:, j + 1) = cylindrical(:, j)
+                j = j - 1
+            end do
+            states(:, j + 1) = state_tmp
+            metadata(:, j + 1) = metadata_tmp
+            residuals(j + 1) = residual_tmp
+            cylindrical(:, j + 1) = cylindrical_tmp
+        end do
+    end subroutine sort_invariant_starts
+
     subroutine trace_to_cut_flat(anorb, initial_state, requested_cut_type, &
             max_events, cut_state, cut_type, status)
         use cut_detector, only: cut_detector_t, init_cut_detector => init, &

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -69,6 +69,12 @@ add_simple_api_test(trace_to_tip
     TestTraceOrbits::test_trace_to_tip)
 add_simple_api_test(trace_to_cut_validation
     TestTraceOrbits::test_trace_to_cut_validation)
+add_simple_api_test(invariant_initial_conditions
+    TestTraceOrbits::test_invariant_initial_conditions)
+add_simple_api_test(potato_invariant_normalization
+    TestTraceOrbits::test_potato_invariant_normalization)
+add_simple_api_test(invariant_validation
+    TestTraceOrbits::test_invariant_validation)
 add_simple_api_test(trace_skipped TestTraceOrbits::test_trace_parallel_preserves_skipped_passing_sentinel)
 add_simple_api_test(trace_early_loss TestTraceOrbits::test_trace_orbit_uses_backend_loss_time_for_early_loss)
 

--- a/test/python/test_simple_api.py
+++ b/test/python/test_simple_api.py
@@ -309,6 +309,78 @@ class TestTraceOrbits:
         with pytest.raises(ValueError, match="symplectic"):
             pysimple.trace_to_cut(particle, integrator="rk45")
 
+    def test_invariant_initial_conditions(self, vmec_file: str):
+        pysimple.init(
+            vmec_file,
+            deterministic=True,
+            ntestpart=1,
+            isw_field_type=-1,
+        )
+        particle = np.array([0.2, 0.7, 0.2, 0.8, 0.6])
+        invariant = pysimple.invariants_from_state(particle)
+
+        assert invariant["status"] == pysimple.INVARIANT_SUCCESS
+        assert invariant["h0"] == pytest.approx(particle[3] ** 2)
+        assert invariant["psi_star"] == invariant["p_phi"]
+        assert invariant["time_convention"] == "tau=v0*t"
+
+        starts = pysimple.states_from_invariants(
+            invariant["h0"], invariant["j_perp"], invariant["p_phi"]
+        )
+        assert starts["status"] == pysimple.INVARIANT_SUCCESS
+        assert starts["n_solutions"] >= 1
+        assert starts["states"].shape == (starts["n_solutions"], 5)
+        assert set(starts["sigma"]).issubset({-1, 1})
+
+        for state in starts["states"]:
+            reconstructed = pysimple.invariants_from_state(state)
+            assert reconstructed["h0"] == pytest.approx(invariant["h0"])
+            assert reconstructed["j_perp"] == pytest.approx(
+                invariant["j_perp"], rel=1e-10
+            )
+            assert reconstructed["p_phi"] == pytest.approx(
+                invariant["p_phi"], rel=1e-9, abs=1e-9
+            )
+
+    def test_potato_invariant_normalization(self, vmec_file: str):
+        pysimple.init(
+            vmec_file,
+            deterministic=True,
+            ntestpart=1,
+            isw_field_type=-1,
+        )
+        result = pysimple.states_from_potato_invariants(
+            1.0,
+            2.0,
+            12.0,
+            psi_axis=10.0,
+            psi_edge=20.0,
+            v0_ratio=0.5,
+        )
+        np.testing.assert_allclose(result["simple_invariants"], [0.25, 0.5, 2.0])
+
+        reversed_flux = pysimple.states_from_potato_invariants(
+            1.0,
+            2.0,
+            8.0,
+            psi_axis=10.0,
+            psi_edge=0.0,
+        )
+        np.testing.assert_allclose(
+            reversed_flux["simple_invariants"], [1.0, 2.0, 2.0]
+        )
+
+    def test_invariant_validation(self, vmec_file: str):
+        pysimple.init(vmec_file, deterministic=True, ntestpart=1)
+        with pytest.raises(ValueError, match="shape"):
+            pysimple.invariants_from_state(np.zeros(4))
+        with pytest.raises(ValueError, match="h0"):
+            pysimple.states_from_invariants(0.0, 0.0, 0.0)
+        with pytest.raises(ValueError, match="v0_ratio"):
+            pysimple.states_from_potato_invariants(
+                1.0, 1.0, 1.0, psi_axis=0.0, psi_edge=1.0, v0_ratio=0.0
+            )
+
     def test_trace_parallel_preserves_skipped_passing_sentinel(self, vmec_file: str):
         """Deep-passing particles skipped by contr_pp must keep loss_time = -1."""
         pysimple.init(vmec_file, deterministic=True, trace_time=1e-4, ntestpart=1)

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -450,6 +450,11 @@ set_tests_properties(test_bminmax_lifecycle PROPERTIES
     LABELS "unit"
     TIMEOUT 15)
 
+add_executable(test_orbit_invariants.x test_orbit_invariants.f90)
+target_link_libraries(test_orbit_invariants.x simple)
+add_test(NAME test_orbit_invariants COMMAND test_orbit_invariants.x)
+set_tests_properties(test_orbit_invariants PROPERTIES LABELS "unit")
+
 if(SIMPLE_ENABLE_PYTHON_TOOLS)
     add_test(NAME test_bminmax_python
         COMMAND ${Python3_EXECUTABLE}

--- a/test/tests/test_orbit_invariants.f90
+++ b/test/tests/test_orbit_invariants.f90
@@ -1,0 +1,105 @@
+program test_orbit_invariants
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use field_can_mod, only: evaluate_field => evaluate
+    use magfie_sub, only: TEST
+    use orbit_invariants, only: guiding_center_invariants_t, &
+        invariant_start_result_t, invariants_from_state, states_from_invariants, &
+        potato_to_simple_invariants, invariant_flux_convention, INVARIANT_SUCCESS
+    use orbit_symplectic_base, only: symplectic_integrator_t
+    use params, only: params_init
+    use parmot_mod, only: rho0 => ro0
+    use simple, only: tracer_t, encode_symplectic_state, init_sympl
+    use simple_main, only: init_field
+    use util, only: sqrt2
+    use velo_mod, only: isw_field_type
+
+    implicit none
+
+    type(tracer_t) :: tracer, work
+    type(symplectic_integrator_t) :: symplectic
+    type(guiding_center_invariants_t) :: invariants, reconstructed
+    type(guiding_center_invariants_t) :: potato, converted
+    type(invariant_start_result_t) :: result
+    real(dp) :: state(5), zsympl(4), psi_native
+    real(dp) :: axis_flux, outward_sign
+    integer :: i, status
+
+    isw_field_type = TEST
+    call init_field(tracer, '', 5, 5, 3, 3)
+    call params_init
+    rho0 = 0.02_dp
+
+    state = [0.2_dp, 0.7_dp, 0.2_dp, 0.8_dp, 0.6_dp]
+    call invariants_from_state(tracer, state, invariants, status)
+    call require(status == INVARIANT_SUCCESS, 'forward conversion status')
+
+    work = tracer
+    call evaluate_field(work%f, state(1), state(2), state(3), 0)
+    call invariant_flux_convention(tracer, axis_flux, outward_sign)
+    psi_native = work%f%Aph + rho0*state(4)*state(5)*work%f%hph
+    call require_close(invariants%h0, state(4)**2, 1.0e-13_dp, 'H0')
+    call require_close(invariants%j_perp, &
+        state(4)**2*(1.0_dp - state(5)**2)/work%f%Bmod, 1.0e-13_dp, 'J_perp')
+    call require_close(invariants%p_phi, &
+        outward_sign*(psi_native - axis_flux), 1.0e-13_dp, 'p_phi')
+
+    work = tracer
+    call encode_symplectic_state(work%f, state, zsympl)
+    call require_close(zsympl(4), sqrt2*psi_native/rho0, 1.0e-13_dp, &
+        'private symplectic p_phi normalization')
+
+    work = tracer
+    call init_sympl(symplectic, work%f, state, 0.1_dp, 0.1_dp, 1.0e-10_dp, 3)
+    call require_close(symplectic%z(4), zsympl(4), 1.0e-13_dp, &
+        'shared symplectic encoding')
+    call require_close(symplectic%dt*sqrt2, 0.1_dp, 1.0e-13_dp, &
+        'public tau versus private symplectic time')
+
+    call states_from_invariants(tracer, invariants, result)
+    call require(result%status == INVARIANT_SUCCESS, 'inverse conversion status')
+    call require(size(result%starts) >= 2, 'all cut intersections returned')
+    do i = 1, size(result%starts)
+        call invariants_from_state(tracer, result%starts(i)%state, reconstructed, &
+            status)
+        call require(status == INVARIANT_SUCCESS, 'reconstructed status')
+        call require_close(reconstructed%h0, invariants%h0, 1.0e-11_dp, &
+            'reconstructed H0')
+        call require_close(reconstructed%j_perp, invariants%j_perp, 1.0e-10_dp, &
+            'reconstructed J_perp')
+        call require_close(reconstructed%p_phi, invariants%p_phi, 1.0e-9_dp, &
+            'reconstructed p_phi')
+    end do
+
+    potato = guiding_center_invariants_t(1.0_dp, 2.0_dp, 12.0_dp)
+    call potato_to_simple_invariants(potato, 10.0_dp, 20.0_dp, 0.5_dp, converted)
+    call require_close(converted%h0, 0.25_dp, 1.0e-14_dp, 'POTATO H0 scale')
+    call require_close(converted%j_perp, 0.5_dp, 1.0e-14_dp, &
+        'POTATO J_perp scale')
+    call require_close(converted%p_phi, 2.0_dp, 1.0e-14_dp, &
+        'POTATO outward flux convention')
+    potato%p_phi = 8.0_dp
+    call potato_to_simple_invariants(potato, 10.0_dp, 0.0_dp, 1.0_dp, converted)
+    call require_close(converted%p_phi, 2.0_dp, 1.0e-14_dp, &
+        'POTATO reversed-flux convention')
+
+contains
+
+    subroutine require(condition, message)
+        logical, intent(in) :: condition
+        character(*), intent(in) :: message
+
+        if (.not. condition) then
+            write (*, '(A)') 'FAILED: '//message
+            error stop 1
+        end if
+    end subroutine require
+
+    subroutine require_close(actual, expected, tolerance, message)
+        real(dp), intent(in) :: actual, expected, tolerance
+        character(*), intent(in) :: message
+
+        call require(abs(actual - expected) <= tolerance*max(1.0_dp, abs(expected)), &
+            message)
+    end subroutine require_close
+
+end program test_orbit_invariants


### PR DESCRIPTION
## Risk tier

- [ ] T0: docs, comments, small build metadata
- [ ] T1: pure refactor, no behavior change intended
- [ ] T2: local numerical logic
- [x] T3: physics, output behavior, coordinate convention
- [ ] T4: parallelism, GPU, dependency, CI, or security-sensitive build logic

## Correctness contract

### Intended behavior change

Add an axisymmetric preprocessing API that converts guiding-center invariants `(H0, J_perp, p_phi)` into the existing SIMPLE initial state `[s, theta, phi, p, lambda]`. The inverse returns every regular intersection with `grad(psi) x grad(B) = 0` on both parallel-velocity branches; it does not silently choose an inner or outer orbit class. Python wrappers also accept raw POTATO `psi_star` plus its axis/edge flux gauge.

### Behavior that must not change

The existing initial-state API and orbit hot loop remain unchanged. `init_sympl` and `reseed_sympl` now share one mathematically identical state encoder so their private normalization cannot drift from the new preprocessing API. Existing orbit output, frequency APIs, and golden records are not intentionally changed.

### Coordinate / unit conventions

- `H0 = p**2`, where public `p = |momentum|/(m v0)`.
- `J_perp = p**2 (1-lambda**2)/B` for the current magnetic Hamiltonian.
- Public `p_phi` has magnetic-flux units and is `(c/q) P_phi`, with the magnetic-flux gauge zeroed on axis and oriented positive outward.
- Raw POTATO values convert as `sign(psi_edge-psi_axis) * (psi_star-psi_axis)`.
- If reference velocities differ, `H0` and `J_perp` scale by `(v0_POTATO/v0_SIMPLE)**2`; physical `p_phi` does not.
- Public time remains `tau = v0 t`. The symplectic integrator's private `sqrt(2)` momentum and time scaling is not exposed.
- Results are sorted by cylindrical major radius from HFS to LFS, matching POTATO's `R_c` direction. This ordering is not an inner/outer topology classification.

### Numerical invariants

Forward and inverse conversion preserve `H0`, `J_perp`, and public `p_phi` within the tested root tolerances. The shared symplectic encoder preserves the previous fourth canonical coordinate and `dt/sqrt(2)` convention exactly.

## Tests added

- unit: native forward/inverse round trip, all regular roots, shared symplectic normalization, public time convention, POTATO velocity/gauge conversion in both flux directions
- integration: Python forward/inverse API, POTATO conversion, metadata, validation, and CTest registration
- system: none
- golden record: existing golden records intentionally unchanged

## Golden-record impact

- [x] unchanged
- [ ] changed

If changed, explain the expected sign, magnitude, and physical or numerical reason.

## Failure modes considered

Invalid or non-finite invariants, non-axisymmetric fields, absent regular intersections, output-capacity truncation, reversed equilibrium flux direction, different reference velocities, and the ambiguity of multiple cut points belonging to one physical orbit. Electrostatic potential energy is explicitly outside this first magnetic-Hamiltonian API.

## Manual validation

Reviewed SIMPLE's existing symplectic normalization and POTATO's `psi_star`, section, branch, and time conventions against NEO-RT/POTATO source and the Buchholz et al. potato-orbit construction. Confirmed the public API adds preprocessing only and no per-step language crossing.

## Verification

- clean Release build: 95/97 non-regression tests pass directly; `test_orbit_invariants` (including reversed flux) passes after a final rebuild
- the two direct failures are the pre-existing out-of-tree `../../../examples` assumption in `orbit_netcdf_verify` and `orbit_netcdf_plot`; their producer passed, and both verifiers pass from the intended source-tree-relative working directory
- focused Python CTests: invariant round trip, POTATO normalization (including reversed flux), and validation pass
- existing chart-map initialization, canonical-frequency, tip-cut, orbit-macro, and NetCDF tests pass after rebuilding the editable wrapper
- `git diff --check`
- `fo lint` reports only two pre-existing array-temporary warnings in `get_canonical_coordinates.F90`
- GitHub checks are the final merge gate
