### PR TITLE
Stabilize orbit recovery and boundary reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ compared to earlier versions.
 
 | Differing behavior | commit hash / tag and timestamp | Summary |
 | ---------------- | ------------------------------- | ------- |
+| Y | PR #503 2026-07-22 | In warning mode, recover a failed conventional guiding-centre interval with toroidal regularization and, only at an unresolved polar axis, a Cartesian full-orbit bridge. Preserve the last accepted momentum shell, return to the requested symplectic method after a safe streak, and retain the bounded isolated-warning hold instead of freezing a marker indefinitely. Successful legacy steps are unchanged. |
 | N | v1.5.1 (release/1.5) 2025-12-23 | Use atomic updates when incrementing the confined pass/trap counters so each branch stays thread-safe without enclosing the entire branch in an OpenMP critical region. |
 | N | v1.4.2 (release/1.4) 2025-12-23 | Backport the atomic-update behavior for confined counters so release/1.4 matches v1.5.1’s threading sync. |
 | Y | 6ae316f 2025-12-22 | Deterministic mode: change RNG seed from 0 to 42 |

--- a/DOC/config.md
+++ b/DOC/config.md
@@ -12,24 +12,24 @@
   values to refine event location independently of the nonlinear solve.
 
 * `symplectic_newton_warning_mode` defaults to `.true.`. When an implicit solve
-  reaches its iteration limit, SIMPLE continues only if the final Newton
-  correction is finite and no more than ten times the requested relative
-  tolerance. Each occurrence is reported by the corresponding `*_maxit`
-  diagnostic. The production RK, symplectic, and full-orbit paths then use the
-  same terminal convention: if bounded recovery cannot resolve a numerical
-  microstep, SIMPLE retains any contiguous accepted prefix and holds only the
-  unresolved remainder, records `warning_step_skip`, advances the clock for
-  the complete interval, and retries from that valid state on the next
-  microstep. A warning hold does not terminate or
-  numerically disqualify the marker: a marker that reaches the requested end
-  time remains a resolved survivor, while a later physical boundary event is
-  still a loss. Set the option to `.false.` for strict diagnostic runs that end
-  only the affected marker at the first exhausted recovery and report a
-  101--105 `orbit_exit_code` with `NaN` in `times_lost`.
-  A symplectic failure may use the established adaptive-RK pusher from the last
-  accepted state. That fallback is capped at 10,000 internal steps. If both
-  pushers fail from the same state, warning mode records held intervals for the
-  rest of the trace instead of repeating an identical stalled RK solve.
+  reaches its iteration limit, the generic integrators accept a finite final
+  correction through 100 requested-tolerance units; SPECTRE keeps a 10-unit
+  bound. Midpoint steps that cross the polar-coordinate axis have one additional
+  local rule. If both radial Newton variables remain within `1d-6`, the endpoint
+  radius is negative, and every angular and momentum correction satisfies the
+  usual warning bound, SIMPLE accepts the step and applies the equivalent
+  positive-radius chart switch. This avoids rejecting a physically regular axis
+  passage because its signed radial coordinate is singular. The
+  `warning_axis_crossing_accept` diagnostic counts these steps.
+
+  Other rejected steps use bounded dyadic symplectic retries and then the
+  established adaptive-RK pusher from the last accepted state. The RK fallback
+  is capped at 10,000 internal steps. If both methods fail, warning mode rolls
+  back and consumes one isolated microstep, records `warning_step_skip`, and
+  retries. A successful step resets the allowance; a second consecutive failure
+  is a numerical exit. Set the option to `.false.` for strict diagnostic runs
+  that end the affected marker at the first exhausted recovery. Numerical exits
+  use codes 101--105 and `NaN` in `times_lost`.
 
 * `canonical_grid_nr`, `canonical_grid_ntheta`, and `canonical_grid_nphi`
   control the Meiss or Albert canonical-map grid. Their defaults are 62, 63,

--- a/DOC/config.md
+++ b/DOC/config.md
@@ -31,6 +31,14 @@
   that end the affected marker at the first exhausted recovery. Numerical exits
   use codes 101--105 and `NaN` in `times_lost`.
 
+  A collisionless guiding-centre marker that exhausts every recovery method
+  after the warning hold while its last validated normalized toroidal flux is
+  below `s=0.01` is classified as numerically confined. For chartmap inputs,
+  SIMPLE converts the stored `rho` to `s=rho^2` before applying the gate. It
+  uses exit code 4 and `trace_time` in `times_lost`. This core-only fallback is
+  disabled for collisions, strict mode, full-orbit tracing, SPECTRE, and
+  failures outside the axis-local region.
+
 * `canonical_grid_nr`, `canonical_grid_ntheta`, and `canonical_grid_nphi`
   control the Meiss or Albert canonical-map grid. Their defaults are 62, 63,
   and 64. Each dimension must be between 6 and 512, and their product must not

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CONFIG ?= Release
 FLAGS ?=
 BUILD_DIR := build
-GOLDEN_LIBNEO_REF := e451e0a42f5228d85b0479de40aa35db8b48239d
+GOLDEN_LIBNEO_REF := e2b281b1bc9f9f48f9526622445e0b2c0f8a4984
 
 # Prevent ambient shell env from silently changing which libneo is fetched.
 # Pass the ref explicitly via: make ... LIBNEO_REF=<branch|tag|sha>
@@ -98,10 +98,12 @@ test-all: build
 # Golden record test target
 # Compares current branch against main to enforce strict numerical reproducibility
 # Any differences must be manually reviewed before merging
+test-golden: FLAGS += -DLIBNEO_REF=$(GOLDEN_LIBNEO_REF)
 test-golden: build-deterministic-nopy
 	cd $(BUILD_DIR) && ctest --output-on-failure $(if $(filter 1,$(VERBOSE)),-V) -L "golden_record" $(if $(TEST),-R "$(TEST)")
 
 # Golden record tests without deterministic FP (faster, for local iteration only)
+test-golden-fast: FLAGS += -DLIBNEO_REF=$(GOLDEN_LIBNEO_REF)
 test-golden-fast: build
 	cd $(BUILD_DIR) && ctest --output-on-failure $(if $(filter 1,$(VERBOSE)),-V) -L "golden_record" $(if $(TEST),-R "$(TEST)")
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,12 @@ surface represents. Its values are `auto` (the default), `lcfs`, `wall`, and
 as an LCFS and treats other outer chart surfaces as numerical-domain limits.
 Set `wall` explicitly when the outer chart surface is the physical coordinate
 wall. The requested and effective values are stored in `results.nc`.
+For an external `wall_input` STL, SIMPLE tests every accepted microstep chord
+whose endpoint has passed the chart's recorded LCFS. Chords ending inside the
+LCFS are not queried: in a non-convex toroidal geometry their straight
+Cartesian interpolation can intersect the external wall even though the
+physical orbit has not left the plasma. The effective radial query threshold
+is stored as `wall_query_rho_lcfs` in `results.nc` (`-1` when inactive).
 
 Default warning mode accepts finite generic Newton corrections through 100
 tolerance units after the iteration limit. This covers the observed roundoff

--- a/README.md
+++ b/README.md
@@ -232,7 +232,19 @@ wget https://github.com/hiddenSymmetries/simsopt/raw/master/tests/test_files/wou
 For a self-contained demo that downloads test data, runs SIMPLE, and prints the confined fraction, use `examples/run_example.sh`.
 
 In addition `start.dat` is either an input for given (`startmode>=2`) or an output (`startmode` 0 or 1) for randomly generated initial conditions.
-Diagnostics for slow convergence of Newton iterations are written in `fort.6601`.
+For chartmap coordinates, `chart_boundary_kind` declares what the outer chart
+surface represents. Its values are `auto` (the default), `lcfs`, `wall`, and
+`domain`. `auto` treats a chart whose recorded LCFS is at normalized radius one
+as an LCFS and treats other outer chart surfaces as numerical-domain limits.
+Set `wall` explicitly when the outer chart surface is the physical coordinate
+wall. The requested and effective values are stored in `results.nc`.
+
+Default warning mode accepts finite generic Newton corrections through 100
+tolerance units after the iteration limit. This covers the observed roundoff
+plateau at `relerr=1e-13` while still rejecting large and non-finite iterates.
+SPECTRE interface states retain the stricter 10-unit bound. Aggregate Newton,
+retry, recovery, and rejection counters are stored as `diagnostic_*` global
+attributes in `results.nc`.
 
 ### Output
 `confined_fraction.dat` is the main output, containing four columns:

--- a/README.md
+++ b/README.md
@@ -254,12 +254,37 @@ has converged. SIMPLE accepts that chart change only when both radial values are
 within `1d-6`, the endpoint radius is negative, and the angular and momentum
 corrections satisfy the normal warning bound. It then applies the equivalent
 positive-radius chart switch and records `warning_axis_crossing_accept`.
-If symplectic retries and the adaptive-RK fallback both fail, one isolated
-microstep is rolled back and consumed as a warning hold; the next microstep
-retries normally. A successful step resets the allowance, while a second
-consecutive full failure is a numerical exit instead of a permanent frozen
-orbit. SPECTRE interface states retain the stricter 10-unit bound and their
-established recovery behavior. The hold limit and aggregate Newton, retry,
+After symplectic retries fail, SIMPLE advances the same interval with the
+established adaptive-RK guiding-centre pusher. The conventional equations are
+always tried first. If they encounter the
+`B_parallel_star = B + rho_0 v_parallel b dot curl(b)` singularity, SIMPLE uses
+the leading toroidally regularized equations of
+[Burby and Ellison](https://doi.org/10.1063/1.5004429). The required condition
+is a nonzero contravariant toroidal field component. The near-identity spatial
+map is applied on entry and inverted on exit. If the reference polar chart
+itself becomes unresolved at the magnetic axis, one interval is bridged with
+the Cartesian Boris full-orbit pusher. Its field assembly uses the regular
+co-rotating `(X,Y,phi)` frame; the field-period wedge rotation restores the lab
+frame without an angular seam. These paths use the existing physical field in
+its native reference coordinates; they do not replace the field or reprocess
+the whole device.
+
+For a collisionless marker, every recovery handoff retains the momentum shell
+from the last accepted symplectic state. A collision updates that reference in
+the usual way. Recovery returns to the requested symplectic method after 256
+consecutive conventional-RK intervals with
+`abs(B_parallel_star/B) >= 0.3` and, for an axis or edge recovery, after the
+corresponding chart hysteresis has also been cleared. This prevents repeated
+reseed cycles from promoting a bounded energy oscillation into a new reference
+energy. The measured Hamiltonian remains an output diagnostic; symplectic
+integration is not described as exact energy conservation.
+
+If every recovery path fails, one isolated microstep is rolled back and
+consumed as a warning hold; the next microstep retries normally. A successful
+step resets the allowance, while a second consecutive full failure is a
+numerical exit instead of a permanent frozen orbit. SPECTRE interface states
+retain the stricter 10-unit bound and their established recovery behavior. The
+hold limit and aggregate Newton, retry, toroidal-regularization, axis-full-orbit,
 recovery, and rejection counters are stored in `results.nc`.
 
 ### Output

--- a/README.md
+++ b/README.md
@@ -248,9 +248,13 @@ is stored as `wall_query_rho_lcfs` in `results.nc` (`-1` when inactive).
 Default warning mode accepts finite generic Newton corrections through 100
 tolerance units after the iteration limit. This covers the observed roundoff
 plateau at `relerr=1e-13` while still rejecting large and non-finite iterates.
-SPECTRE interface states retain the stricter 10-unit bound. Aggregate Newton,
-retry, recovery, and rejection counters are stored as `diagnostic_*` global
-attributes in `results.nc`.
+If symplectic retries and the adaptive-RK fallback both fail, one isolated
+microstep is rolled back and consumed as a warning hold; the next microstep
+retries normally. A successful step resets the allowance, while a second
+consecutive full failure is a numerical exit instead of a permanent frozen
+orbit. SPECTRE interface states retain the stricter 10-unit bound and their
+established recovery behavior. The hold limit and aggregate Newton, retry,
+recovery, and rejection counters are stored in `results.nc`.
 
 ### Output
 `confined_fraction.dat` is the main output, containing four columns:

--- a/README.md
+++ b/README.md
@@ -287,6 +287,15 @@ retain the stricter 10-unit bound and their established recovery behavior. The
 hold limit and aggregate Newton, retry, toroidal-regularization, axis-full-orbit,
 recovery, and rejection counters are stored in `results.nc`.
 
+One narrower collisionless guiding-centre outcome is recorded separately. If
+all recovery methods have been attempted, the final error is Newton
+nonconvergence, and the last validated state remains in the axis-local core
+(normalized toroidal flux `s<0.01`, equivalent to chartmap `rho<0.1`), SIMPLE
+records exit code 4 and counts the marker confined through `trace_time`. This
+is neither a wall/LCFS loss nor an unlabelled successful completion.
+Collisional, full-orbit, strict-mode, SPECTRE, and non-core failures retain
+their numerical exit codes.
+
 ### Output
 `confined_fraction.dat` is the main output, containing four columns:
 1. Physical time
@@ -309,6 +318,9 @@ number of particles.
   * If ignored due to contr_pp, which defines deep passing region as confined (we don consider them anymore), -1 is written.
   * If tracing ends in a numerical fatal condition, `NaN` is written. Such an
     orbit is unresolved, not physically lost or confined.
+  * If a collisionless guiding-centre marker exhausts all recovery methods in
+    the axis-local core, `trace_time` is written with audited exit code 4 and
+    the marker is counted confined.
 3. Trapping parameter trap_par that is 1 for deeply trapped, 0 for tp boundary
    and negative for passing. Eq. (3.1) in Accelerated Methods paper.
    Whenever trap_par < contr_pp, particle is not traced and counted as confined.

--- a/README.md
+++ b/README.md
@@ -248,6 +248,12 @@ is stored as `wall_query_rho_lcfs` in `results.nc` (`-1` when inactive).
 Default warning mode accepts finite generic Newton corrections through 100
 tolerance units after the iteration limit. This covers the observed roundoff
 plateau at `relerr=1e-13` while still rejecting large and non-finite iterates.
+At a midpoint crossing of the polar-coordinate axis, the signed endpoint and
+midpoint radii may remain unconverged even though the physical nonradial state
+has converged. SIMPLE accepts that chart change only when both radial values are
+within `1d-6`, the endpoint radius is negative, and the angular and momentum
+corrections satisfy the normal warning bound. It then applies the equivalent
+positive-radius chart switch and records `warning_axis_crossing_accept`.
 If symplectic retries and the adaptive-RK fallback both fail, one isolated
 microstep is rolled back and consumed as a warning hold; the next microstep
 retries normally. A successful step resets the allowance, while a second

--- a/src/classification.f90
+++ b/src/classification.f90
@@ -7,6 +7,7 @@ module classification
         class_plot, ntcut, nturns, fast_class, n_tip_vars, nplagr, nder, npl_half, &
         nfp, fper, zerolam, num_surf, bmax, bmin, dtaumin, v0, cut_in_per, &
         integmode, relerr, ntau, should_skip, orbit_exit_code, unresolved_orbits, &
+        max_consecutive_warning_holds, &
         ORBIT_EXIT_COMPLETED, ORBIT_EXIT_LCFS, ORBIT_EXIT_SKIPPED, &
         ORBIT_EXIT_NUMERICAL_DOMAIN, ORBIT_EXIT_NUMERICAL_MAXITER, &
         ORBIT_EXIT_NUMERICAL_LINEAR, ORBIT_EXIT_NUMERICAL_EVENT
@@ -74,7 +75,7 @@ contains
         integer, intent(in) :: ipart
         type(classification_result_t), intent(out) :: class_result
         integer :: ierr
-        real(dp), dimension(5) :: z
+        real(dp), dimension(5) :: z, z_step_start
         real(dp) :: bmod,sqrtg
         real(dp), dimension(3) :: bder, hcovar, hctrvr, hcurl
         integer :: first_unresolved_it, hold_streak, it, ktau, it_f
@@ -260,22 +261,31 @@ contains
                 cycle
             endif
             do ktau=1,ntau
+                z_step_start = z
                 if (integmode <= 0) then
                     call orbit_timestep_axis(z, dtaumin, dtaumin, relerr, ierr)
                     if (ierr /= 0 .and. ierr /= 1 .and. &
                         symplectic_newton_warning_mode) then
-                        call count_event(EVT_WARNING_STEP_SKIP)
-                        hold_streak = ierr
-                        ierr = 0
+                        z = z_step_start
+                        if (hold_streak < max_consecutive_warning_holds) then
+                            call count_event(EVT_WARNING_STEP_SKIP)
+                            hold_streak = hold_streak + 1
+                            ierr = 0
+                        end if
+                    else if (ierr == 0) then
+                        hold_streak = 0
                     end if
                 else
                     call advance_symplectic_with_retry(anorb%si, anorb%f, &
                         orbit_timestep_sympl, ierr)
                     if (ierr /= 0 .and. ierr /= SYMPLECTIC_STEP_BOUNDARY .and. &
                         symplectic_newton_warning_mode) then
-                        call count_event(EVT_WARNING_STEP_SKIP)
-                        hold_streak = ierr
-                        ierr = 0
+                        z = z_step_start
+                        if (hold_streak < max_consecutive_warning_holds) then
+                            call count_event(EVT_WARNING_STEP_SKIP)
+                            hold_streak = hold_streak + 1
+                            ierr = 0
+                        end if
                     else if (ierr == 0) then
                         hold_streak = 0
                         z(1:3) = anorb%si%z(1:3)

--- a/src/diag_counters.f90
+++ b/src/diag_counters.f90
@@ -21,7 +21,8 @@ module diag_counters
         EVT_SYMPLECTIC_RESUME, EVT_WARNING_MAXIT_ACCEPT, &
         EVT_WARNING_MAXIT_REJECT_100, EVT_WARNING_MAXIT_REJECT_1E4, &
         EVT_WARNING_MAXIT_REJECT_LARGE, EVT_WARNING_MAXIT_NONFINITE, &
-        EVT_RETRY_EXHAUSTED, EVT_WARNING_AXIS_CROSSING_ACCEPT, N_EVENT
+        EVT_RETRY_EXHAUSTED, EVT_WARNING_AXIS_CROSSING_ACCEPT, &
+        EVT_TOROIDAL_REGULARIZATION, EVT_AXIS_FO_BRIDGE, N_EVENT
     public :: diag_counters_init, count_event, diag_counters_total, &
         diag_counters_reset, event_name
 
@@ -49,7 +50,9 @@ module diag_counters
     integer, parameter :: EVT_WARNING_MAXIT_NONFINITE = 19
     integer, parameter :: EVT_RETRY_EXHAUSTED = 20
     integer, parameter :: EVT_WARNING_AXIS_CROSSING_ACCEPT = 21
-    integer, parameter :: N_EVENT = 21
+    integer, parameter :: EVT_TOROIDAL_REGULARIZATION = 22
+    integer, parameter :: EVT_AXIS_FO_BRIDGE = 23
+    integer, parameter :: N_EVENT = 23
 
     ! Whole cache lines per thread column keep neighbouring threads from sharing
     ! a line. The event id indexes within a column; STRIDE >= N_EVENT.
@@ -140,6 +143,10 @@ contains
             name = 'retry_exhausted'
         case (EVT_WARNING_AXIS_CROSSING_ACCEPT)
             name = 'warning_axis_crossing_accept'
+        case (EVT_TOROIDAL_REGULARIZATION)
+            name = 'toroidal_regularization'
+        case (EVT_AXIS_FO_BRIDGE)
+            name = 'axis_fo_bridge'
         case default
             name = 'unknown'
         end select

--- a/src/diag_counters.f90
+++ b/src/diag_counters.f90
@@ -18,7 +18,10 @@ module diag_counters
         EVT_FO_LOSS, EVT_FO_FAULT, EVT_MIDPOINT_MAXIT, &
         EVT_WARNING_STEP_SKIP, EVT_SPECTRE_REF_INVERSE_MAXIT, &
         EVT_SPECTRE_INVALID_STATE, EVT_SYMPLECTIC_RK_RECOVERY, &
-        EVT_SYMPLECTIC_RESUME, N_EVENT
+        EVT_SYMPLECTIC_RESUME, EVT_WARNING_MAXIT_ACCEPT, &
+        EVT_WARNING_MAXIT_REJECT_100, EVT_WARNING_MAXIT_REJECT_1E4, &
+        EVT_WARNING_MAXIT_REJECT_LARGE, EVT_WARNING_MAXIT_NONFINITE, &
+        EVT_RETRY_EXHAUSTED, N_EVENT
     public :: diag_counters_init, count_event, diag_counters_total, &
         diag_counters_reset, event_name
 
@@ -39,11 +42,17 @@ module diag_counters
     integer, parameter :: EVT_SPECTRE_INVALID_STATE = 12
     integer, parameter :: EVT_SYMPLECTIC_RK_RECOVERY = 13
     integer, parameter :: EVT_SYMPLECTIC_RESUME = 14
-    integer, parameter :: N_EVENT = 14
+    integer, parameter :: EVT_WARNING_MAXIT_ACCEPT = 15
+    integer, parameter :: EVT_WARNING_MAXIT_REJECT_100 = 16
+    integer, parameter :: EVT_WARNING_MAXIT_REJECT_1E4 = 17
+    integer, parameter :: EVT_WARNING_MAXIT_REJECT_LARGE = 18
+    integer, parameter :: EVT_WARNING_MAXIT_NONFINITE = 19
+    integer, parameter :: EVT_RETRY_EXHAUSTED = 20
+    integer, parameter :: N_EVENT = 20
 
     ! Whole cache lines per thread column keep neighbouring threads from sharing
     ! a line. The event id indexes within a column; STRIDE >= N_EVENT.
-    integer, parameter :: STRIDE = 16
+    integer, parameter :: STRIDE = 32
     integer(int64), allocatable :: counts(:, :) ! (STRIDE, 0:nthreads-1)
 
 contains
@@ -116,6 +125,18 @@ contains
             name = 'symplectic_rk_recovery'
         case (EVT_SYMPLECTIC_RESUME)
             name = 'symplectic_resume'
+        case (EVT_WARNING_MAXIT_ACCEPT)
+            name = 'warning_maxit_accept'
+        case (EVT_WARNING_MAXIT_REJECT_100)
+            name = 'warning_maxit_reject_100'
+        case (EVT_WARNING_MAXIT_REJECT_1E4)
+            name = 'warning_maxit_reject_1e4'
+        case (EVT_WARNING_MAXIT_REJECT_LARGE)
+            name = 'warning_maxit_reject_large'
+        case (EVT_WARNING_MAXIT_NONFINITE)
+            name = 'warning_maxit_nonfinite'
+        case (EVT_RETRY_EXHAUSTED)
+            name = 'retry_exhausted'
         case default
             name = 'unknown'
         end select

--- a/src/diag_counters.f90
+++ b/src/diag_counters.f90
@@ -21,7 +21,7 @@ module diag_counters
         EVT_SYMPLECTIC_RESUME, EVT_WARNING_MAXIT_ACCEPT, &
         EVT_WARNING_MAXIT_REJECT_100, EVT_WARNING_MAXIT_REJECT_1E4, &
         EVT_WARNING_MAXIT_REJECT_LARGE, EVT_WARNING_MAXIT_NONFINITE, &
-        EVT_RETRY_EXHAUSTED, N_EVENT
+        EVT_RETRY_EXHAUSTED, EVT_WARNING_AXIS_CROSSING_ACCEPT, N_EVENT
     public :: diag_counters_init, count_event, diag_counters_total, &
         diag_counters_reset, event_name
 
@@ -48,7 +48,8 @@ module diag_counters
     integer, parameter :: EVT_WARNING_MAXIT_REJECT_LARGE = 18
     integer, parameter :: EVT_WARNING_MAXIT_NONFINITE = 19
     integer, parameter :: EVT_RETRY_EXHAUSTED = 20
-    integer, parameter :: N_EVENT = 20
+    integer, parameter :: EVT_WARNING_AXIS_CROSSING_ACCEPT = 21
+    integer, parameter :: N_EVENT = 21
 
     ! Whole cache lines per thread column keep neighbouring threads from sharing
     ! a line. The event id indexes within a column; STRIDE >= N_EVENT.
@@ -137,6 +138,8 @@ contains
             name = 'warning_maxit_nonfinite'
         case (EVT_RETRY_EXHAUSTED)
             name = 'retry_exhausted'
+        case (EVT_WARNING_AXIS_CROSSING_ACCEPT)
+            name = 'warning_axis_crossing_accept'
         case default
             name = 'unknown'
         end select

--- a/src/magfie.f90
+++ b/src/magfie.f90
@@ -1,8 +1,9 @@
 module magfie_sub
 use spline_vmec_sub, only: vmec_field
-use field_can_meiss, only: magfie_meiss
+use field_can_meiss, only: magfie_meiss, field_noncan
 use field_can_albert, only: magfie_albert
 use magfie_can_boozer_sub, only: magfie_can, magfie_boozer
+use field_base, only: magnetic_field_t
 use field_splined, only: splined_field_t
 use field_spectre, only: spectre_field_t
 use libneo_coordinates, only: coordinate_system_t, chartmap_coordinate_system_t, &
@@ -43,13 +44,19 @@ procedure(magfie_base), pointer :: magfie => null()
 integer, parameter :: TEST=-1, CANFLUX=0, VMEC=1, BOOZER=2, MEISS=3, ALBERT=4, &
                       REFCOORDS=5, SPECTRE=6
 
-type(splined_field_t), allocatable :: refcoords_field
+class(magnetic_field_t), allocatable :: refcoords_field
 type(spectre_field_t), allocatable :: spectre_field
 
 contains
 
+logical function has_magfie_refcoords_field()
+  has_magfie_refcoords_field = allocated(refcoords_field)
+  if (has_magfie_refcoords_field) return
+  has_magfie_refcoords_field = allocated(field_noncan)
+end function has_magfie_refcoords_field
+
 subroutine set_magfie_refcoords_field(field)
-  type(splined_field_t), intent(in) :: field
+  class(magnetic_field_t), intent(in) :: field
 
   if (allocated(refcoords_field)) deallocate (refcoords_field)
   allocate (refcoords_field, source=field)
@@ -158,6 +165,40 @@ subroutine magfie_refcoords(x, bmod, sqrtg, bder, hcovar, hctrvr, hcurl)
   real(dp), intent(out) :: bmod, sqrtg
   real(dp), intent(out) :: bder(3), hcovar(3), hctrvr(3), hcurl(3)
 
+  if (allocated(refcoords_field)) then
+    select type (refcoords_field)
+    type is (splined_field_t)
+      call magfie_splined_refcoords(refcoords_field, x, bmod, sqrtg, bder, &
+        hcovar, hctrvr, hcurl)
+      return
+    class default
+      call magfie_generic_refcoords(refcoords_field, x, bmod, sqrtg, bder, &
+        hcovar, hctrvr, hcurl)
+      return
+    end select
+  end if
+  if (allocated(field_noncan)) then
+    select type (field_noncan)
+    type is (splined_field_t)
+      call magfie_splined_refcoords(field_noncan, x, bmod, sqrtg, bder, &
+        hcovar, hctrvr, hcurl)
+      return
+    class default
+      call magfie_generic_refcoords(field_noncan, x, bmod, sqrtg, bder, &
+        hcovar, hctrvr, hcurl)
+      return
+    end select
+  end if
+  print *, 'magfie_refcoords: no splined reference field available'
+  error stop
+end subroutine magfie_refcoords
+
+subroutine magfie_splined_refcoords(field, x, bmod, sqrtg, bder, hcovar, &
+    hctrvr, hcurl)
+  type(splined_field_t), intent(in) :: field
+  real(dp), intent(in) :: x(3)
+  real(dp), intent(out) :: bmod, sqrtg
+  real(dp), intent(out) :: bder(3), hcovar(3), hctrvr(3), hcurl(3)
   real(dp) :: Acov(3), Bmod_local
   real(dp) :: dAcov(3, 3), dhcov(3, 3), dBmod(3)
   real(dp) :: g(3, 3), ginv_u(3, 3), ginv_x(3, 3)
@@ -165,20 +206,14 @@ subroutine magfie_refcoords(x, bmod, sqrtg, bder, hcovar, hctrvr, hcurl)
   real(dp) :: e_cov(3, 3), jac_signed
   real(dp) :: sqrtg_abs
 
-  if (.not. allocated(refcoords_field)) then
-    print *, 'magfie_refcoords: refcoords_field not set'
-    print *, 'Call set_magfie_refcoords_field before init_magfie(REFCOORDS)'
-    error stop
-  end if
-
-  call refcoords_field%evaluate_with_der(x, Acov, hcovar, Bmod_local, dAcov, &
-                                         dhcov, dBmod)
+  call field%evaluate_with_der(x, Acov, hcovar, Bmod_local, dAcov, dhcov, &
+    dBmod)
   bmod = Bmod_local
   bder = dBmod/max(bmod, 1.0d-30)
 
-  call scaled_to_ref_coords(refcoords_field%coords, x, u_ref, J)
-  call refcoords_field%coords%metric_tensor(u_ref, g, ginv_u, sqrtg_abs)
-  call refcoords_field%coords%covariant_basis(u_ref, e_cov)
+  call scaled_to_ref_coords(field%coords, x, u_ref, J)
+  call field%coords%metric_tensor(u_ref, g, ginv_u, sqrtg_abs)
+  call field%coords%covariant_basis(u_ref, e_cov)
 
   jac_signed = signed_jacobian(e_cov)
   sqrtg = jac_signed*J
@@ -187,7 +222,62 @@ subroutine magfie_refcoords(x, bmod, sqrtg, bder, hcovar, hctrvr, hcurl)
   hctrvr = matmul(ginv_x, hcovar)
 
   call compute_hcurl(sqrtg, dhcov, hcurl)
-end subroutine magfie_refcoords
+end subroutine magfie_splined_refcoords
+
+subroutine magfie_generic_refcoords(field, x, bmod, sqrtg, bder, hcovar, &
+    hctrvr, hcurl)
+  class(magnetic_field_t), intent(in) :: field
+  real(dp), intent(in) :: x(3)
+  real(dp), intent(out) :: bmod, sqrtg
+  real(dp), intent(out) :: bder(3), hcovar(3), hctrvr(3), hcurl(3)
+  real(dp), parameter :: derivative_step = 1.0e-5_dp
+  real(dp) :: Acov(3), dBmod(3), dhcov(3, 3)
+  real(dp) :: ap(3), hp(3), bp, am(3), hm(3), bm
+  real(dp) :: xp(3), xm(3), denominator
+  real(dp) :: g(3, 3), ginv(3, 3), e_cov(3, 3)
+  real(dp) :: sqrtg_abs
+  integer :: i
+
+  call field%evaluate(x, Acov, hcovar, bmod)
+  do i = 1, 3
+    xp = x
+    xm = x
+    xp(i) = x(i) + derivative_step
+    xm(i) = x(i) - derivative_step
+    if (i == 1 .and. xm(i) < 0.0_dp) xm(i) = x(i)
+    call field%evaluate(xp, ap, hp, bp)
+    call field%evaluate(xm, am, hm, bm)
+    denominator = xp(i) - xm(i)
+    dBmod(i) = (bp - bm)/denominator
+    dhcov(:, i) = (hp - hm)/denominator
+  end do
+  bder = dBmod/max(bmod, 1.0d-30)
+  call field%coords%metric_tensor(x, g, ginv, sqrtg_abs)
+  call field%coords%covariant_basis(x, e_cov)
+  sqrtg = sign(sqrtg_abs, signed_jacobian(e_cov))
+  hctrvr = matmul(ginv, hcovar)
+  call compute_hcurl(sqrtg, dhcov, hcurl)
+end subroutine magfie_generic_refcoords
+
+subroutine evaluate_magfie_refcoords_field(x, Acov, hcov, Bmod, status)
+  real(dp), intent(in) :: x(3)
+  real(dp), intent(out) :: Acov(3), hcov(3), Bmod
+  integer, intent(out) :: status
+
+  status = 0
+  if (allocated(refcoords_field)) then
+    call refcoords_field%evaluate(x, Acov, hcov, Bmod)
+    return
+  end if
+  if (allocated(field_noncan)) then
+    call field_noncan%evaluate(x, Acov, hcov, Bmod)
+    return
+  end if
+  Acov = 0.0_dp
+  hcov = 0.0_dp
+  Bmod = 0.0_dp
+  status = 1
+end subroutine evaluate_magfie_refcoords_field
 
 
 subroutine magfie_spectre(x, bmod, sqrtg, bder, hcovar, hctrvr, hcurl)

--- a/src/netcdf_results_output.f90
+++ b/src/netcdf_results_output.f90
@@ -54,6 +54,7 @@ contains
                           isw_field_type, swcoll, deterministic, ran_seed, &
                           netcdffile, field_input, coord_input, &
             wall_input, wall_units, wall_hit, wall_hit_cart, &
+            wall_query_rho_lcfs, &
             chart_boundary_kind, chart_boundary_kind_effective, &
                           wall_hit_normal_cart, wall_hit_cos_incidence, &
                           wall_hit_angle_rad
@@ -374,6 +375,9 @@ contains
         call check_nc(status, 'put_att wall_input')
         status = nf90_put_att(ncid, nf90_global, 'wall_units', trim(wall_units))
         call check_nc(status, 'put_att wall_units')
+        status = nf90_put_att(ncid, nf90_global, 'wall_query_rho_lcfs', &
+            wall_query_rho_lcfs)
+        call check_nc(status, 'put_att wall_query_rho_lcfs')
         status = nf90_put_att(ncid, nf90_global, 'chart_boundary_kind', &
             trim(chart_boundary_kind))
         call check_nc(status, 'put_att chart_boundary_kind')

--- a/src/netcdf_results_output.f90
+++ b/src/netcdf_results_output.f90
@@ -52,6 +52,7 @@ contains
                           ntimstep, startmode, num_surf, sbeg, &
                           contr_pp, notrace_passing, &
                           isw_field_type, swcoll, deterministic, ran_seed, &
+                          max_consecutive_warning_holds, &
                           netcdffile, field_input, coord_input, &
             wall_input, wall_units, wall_hit, wall_hit_cart, &
             wall_query_rho_lcfs, &
@@ -365,6 +366,9 @@ contains
         call check_nc(status, 'put_att deterministic')
         status = nf90_put_att(ncid, nf90_global, 'ran_seed', ran_seed)
         call check_nc(status, 'put_att ran_seed')
+        status = nf90_put_att(ncid, nf90_global, &
+            'max_consecutive_warning_holds', max_consecutive_warning_holds)
+        call check_nc(status, 'put_att max_consecutive_warning_holds')
         status = nf90_put_att(ncid, nf90_global, 'netcdffile', trim(netcdffile))
         call check_nc(status, 'put_att netcdffile')
         status = nf90_put_att(ncid, nf90_global, 'field_input', trim(field_input))

--- a/src/netcdf_results_output.f90
+++ b/src/netcdf_results_output.f90
@@ -147,14 +147,16 @@ contains
         status = nf90_put_att(ncid, var_times_lost, 'units', 's')
         call check_nc(status, 'put_att times_lost units')
         status = nf90_put_att(ncid, var_times_lost, 'description', &
-            'Physical loss time (-1 if skipped; NaN after numerical failure)')
+            'Physical loss time (-1 if skipped; trace_time if confined; ' // &
+            'NaN after fatal numerical failure)')
         call check_nc(status, 'put_att times_lost description')
 
         status = nf90_def_var(ncid, 'orbit_exit_code', nf90_int, &
             [dim_particle], var_orbit_exit_code)
         call check_nc(status, 'def_var orbit_exit_code')
         status = nf90_put_att(ncid, var_orbit_exit_code, 'description', &
-            '0=completed, 1=LCFS, 2=wall, 3=skipped, 101-105=numerical failure')
+            '0=completed, 1=LCFS, 2=wall, 3=skipped, ' // &
+            '4=numerically confined in core, 101-105=numerical failure')
         call check_nc(status, 'put_att orbit_exit_code description')
 
         status = nf90_def_var(ncid, 'boundary_event_radial_residual', nf90_double, &

--- a/src/netcdf_results_output.f90
+++ b/src/netcdf_results_output.f90
@@ -53,7 +53,8 @@ contains
                           contr_pp, notrace_passing, &
                           isw_field_type, swcoll, deterministic, ran_seed, &
                           netcdffile, field_input, coord_input, &
-                          wall_input, wall_units, wall_hit, wall_hit_cart, &
+            wall_input, wall_units, wall_hit, wall_hit_cart, &
+            chart_boundary_kind, chart_boundary_kind_effective, &
                           wall_hit_normal_cart, wall_hit_cos_incidence, &
                           wall_hit_angle_rad
         use new_vmec_stuff_mod, only: multharm
@@ -61,10 +62,14 @@ contains
         use libneo_coordinates, only: chartmap_coordinate_system_t
         use reference_coordinates, only: ref_coords
         use version, only: simple_version
+        use diag_counters, only: N_EVENT, diag_counters_total, event_name
+        use orbit_symplectic_base, only: symplectic_newton_warning_factor, &
+            symplectic_spectre_newton_warning_factor
 
         character(len=*), intent(in) :: filename
 
-        integer :: ncid, status
+        integer :: event_id, ncid, status
+        character(:), allocatable :: diagnostic_name
         integer :: dim_particle, dim_xyz, dim_phase, dim_iclass
         integer :: var_times_lost, var_orbit_exit_code, var_trap_par, var_perp_inv
         integer :: var_boundary_event_radial_residual, var_boundary_event_time_width
@@ -304,6 +309,14 @@ contains
         status = nf90_put_att(ncid, nf90_global, 'relerr', relerr)
         call check_nc(status, 'put_att relerr')
         status = nf90_put_att(ncid, nf90_global, &
+            'symplectic_newton_warning_factor', &
+            symplectic_newton_warning_factor)
+        call check_nc(status, 'put_att symplectic_newton_warning_factor')
+        status = nf90_put_att(ncid, nf90_global, &
+            'symplectic_spectre_newton_warning_factor', &
+            symplectic_spectre_newton_warning_factor)
+        call check_nc(status, 'put_att symplectic_spectre_newton_warning_factor')
+        status = nf90_put_att(ncid, nf90_global, &
                               'boundary_event_fraction_tolerance', &
                               boundary_event_fraction_tolerance)
         call check_nc(status, 'put_att boundary_event_fraction_tolerance')
@@ -361,8 +374,21 @@ contains
         call check_nc(status, 'put_att wall_input')
         status = nf90_put_att(ncid, nf90_global, 'wall_units', trim(wall_units))
         call check_nc(status, 'put_att wall_units')
+        status = nf90_put_att(ncid, nf90_global, 'chart_boundary_kind', &
+            trim(chart_boundary_kind))
+        call check_nc(status, 'put_att chart_boundary_kind')
+        status = nf90_put_att(ncid, nf90_global, &
+            'chart_boundary_kind_effective', &
+            trim(chart_boundary_kind_effective))
+        call check_nc(status, 'put_att chart_boundary_kind_effective')
         status = nf90_put_att(ncid, nf90_global, 'coordinate_type', trim(coord_type))
         call check_nc(status, 'put_att coordinate_type')
+        do event_id = 1, N_EVENT
+            diagnostic_name = 'diagnostic_'//event_name(event_id)
+            status = nf90_put_att(ncid, nf90_global, diagnostic_name, &
+                diag_counters_total(event_id))
+            call check_nc(status, 'put_att '//diagnostic_name)
+        end do
 
         ! End define mode
         status = nf90_enddef(ncid)

--- a/src/orbit_fo_boris.f90
+++ b/src/orbit_fo_boris.f90
@@ -21,7 +21,7 @@ module orbit_fo_boris
   ! never a loss.
   use, intrinsic :: iso_fortran_env, only: dp => real64
   use reference_coordinates, only: ref_coords
-  use orbit_fo_field, only: fo_eval_field
+  use orbit_fo_field, only: fo_eval_field, fo_eval_reference_field
   use libneo_coordinates, only: chartmap_coordinate_system_t, chartmap_from_cyl_ok
   implicit none
   private
@@ -47,7 +47,8 @@ module orbit_fo_boris
   ! numerical locate fault (NOT a loss).
   integer, parameter, public :: FO_OK = 0, FO_LOSS = 1, FO_LOCATE_FAIL = 2
 
-  public :: fo_state_t, fo_init, fo_step, fo_energy, fo_mu, fo_to_gc, accept_or_fail
+  public :: fo_state_t, fo_init, fo_init_reference, fo_step, fo_energy, &
+    fo_mu, fo_to_gc, fo_to_reference_gc, accept_or_fail
 
   type :: fo_state_t
     real(dp) :: x(3)   = 0.0_dp    ! Cartesian position (scaled cm)
@@ -59,6 +60,7 @@ module orbit_fo_boris
     real(dp) :: charge = 1.0_dp
     real(dp) :: ro0    = 1.0_dp
     real(dp) :: pabs   = 0.0_dp    ! normalized speed (carried for z(4) write-back)
+    logical :: reference_field = .false.
   end type fo_state_t
 
 contains
@@ -263,18 +265,52 @@ contains
   ! Cartesian B, |B|, grad|B| at logical u from the chartmap field (field_can) and
   ! geometry (ref_coords): B^i = |B| g^{ij} h_j, B_cart = Jc B^i; grad|B| covariant
   ! d|B|/du -> Cartesian by Jc^{-T}. Jc returned for downstream Larmor offsets.
-  subroutine field_at_logical(u, Bvec, Bmod, gradB, Jc, status)
+  subroutine field_at_logical(u, Bvec, Bmod, gradB, Jc, status, reference_field)
     real(dp), intent(in) :: u(3)
     real(dp), intent(out) :: Bvec(3), Bmod, gradB(3), Jc(3,3)
     integer, intent(out) :: status
+    logical, intent(in) :: reference_field
     real(dp) :: ue(3), Acov(3), dA(3,3), dBmod(3), hcov(3)
     real(dp) :: Jw(3,3), Jwinv(3,3), cth, sth, rho, detJw, Bw(3), dBw(3), Bn
+    real(dp) :: hw(3)
     integer :: i
 
     ! A particle may gyro-excurse a Larmor radius past s=1; evaluate the field at
     ! the clamped edge there (field_can is undefined past the last closed surface).
     ue = u
     ue(1) = min(ue(1), 1.0_dp - 1.0e-9_dp)
+    if (reference_field) then
+      call fo_eval_reference_field(ue, hcov, Bmod, status)
+      if (status /= 0) then
+        status = FO_LOCATE_FAIL
+        return
+      end if
+      call ref_coords%covariant_basis(ue, Jc)
+      ! Assemble the covector in the regular rotating (X,Y,phi) frame.  Directly
+      ! inverting the polar Jc becomes ill-conditioned as rho->0 even though the
+      ! Cartesian field is smooth.  The same frame is used by the chart inverse;
+      ! to_wedge supplies the exact field-period rotation on return to global
+      ! Cartesian coordinates.
+      call pseudocart_basis(ue, Jc, Jw, cth, sth, rho)
+      if (.not. jacobian_ok(Jw)) then
+        status = FO_LOCATE_FAIL
+        return
+      end if
+      hw(1) = cth*hcov(1) - (sth/rho)*hcov(2)
+      hw(2) = sth*hcov(1) + (cth/rho)*hcov(2)
+      hw(3) = hcov(3)
+      call inv3(Jw, Jwinv)
+      Bvec = matmul(transpose(Jwinv), hw)
+      Bn = norm2(Bvec)
+      if (Bn <= 0.0_dp) then
+        status = FO_LOCATE_FAIL
+        return
+      end if
+      Bvec = Bvec*(Bmod/Bn)
+      gradB = 0.0_dp
+      status = FO_OK
+      return
+    end if
     call fo_eval_field(ue, Acov, dA, Bmod, dBmod, hcov)
     call ref_coords%covariant_basis(ue, Jc)
     ! Heal the axis: work in the pseudo-Cartesian chart w=(X,Y,phi). The polar
@@ -320,17 +356,19 @@ contains
   ! fault). On fault Bvec etc. are undefined and the caller must not push. Loss is
   ! not decided here -- the field is defined through the clamped edge, and only the
   ! guiding-centre crossing rho>=1 in fo_to_gc is a confinement loss.
-  subroutine cart_field(x, u_guess, Bvec, Bmod, gradB, u_out, status)
+  subroutine cart_field(x, u_guess, Bvec, Bmod, gradB, u_out, status, &
+      reference_field)
     real(dp), intent(in) :: x(3), u_guess(3)
     real(dp), intent(out) :: Bvec(3), Bmod, gradB(3), u_out(3)
     integer, intent(out) :: status
+    logical, intent(in) :: reference_field
     real(dp) :: xw(3), ca, sa, u(3), Jc(3,3), Bw(3), gw(3)
 
     call to_wedge(x, xw, ca, sa)
     call invert_cart_warm(xw, u_guess, u, status)
     if (status /= FO_OK) return
     u_out = u
-    call field_at_logical(u, Bw, Bmod, gw, Jc, status)
+    call field_at_logical(u, Bw, Bmod, gw, Jc, status, reference_field)
     if (status /= FO_OK) return
     Bvec = rotz(Bw, ca, sa)       ! wedge field vector -> global frame
     gradB = rotz(gw, ca, sa)
@@ -338,10 +376,11 @@ contains
 
   ! Logical chart of a Cartesian point and the local covariant frame, for seeding
   ! and Larmor offsets. status as in cart_field. u_guess warm-starts the inversion.
-  subroutine locate(x, u_guess, u_out, bhat, eperp, Bmod, status)
+  subroutine locate(x, u_guess, u_out, bhat, eperp, Bmod, status, reference_field)
     real(dp), intent(in) :: x(3), u_guess(3)
     real(dp), intent(out) :: u_out(3), bhat(3), eperp(3), Bmod
     integer, intent(out) :: status
+    logical, intent(in) :: reference_field
     real(dp) :: xw(3), ca, sa, u(3), Jc(3,3), Bw(3), gw(3), bw_hat(3), ew(3)
 
     call to_wedge(x, xw, ca, sa)
@@ -350,7 +389,7 @@ contains
     u_out = u
     ! Same axis-healed field assembly as the push (field_at_logical), so the seed
     ! frame and the orbit-step field are identical.
-    call field_at_logical(u, Bw, Bmod, gw, Jc, status)
+    call field_at_logical(u, Bw, Bmod, gw, Jc, status, reference_field)
     if (status /= FO_OK) return
     bw_hat = Bw/max(sqrt(Bw(1)**2 + Bw(2)**2 + Bw(3)**2), 1.0e-30_dp)
     call perp_ref(bw_hat, ew)     ! arbitrary unit vector perpendicular to b
@@ -369,15 +408,37 @@ contains
     type(fo_state_t), intent(out) :: st
     real(dp), intent(in) :: x0_boozer(3), vpar0, vperp0, mu_in, mass, charge, &
                             dt, ro0_in, pabs
-    real(dp) :: u_gc(3), xyz_gc(3), u_p(3), x_p(3), qc
+    real(dp) :: u_gc(3)
+
+    u_gc = [sqrt(max(x0_boozer(1), 0.0_dp)), x0_boozer(2), x0_boozer(3)]
+    call fo_init_logical(st, u_gc, vpar0, vperp0, mu_in, mass, charge, dt, &
+      ro0_in, pabs, .false.)
+  end subroutine fo_init
+
+  subroutine fo_init_reference(st, u_gc, vpar0, vperp0, mu_in, mass, &
+      charge, dt, ro0_in, pabs)
+    type(fo_state_t), intent(out) :: st
+    real(dp), intent(in) :: u_gc(3), vpar0, vperp0, mu_in, mass, charge, dt, &
+      ro0_in, pabs
+
+    call fo_init_logical(st, u_gc, vpar0, vperp0, mu_in, mass, charge, dt, &
+      ro0_in, pabs, .true.)
+  end subroutine fo_init_reference
+
+  subroutine fo_init_logical(st, u_gc, vpar0, vperp0, mu_in, mass, charge, &
+      dt, ro0_in, pabs, reference_field)
+    type(fo_state_t), intent(out) :: st
+    real(dp), intent(in) :: u_gc(3), vpar0, vperp0, mu_in, mass, charge, dt, &
+      ro0_in, pabs
+    logical, intent(in) :: reference_field
+    real(dp) :: xyz_gc(3), u_p(3), x_p(3), qc
     real(dp) :: bhat(3), eperp(3), Bmod
     integer :: status
 
     st%mass = mass; st%charge = charge; st%dt = dt; st%ro0 = ro0_in
     st%mu = mu_in; st%pabs = pabs
+    st%reference_field = reference_field
 
-    ! GC logical coords: chartmap radial label is rho = sqrt(s).
-    u_gc = [sqrt(max(x0_boozer(1), 0.0_dp)), x0_boozer(2), x0_boozer(3)]
     call ref_coords%evaluate_cart(u_gc, xyz_gc)
     qc = charge/ro0_in
 
@@ -389,7 +450,8 @@ contains
       ! locate, fall back to seeding at the guiding centre: the offset is O(rho_L),
       ! and a genuine edge orbit is then lost during integration, not at init. Never
       ! abort -- this runs per particle inside the OpenMP loop.
-      call gc_to_particle(xyz_gc, u_gc, vperp0, mass, qc, x_p, u_p, status)
+      call gc_to_particle(xyz_gc, u_gc, vperp0, mass, qc, x_p, u_p, status, &
+        reference_field)
       if (status /= FO_OK) then
         x_p = xyz_gc
         u_p = u_gc
@@ -398,7 +460,7 @@ contains
 
     st%x = x_p
     st%u = u_p
-    call locate(x_p, u_p, u_p, bhat, eperp, Bmod, status)
+    call locate(x_p, u_p, u_p, bhat, eperp, Bmod, status, reference_field)
     if (status /= FO_OK) then
       ! Cannot even seed the frame at the guiding centre: leave v=0 so the first
       ! orbit step reports a locate fault (counted confined), never a crash.
@@ -408,16 +470,18 @@ contains
     st%u = u_p
     st%v = vpar0*bhat
     if (vperp0 > 0.0_dp) st%v = st%v + vperp0*eperp
-  end subroutine fo_init
+  end subroutine fo_init_logical
 
   ! Cartesian guiding centre x_gc -> particle position a Larmor vector off it,
   ! solved by the fixed point x_p with cart(x_p) - rho(x_p) = x_gc, rho the Larmor
   ! vector built from the perpendicular speed at x_p (same gyrophase reference as
   ! the velocity seed), so the seed offset and the GC reconstruction are inverses.
-  subroutine gc_to_particle(xyz_gc, u_gc, vperp0, mass, qc, x_p, u_p, status)
+  subroutine gc_to_particle(xyz_gc, u_gc, vperp0, mass, qc, x_p, u_p, status, &
+      reference_field)
     real(dp), intent(in) :: xyz_gc(3), u_gc(3), vperp0, mass, qc
     real(dp), intent(out) :: x_p(3), u_p(3)
     integer, intent(out) :: status
+    logical, intent(in) :: reference_field
     integer, parameter :: maxfp = 50
     real(dp), parameter :: tol = 1.0e-10_dp
     real(dp) :: bhat(3), eperp(3), Bmod
@@ -426,14 +490,14 @@ contains
 
     x_p = xyz_gc
     do it = 1, maxfp
-      call locate(x_p, u_gc, u_p, bhat, eperp, Bmod, status)
+      call locate(x_p, u_gc, u_p, bhat, eperp, Bmod, status, reference_field)
       if (status /= FO_OK) return
       ! rho = (m/(qc|B|)) bhat x v_perp, v_perp = vperp0 eperp (Cartesian).
       rho_l = (mass/(qc*Bmod))*cross(bhat, vperp0*eperp)
       xnew = xyz_gc + rho_l
       if (maxval(abs(xnew - x_p)) < tol) then
         x_p = xnew
-        call locate(x_p, u_gc, u_p, bhat, eperp, Bmod, status)
+        call locate(x_p, u_gc, u_p, bhat, eperp, Bmod, status, reference_field)
         return
       end if
       x_p = xnew
@@ -452,7 +516,8 @@ contains
     qcm = st%charge/(c*st%ro0*st%mass)   ! rotation: dv/dt = qcm v x B
 
     x = x + 0.5_dp*st%dt*v
-    call cart_field(x, st%u, Bvec, Bmod, gradB, u, status)
+    call cart_field(x, st%u, Bvec, Bmod, gradB, u, status, &
+      st%reference_field)
     if (status /= FO_OK) return    ! unresolved: leave st at the last resolved state
     st%u = u
 
@@ -499,14 +564,37 @@ contains
     real(dp), intent(out) :: s, th, ph, vpar
     integer, intent(out) :: status
     real(dp), intent(out), optional :: Bmod_gc
-    real(dp) :: u_p(3), x_gc(3), u_gc(3), qc
+    real(dp) :: u_gc(3), Bmod_local
+
+    call fo_to_reference_gc(st, u_gc, vpar, status, Bmod_local)
+    if (status /= FO_OK .and. status /= FO_LOSS) then
+      s = 0.0_dp
+      th = 0.0_dp
+      ph = 0.0_dp
+      if (present(Bmod_gc)) Bmod_gc = 0.0_dp
+      return
+    end if
+    s = u_gc(1)**2
+    th = u_gc(2)
+    ph = u_gc(3)
+    if (present(Bmod_gc)) Bmod_gc = Bmod_local
+  end subroutine fo_to_gc
+
+  subroutine fo_to_reference_gc(st, u_gc, vpar, status, Bmod_gc)
+    type(fo_state_t), intent(in) :: st
+    real(dp), intent(out) :: u_gc(3), vpar
+    integer, intent(out) :: status
+    real(dp), intent(out), optional :: Bmod_gc
+    real(dp) :: u_p(3), x_gc(3), qc
     real(dp) :: bhat(3), eperp(3), Bmod
     real(dp) :: vpar_p, vperp_cart(3), rho_l(3)
 
-    s = 0.0_dp; th = 0.0_dp; ph = 0.0_dp; vpar = 0.0_dp
+    u_gc = 0.0_dp
+    vpar = 0.0_dp
     if (present(Bmod_gc)) Bmod_gc = 0.0_dp
 
-    call locate(st%x, st%u, u_p, bhat, eperp, Bmod, status)
+    call locate(st%x, st%u, u_p, bhat, eperp, Bmod, status, &
+      st%reference_field)
     if (status /= FO_OK) return
     qc = st%charge/st%ro0
 
@@ -517,10 +605,9 @@ contains
     rho_l = (st%mass/(qc*Bmod))*cross(bhat, vperp_cart)
     x_gc = st%x - rho_l
 
-    call locate(x_gc, u_p, u_gc, bhat, eperp, Bmod, status)
+    call locate(x_gc, u_p, u_gc, bhat, eperp, Bmod, status, &
+      st%reference_field)
     if (status /= FO_OK) return
-    s = u_gc(1)**2               ! chart rho -> s
-    th = u_gc(2); ph = u_gc(3)
     vpar = st%v(1)*bhat(1) + st%v(2)*bhat(2) + st%v(3)*bhat(3)
     if (present(Bmod_gc)) Bmod_gc = Bmod
     ! Confinement loss: the Larmor-corrected guiding centre crosses the last closed
@@ -534,7 +621,7 @@ contains
     ! inside is a reconstruction glitch, not a loss. The field, integrator and energy
     ! match the ASCOT full-orbit reference, so the loss detector must be this clean.
     if (u_gc(1) >= 1.0_dp .and. u_p(1) >= 1.0_dp - GC_PARTICLE_GAP) status = FO_LOSS
-  end subroutine fo_to_gc
+  end subroutine fo_to_reference_gc
 
   ! Pseudo-Cartesian near-axis chart w=(X,Y,phi)=(rho cos th, rho sin th, phi).
   ! The chartmap polar chart (rho,theta) is singular at the magnetic axis: the

--- a/src/orbit_fo_field.f90
+++ b/src/orbit_fo_field.f90
@@ -10,9 +10,26 @@ module orbit_fo_field
   implicit none
   private
 
-  public :: fo_eval_field
+  public :: fo_eval_field, fo_eval_reference_field, &
+    fo_reference_field_available
 
 contains
+
+  logical function fo_reference_field_available()
+    use magfie_sub, only: has_magfie_refcoords_field
+
+    fo_reference_field_available = has_magfie_refcoords_field()
+  end function fo_reference_field_available
+
+  subroutine fo_eval_reference_field(u, hcov, Bmod, status)
+    use magfie_sub, only: evaluate_magfie_refcoords_field
+    real(dp), intent(in) :: u(3)
+    real(dp), intent(out) :: hcov(3), Bmod
+    integer, intent(out) :: status
+    real(dp) :: Acov(3)
+
+    call evaluate_magfie_refcoords_field(u, Acov, hcov, Bmod, status)
+  end subroutine fo_eval_reference_field
 
   ! Production Boozer field at u=(rho,theta_B,phi_B), reparametrized from
   ! field_can(s=rho^2). field_can returns covariant A_theta,A_phi (A_s=0),

--- a/src/orbit_symplectic.f90
+++ b/src/orbit_symplectic.f90
@@ -27,7 +27,7 @@ use diag_counters, only: count_event, EVT_NEWTON1_MAXIT, EVT_NEWTON2_MAXIT, &
   EVT_MIDPOINT_MAXIT, EVT_WARNING_MAXIT_ACCEPT, &
   EVT_WARNING_MAXIT_REJECT_100, EVT_WARNING_MAXIT_REJECT_1E4, &
   EVT_WARNING_MAXIT_REJECT_LARGE, EVT_WARNING_MAXIT_NONFINITE, &
-  EVT_RETRY_EXHAUSTED
+  EVT_RETRY_EXHAUSTED, EVT_WARNING_AXIS_CROSSING_ACCEPT
 
 implicit none
 
@@ -85,6 +85,29 @@ logical function accept_warning_maxiter(x, xlast, tolref, rtol, warning_factor)
     call count_event(EVT_WARNING_MAXIT_REJECT_LARGE)
   end if
 end function accept_warning_maxiter
+
+logical function accept_warning_axis_crossing(si, x, xlast, tolref, rtol)
+  ! Near the polar-coordinate axis, the endpoint and midpoint radii can change
+  ! sign while the physical step and its angular/momentum components have
+  ! converged. Accept only that local chart crossing; the caller immediately
+  ! maps the negative endpoint to the equivalent positive-radius chart.
+  type(symplectic_integrator_t), intent(in) :: si
+  real(dp), intent(in) :: x(5), xlast(5), tolref(5), rtol
+  real(dp), parameter :: axis_radius = 1.0e-6_dp
+
+  accept_warning_axis_crossing = .false.
+  if (.not. symplectic_newton_warning_mode .or. rtol <= 0.0_dp) return
+  if (si%z(1) < 0.0_dp .or. si%z(1) > axis_radius) return
+  if (.not. finite_newton_iterate(x)) return
+  if (.not. finite_newton_iterate(xlast)) return
+  if (.not. finite_newton_iterate(tolref)) return
+  if (x(1) >= 0.0_dp) return
+  if (max(abs(x(1)), abs(x(5))) > axis_radius) return
+  accept_warning_axis_crossing = all(abs(x(2:4) - xlast(2:4)) <= &
+    si%warning_factor*rtol*abs(tolref(2:4)))
+  if (accept_warning_axis_crossing) &
+    call count_event(EVT_WARNING_AXIS_CROSSING_ACCEPT)
+end function accept_warning_axis_crossing
 
 subroutine advance_symplectic_with_retry(si, f, stepper, status, &
     accepted_fraction)
@@ -849,8 +872,12 @@ recursive subroutine newton_midpoint(si, f, x, atol, rtol, maxit, xlast, status)
     end if
   else
     call count_event(EVT_MIDPOINT_MAXIT)
-    if (accept_warning_maxiter(x, xlast, tolref, rtol, si%warning_factor)) &
+    if (accept_warning_axis_crossing(si, x, xlast, tolref, rtol)) then
       status = SYMPLECTIC_STEP_OK
+    else if (accept_warning_maxiter(x, xlast, tolref, rtol, &
+        si%warning_factor)) then
+      status = SYMPLECTIC_STEP_OK
+    end if
   end if
 end subroutine
 

--- a/src/orbit_symplectic.f90
+++ b/src/orbit_symplectic.f90
@@ -12,8 +12,7 @@ use orbit_symplectic_base, only: symplectic_integrator_t, multistage_integrator_
   SYMPLECTIC_STEP_MAXITER, SYMPLECTIC_STEP_LINEAR_SOLVE, &
   SYMPLECTIC_STEP_BOUNDARY, SYMPLECTIC_STEP_EVENT_NOT_CONVERGED, &
   SYMPLECTIC_STEP_BOUNDARY_LIMITED, boundary_event_fraction_tolerance, &
-  boundary_event_radial_tolerance, symplectic_newton_warning_mode, &
-  symplectic_newton_warning_factor
+  boundary_event_radial_tolerance, symplectic_newton_warning_mode
 use orbit_symplectic_quasi, only: orbit_timestep_quasi, timestep_expl_impl_euler_quasi, &
   timestep_impl_expl_euler_quasi, timestep_midpoint_quasi, orbit_timestep_rk45, &
   timestep_rk_gauss_quasi, timestep_rk_lobatto_quasi
@@ -25,7 +24,10 @@ use vector_potentail_mod, only: torflux
 use lapack_interfaces, only: dgesv
 use diag_counters, only: count_event, EVT_NEWTON1_MAXIT, EVT_NEWTON2_MAXIT, &
   EVT_RK_GAUSS_MAXIT, EVT_RK_LOBATTO_MAXIT, EVT_FIXPOINT_MAXIT, EVT_R_NEGATIVE, &
-  EVT_MIDPOINT_MAXIT, EVT_WARNING_STEP_SKIP
+  EVT_MIDPOINT_MAXIT, EVT_WARNING_MAXIT_ACCEPT, &
+  EVT_WARNING_MAXIT_REJECT_100, EVT_WARNING_MAXIT_REJECT_1E4, &
+  EVT_WARNING_MAXIT_REJECT_LARGE, EVT_WARNING_MAXIT_NONFINITE, &
+  EVT_RETRY_EXHAUSTED
 
 implicit none
 
@@ -50,20 +52,38 @@ pure logical function finite_newton_iterate(x)
   finite_newton_iterate = .true.
 end function finite_newton_iterate
 
-logical function accept_warning_maxiter(x, xlast, tolref, rtol)
-  ! Continue directly only when the last Newton correction is finite and close
-  ! to the requested tolerance. Larger finite iterates are not trustworthy
-  ! states: the warning-mode driver retries them at smaller substeps and, if
-  ! every recovery is exhausted, advances the clock from the last valid state.
-  real(dp), intent(in) :: x(:), xlast(:), tolref(:), rtol
+logical function accept_warning_maxiter(x, xlast, tolref, rtol, warning_factor)
+  ! Continue only when the final Newton correction is finite and inside this
+  ! integrator's tolerance-scaled guard. Other iterates enter retry recovery.
+  real(dp), intent(in) :: x(:), xlast(:), tolref(:), rtol, warning_factor
+  real(dp) :: correction_ratio
 
   accept_warning_maxiter = .false.
   if (.not. symplectic_newton_warning_mode .or. rtol <= 0.0_dp) return
-  if (.not. finite_newton_iterate(x)) return
-  if (.not. finite_newton_iterate(xlast)) return
-  if (.not. finite_newton_iterate(tolref)) return
-  accept_warning_maxiter = all(abs(x - xlast) <= &
-    symplectic_newton_warning_factor*rtol*abs(tolref))
+  if (.not. finite_newton_iterate(x)) then
+    call count_event(EVT_WARNING_MAXIT_NONFINITE)
+    return
+  end if
+  if (.not. finite_newton_iterate(xlast)) then
+    call count_event(EVT_WARNING_MAXIT_NONFINITE)
+    return
+  end if
+  if (.not. finite_newton_iterate(tolref)) then
+    call count_event(EVT_WARNING_MAXIT_NONFINITE)
+    return
+  end if
+  correction_ratio = maxval(abs(x - xlast)/ &
+    max(rtol*abs(tolref), tiny(1.0_dp)))
+  accept_warning_maxiter = correction_ratio <= warning_factor
+  if (accept_warning_maxiter) then
+    call count_event(EVT_WARNING_MAXIT_ACCEPT)
+  else if (correction_ratio <= 100.0_dp) then
+    call count_event(EVT_WARNING_MAXIT_REJECT_100)
+  else if (correction_ratio <= 1.0e4_dp) then
+    call count_event(EVT_WARNING_MAXIT_REJECT_1E4)
+  else
+    call count_event(EVT_WARNING_MAXIT_REJECT_LARGE)
+  end if
 end function accept_warning_maxiter
 
 subroutine advance_symplectic_with_retry(si, f, stepper, status, &
@@ -91,9 +111,7 @@ recursive subroutine advance_retry_interval(si, f, stepper, interval, depth, &
   integer, intent(out) :: status
   real(dp), intent(out) :: accepted_fraction
   type(symplectic_integrator_t) :: initial_integrator
-  type(symplectic_integrator_t) :: half_integrator
   type(field_can_t) :: initial_field
-  type(field_can_t) :: half_field
   real(dp) :: child_fraction
   logical :: recoverable
 
@@ -119,7 +137,11 @@ recursive subroutine advance_retry_interval(si, f, stepper, interval, depth, &
   recoverable = status == SYMPLECTIC_STEP_MAXITER .or. &
     status == SYMPLECTIC_STEP_LINEAR_SOLVE
   if (.not. symplectic_newton_warning_mode .or. .not. recoverable .or. &
-      depth >= max_retry_depth) return
+      depth >= max_retry_depth) then
+    if (recoverable .and. depth >= max_retry_depth) &
+      call count_event(EVT_RETRY_EXHAUSTED)
+    return
+  end if
 
   ! For a fixed subdivision, the two accepted maps remain symplectic and cover
   ! the original interval exactly. State-dependent subdivision is a warning-mode
@@ -134,16 +156,6 @@ recursive subroutine advance_retry_interval(si, f, stepper, interval, depth, &
     return
   end if
   if (status == SYMPLECTIC_STEP_OK) then
-    if (child_fraction < 1.0_dp) then
-      ! A nested recovery already consumed the unresolved suffix of this first
-      ! half. Preserve that contiguous accepted prefix and do not leap over the
-      ! held interval to attempt the nominal second half.
-      accepted_fraction = 0.5_dp*child_fraction
-      si%dt = interval
-      return
-    end if
-    half_integrator = si
-    half_field = f
     call advance_retry_interval(si, f, stepper, 0.5_dp*interval, depth + 1, &
       status, child_fraction)
     if (status == SYMPLECTIC_STEP_BOUNDARY) then
@@ -158,24 +170,11 @@ recursive subroutine advance_retry_interval(si, f, stepper, interval, depth, &
       si%dt = interval
       return
     end if
-    recoverable = status == SYMPLECTIC_STEP_MAXITER .or. &
-      status == SYMPLECTIC_STEP_LINEAR_SOLVE
-    if (recoverable) then
-      ! Keep the first accepted half rather than discarding meaningful orbit
-      ! progress because the second half exhausted every retry. Warning mode
-      ! consumes only that unresolved remainder and resumes from this state.
-      si = half_integrator
-      f = half_field
-      si%dt = interval
-      status = SYMPLECTIC_STEP_OK
-      accepted_fraction = 0.5_dp
-      call count_event(EVT_WARNING_STEP_SKIP)
-      return
-    end if
   end if
   if (status /= SYMPLECTIC_STEP_OK) then
     si = initial_integrator
     f = initial_field
+    accepted_fraction = 0.0_dp
   end if
   si%dt = interval
 end subroutine advance_retry_interval
@@ -596,7 +595,8 @@ recursive subroutine newton1(si, f, x, maxit, xlast, status)
     end if
   else
     call count_event(EVT_NEWTON1_MAXIT)
-    if (accept_warning_maxiter(x, xlast, tolref, si%rtol)) &
+    if (accept_warning_maxiter(x, xlast, tolref, si%rtol, &
+        si%warning_factor)) &
       status = SYMPLECTIC_STEP_OK
   end if
 end subroutine
@@ -691,7 +691,7 @@ recursive subroutine newton2(si, f, x, atol, rtol, maxit, xlast, status)
     end if
   else
     call count_event(EVT_NEWTON2_MAXIT)
-    if (accept_warning_maxiter(x, xlast, tolref, rtol)) &
+    if (accept_warning_maxiter(x, xlast, tolref, rtol, si%warning_factor)) &
       status = SYMPLECTIC_STEP_OK
   end if
 end subroutine
@@ -849,7 +849,7 @@ recursive subroutine newton_midpoint(si, f, x, atol, rtol, maxit, xlast, status)
     end if
   else
     call count_event(EVT_MIDPOINT_MAXIT)
-    if (accept_warning_maxiter(x, xlast, tolref, rtol)) &
+    if (accept_warning_maxiter(x, xlast, tolref, rtol, si%warning_factor)) &
       status = SYMPLECTIC_STEP_OK
   end if
 end subroutine
@@ -974,7 +974,7 @@ recursive subroutine newton_rk_gauss(si, fs, s, x, atol, rtol, maxit, xlast, sta
     end if
   else
     call count_event(EVT_RK_GAUSS_MAXIT)
-    if (accept_warning_maxiter(x, xlast, tolref, rtol)) &
+    if (accept_warning_maxiter(x, xlast, tolref, rtol, si%warning_factor)) &
       status = SYMPLECTIC_STEP_OK
   end if
 end subroutine newton_rk_gauss
@@ -1316,7 +1316,7 @@ recursive subroutine newton_rk_lobatto(si, fs, s, x, atol, rtol, maxit, xlast, s
     end if
   else
     call count_event(EVT_RK_LOBATTO_MAXIT)
-    if (accept_warning_maxiter(x, xlast, tolref, rtol)) &
+    if (accept_warning_maxiter(x, xlast, tolref, rtol, si%warning_factor)) &
       status = SYMPLECTIC_STEP_OK
   end if
 end subroutine newton_rk_lobatto

--- a/src/orbit_symplectic_base.f90
+++ b/src/orbit_symplectic_base.f90
@@ -27,13 +27,15 @@ use field_can_mod, only: eval_field => evaluate, field_can_t, get_val, get_deriv
     integer, parameter :: SYMPLECTIC_STEP_EVENT_NOT_CONVERGED = 5
     integer, parameter :: SYMPLECTIC_STEP_BOUNDARY_LIMITED = 6
     logical :: symplectic_newton_warning_mode = .true.
-    real(dp), parameter :: symplectic_newton_warning_factor = 10.0_dp
+    real(dp), parameter :: symplectic_newton_warning_factor = 100.0_dp
+    real(dp), parameter :: symplectic_spectre_newton_warning_factor = 10.0_dp
     real(dp) :: boundary_event_fraction_tolerance = -1d0
     real(dp) :: boundary_event_radial_tolerance = -1d0
 
     type :: symplectic_integrator_t
         real(dp) :: atol
         real(dp) :: rtol
+        real(dp) :: warning_factor = symplectic_newton_warning_factor
 
         ! Current phase-space coordinates z and old pth
         real(dp), dimension(4) :: z  ! z = (r, th, ph, pphi)

--- a/src/params.f90
+++ b/src/params.f90
@@ -46,6 +46,11 @@ module params
     integer, parameter :: ORBIT_EXIT_LCFS = 1
     integer, parameter :: ORBIT_EXIT_WALL = 2
     integer, parameter :: ORBIT_EXIT_SKIPPED = 3
+    ! A collisionless warning-mode marker whose validated last state is in the
+    ! axis-local core after all recovery methods are exhausted. It is not a
+    ! physical loss and is conservatively counted confined, with the distinct
+    ! code retained for auditability.
+    integer, parameter :: ORBIT_EXIT_NUMERICAL_CONFINED = 4
     integer, parameter :: ORBIT_EXIT_NUMERICAL_DOMAIN = 101
     integer, parameter :: ORBIT_EXIT_NUMERICAL_MAXITER = 102
     integer, parameter :: ORBIT_EXIT_NUMERICAL_LINEAR = 103

--- a/src/params.f90
+++ b/src/params.f90
@@ -137,6 +137,11 @@ module params
     logical :: reuse_batch = .False.
     integer, dimension(:), allocatable :: idx
 
+    !> Warning mode may consume one isolated, fully exhausted numerical
+    !> microstep. A second consecutive failure is terminal rather than freezing
+    !> the remainder of the orbit at one phase-space point.
+    integer, parameter :: max_consecutive_warning_holds = 1
+
     character(1000) :: field_input = ''
     character(1000) :: coord_input = ''
     character(1000) :: wall_input = ''

--- a/src/params.f90
+++ b/src/params.f90
@@ -141,6 +141,8 @@ module params
     character(1000) :: coord_input = ''
     character(1000) :: wall_input = ''
     character(16) :: wall_units = 'm'
+    character(16) :: chart_boundary_kind = 'auto'
+    character(16) :: chart_boundary_kind_effective = 'lcfs'
     integer :: integ_coords = -1000  ! Sentinel: -1000 means user did not set it
     !> SPECTRE RK45 interface-crossing map: 1 = Level-1 refraction (default),
     !> 0 = Level-0 energy rescale (regression comparison).
@@ -178,7 +180,7 @@ module params
 	        am1, am2, Z1, Z2, &
 	        densi1, densi2, tempi1, tempi2, tempe, &
 	        batch_size, ran_seed, reuse_batch, field_input, coord_input, &
-	        wall_input, wall_units, integ_coords, crossing_level, &
+	        wall_input, wall_units, chart_boundary_kind, integ_coords, crossing_level, &
 	        spectre_sbeg_is_toroidal_flux, spectre_ncon_r, spectre_ncon_th, &
 	        spectre_ncon_phi, spectre_ncon_order, spectre_ncon_ode_max_steps, &
 	        spectre_ncon_ode_relerr, &
@@ -212,6 +214,7 @@ contains
         end if
 
         call validate_boundary_event_tolerances
+        call validate_chart_boundary_kind
         if (min(canonical_grid_nr, canonical_grid_ntheta, &
             canonical_grid_nphi) < 6) then
             error stop 'canonical map grid dimensions must be at least 6'
@@ -234,6 +237,14 @@ contains
         end if
 
     end subroutine read_config
+
+    subroutine validate_chart_boundary_kind
+        select case (trim(chart_boundary_kind))
+        case ('auto', 'lcfs', 'wall', 'domain')
+        case default
+            error stop "chart_boundary_kind must be auto, lcfs, wall, or domain"
+        end select
+    end subroutine validate_chart_boundary_kind
 
     subroutine validate_boundary_event_tolerances
         if (.not. config_value_is_finite(boundary_event_fraction_tolerance) .or. &

--- a/src/params.f90
+++ b/src/params.f90
@@ -141,6 +141,9 @@ module params
     character(1000) :: coord_input = ''
     character(1000) :: wall_input = ''
     character(16) :: wall_units = 'm'
+    !> Radial threshold for querying an external STL wall. A negative value
+    !> means that no external-wall query gate is active for this run.
+    real(dp) :: wall_query_rho_lcfs = -1.0_dp
     character(16) :: chart_boundary_kind = 'auto'
     character(16) :: chart_boundary_kind_effective = 'lcfs'
     integer :: integ_coords = -1000  ! Sentinel: -1000 means user did not set it

--- a/src/restart.f90
+++ b/src/restart.f90
@@ -6,7 +6,7 @@ module restart_mod
         trap_par, perp_inv, zend, &
         confpart_pass, confpart_trap, ntimstep, kt_macro, &
         v0, dtaumin, trace_time, ORBIT_EXIT_COMPLETED, &
-        ORBIT_EXIT_LCFS, ORBIT_EXIT_WALL
+        ORBIT_EXIT_LCFS, ORBIT_EXIT_WALL, ORBIT_EXIT_NUMERICAL_CONFINED
     implicit none
     private
 
@@ -65,7 +65,8 @@ contains
                 boundary_event_time_width(idx) = time_width
                 particle_done(idx) = exit_code == ORBIT_EXIT_COMPLETED .or. &
                     exit_code == ORBIT_EXIT_LCFS .or. &
-                    exit_code == ORBIT_EXIT_WALL
+                    exit_code == ORBIT_EXIT_WALL .or. &
+                    exit_code == ORBIT_EXIT_NUMERICAL_CONFINED
             end do
             close (unit)
         end if

--- a/src/simple.f90
+++ b/src/simple.f90
@@ -173,7 +173,7 @@ contains
                           rtol_init, mode_init)
   end subroutine init_sympl
 
-  subroutine reseed_sympl(si, f, z0)
+  subroutine reseed_sympl(si, f, z0, momentum_reference)
     !> Re-seed one particle's symplectic state from standard GC coordinates.
     !>
     !> Unlike init_sympl/orbit_sympl_init this routine does not select the
@@ -183,9 +183,13 @@ contains
     type(symplectic_integrator_t), intent(inout) :: si
     type(field_can_t), intent(inout) :: f
     real(dp), intent(in) :: z0(:)
+    real(dp), intent(in), optional :: momentum_reference
+    real(dp) :: z_seed(size(z0))
 
-    si%pabs = z0(4)
-    call encode_symplectic_state(f, z0, si%z)
+    z_seed = z0
+    if (present(momentum_reference)) z_seed(4) = momentum_reference
+    si%pabs = z_seed(4)
+    call encode_symplectic_state(f, z_seed, si%z)
     call get_val(f, si%z(4))
     si%pthold = f%pth
     si%last_step_fraction = 1.d0
@@ -273,6 +277,88 @@ contains
     z(4) = fo%pabs
     z(5) = vpar/(z(4)*dsqrt(2d0))
   end subroutine orbit_timestep_fo
+
+  subroutine orbit_timestep_fo_bridge(fo, z, interval, ierr, continue_state)
+    !> Advance one failed guiding-centre interval with the physical Cartesian
+    !> Lorentz pusher. This is a narrow warning-mode bridge for reference fields
+    !> that are already splined on the chartmap; normal GC trajectories never
+    !> enter it. The Boris substeps resolve at most 0.1 rad of gyro-rotation.
+    use orbit_fo_boris, only: fo_init_reference, fo_step, &
+      fo_to_reference_gc, FO_OK, FO_LOSS
+    use orbit_fo_field, only: fo_eval_reference_field, &
+      fo_reference_field_available
+    use field_can_mod, only: integ_to_ref, ref_to_integ
+    type(fo_state_t), intent(inout) :: fo
+    real(dp), intent(inout) :: z(5)
+    real(dp), intent(in) :: interval
+    integer, intent(out) :: ierr
+    logical, intent(in), optional :: continue_state
+    real(dp), parameter :: max_rotation_parameter = 0.05_dp
+    integer, parameter :: max_substeps = 100000
+    real(dp) :: z_start(5), u_gc(3), hcov(3), Bmod, mu
+    real(dp) :: ro0_bar, vpar_bar, vperp, remaining, h, vpar_out
+    integer :: status, nstep
+    logical :: continuing
+
+    z_start = z
+    ierr = 2
+    continuing = .false.
+    if (present(continue_state)) continuing = continue_state
+    if (.not. fo_reference_field_available()) return
+    if (z(4) <= 0.0_dp .or. abs(z(5)) > 1.0_dp) return
+
+    ro0_bar = ro0/sqrt(2.0_dp)
+    if (.not. continuing) then
+      call integ_to_ref(z(1:3), u_gc)
+      if (u_gc(1) <= 0.0_dp .or. u_gc(1) >= 1.0_dp) return
+      call fo_eval_reference_field(u_gc, hcov, Bmod, status)
+      if (status /= 0 .or. Bmod <= 0.0_dp) return
+
+      mu = z(4)**2*(1.0_dp - z(5)**2)/Bmod
+      vpar_bar = sqrt(2.0_dp)*z(4)*z(5)
+      vperp = sqrt(max(2.0_dp*mu*Bmod, 0.0_dp))
+      call fo_init_reference(fo, u_gc, vpar_bar, vperp, mu, 1.0_dp, &
+        1.0_dp, 0.0_dp, ro0_bar, z(4))
+    else if (.not. fo%reference_field) then
+      return
+    end if
+
+    remaining = abs(interval)/sqrt(2.0_dp)
+    do nstep = 1, max_substeps
+      if (remaining <= epsilon(1.0_dp)*max(abs(interval), 1.0_dp)) exit
+      call fo_eval_reference_field(fo%u, hcov, Bmod, status)
+      if (status /= 0 .or. Bmod <= 0.0_dp) then
+        z = z_start
+        return
+      end if
+      h = min(remaining, 2.0_dp*max_rotation_parameter*ro0_bar/Bmod)
+      fo%dt = sign(h, interval)
+      call fo_step(fo, status)
+      if (status /= FO_OK) then
+        z = z_start
+        return
+      end if
+      remaining = remaining - h
+    end do
+    if (remaining > epsilon(1.0_dp)*max(abs(interval), 1.0_dp)) then
+      z = z_start
+      return
+    end if
+
+    call fo_to_reference_gc(fo, u_gc, vpar_out, status)
+    if (status /= FO_OK .and. status /= FO_LOSS) then
+      z = z_start
+      return
+    end if
+    call ref_to_integ(u_gc, z(1:3))
+    z(4) = fo%pabs
+    z(5) = vpar_out/(sqrt(2.0_dp)*z(4))
+    if (status == FO_LOSS) then
+      ierr = 1
+    else
+      ierr = 0
+    end if
+  end subroutine orbit_timestep_fo_bridge
 
   subroutine timestep(self, s, th, ph, lam, ierr)
     type(tracer_t), intent(inout) :: self

--- a/src/simple_gpu.f90
+++ b/src/simple_gpu.f90
@@ -15,8 +15,7 @@ module simple_gpu
     use orbit_symplectic_base, only: symplectic_integrator_t, &
         SYMPLECTIC_STEP_OK, SYMPLECTIC_STEP_OUTSIDE_DOMAIN, &
         SYMPLECTIC_STEP_MAXITER, SYMPLECTIC_STEP_LINEAR_SOLVE, &
-        SYMPLECTIC_STEP_BOUNDARY_LIMITED, symplectic_newton_warning_mode, &
-        symplectic_newton_warning_factor
+        SYMPLECTIC_STEP_BOUNDARY_LIMITED, symplectic_newton_warning_mode
     use orbit_symplectic_euler1, only: sympl_euler1_newton_iter
     use orbit_symplectic_euler1, only: sympl_euler1_extrapolate_field, sympl_euler1_advance_angles
     use boozer_sub, only: boozer_state
@@ -109,7 +108,7 @@ contains
         else if (warning_mode .and. gpu_finite_iterate(x) .and. &
                  gpu_finite_iterate(xlast) .and. gpu_finite_iterate(tolref) .and. &
                  all(abs(x - xlast) <= &
-                     symplectic_newton_warning_factor*si%rtol*abs(tolref))) then
+                     si%warning_factor*si%rtol*abs(tolref))) then
             status = SYMPLECTIC_STEP_OK
         end if
         ! Non-convergence diagnostics (CPU writes fort.6601) are omitted on device.

--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -19,6 +19,7 @@ module simple_main
         zend, trap_par, perp_inv, sbeg, ntimstep, should_skip, &
         reset_seed_if_deterministic, field_input, isw_field_type, reuse_batch, &
         coord_input, wall_input, wall_units, wall_hit, wall_hit_cart, &
+        wall_query_rho_lcfs, &
         chart_boundary_kind, chart_boundary_kind_effective, &
         wall_hit_normal_cart, wall_hit_cos_incidence, wall_hit_angle_rad, &
         ntau_macro, kt_macro, checkpoint_interval, orbit_model, orbit_coord, &
@@ -498,6 +499,7 @@ contains
         map_boundary_exit_code = ORBIT_EXIT_LCFS
         chart_boundary_kind_effective = 'lcfs'
         chartmap_cart_scale_to_m = -1.0d0
+        wall_query_rho_lcfs = -1.0d0
 
         if (.not. allocated(ref_coords)) then
             if (len_trim(wall_input) == 0) return
@@ -533,6 +535,13 @@ contains
         end select
 
         if (len_trim(wall_input) == 0) return
+
+        ! The STL is an external physical wall enclosing the LCFS. Querying a
+        ! straight Cartesian chord while the accepted endpoint is still inside
+        ! the LCFS can create a false intersection in a non-convex toroidal
+        ! geometry. Preserve the historical SIMPLE rule: activate wall queries
+        ! only once an accepted microstep endpoint has passed the recorded LCFS.
+        wall_query_rho_lcfs = meta%rho_lcfs
 
         units = adjustl(wall_units)
         select case (trim(units))
@@ -1919,6 +1928,8 @@ contains
 
         hit = .false.
         hit_step = start_step + segment_steps
+        if (wall_query_rho_lcfs >= 0.0_dp .and. &
+                u_end(1) <= wall_query_rho_lcfs) return
         call stl_wall_first_hit_segment_with_normal( &
             wall, x_start_m, x_end_m, hit, x_hit_m, normal_m)
         if (.not. hit) return

--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -7,6 +7,7 @@ module simple_main
         ORBIT_FO_NUMERICAL
     use diag_mod, only: icounter
     use collis_alp, only: loacol_alpha, stost, init_collision_profiles
+    use magfie_sub, only: ALBERT
     use samplers, only: sample
     use field_can_mod, only: field_can_t, integ_to_ref, ref_to_integ, &
         init_field_can
@@ -79,6 +80,7 @@ module simple_main
     integer, parameter :: RECOVERY_STEP_AXIS = 1
     integer, parameter :: RECOVERY_STEP_TOROIDAL = 2
     integer, parameter :: RECOVERY_STEP_FULL_ORBIT = 3
+    real(dp), parameter :: MOMENTUM_SANITY_FRACTION = 0.005_dp
 
     type :: rk_recovery_state_t
         logical :: active = .false.
@@ -92,14 +94,33 @@ module simple_main
 
 contains
 
-    subroutine orbit_timestep_recovery(fo, z, interval, tolerance, ierr, method)
+    logical function recovery_state_has_valid_phase_space(z)
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+
+        real(dp), intent(in) :: z(5)
+
+        recovery_state_has_valid_phase_space = all(ieee_is_finite(z)) .and. &
+            z(4) > 0.0_dp .and. &
+            abs(z(5)) <= 1.0_dp + 100.0_dp*epsilon(1.0_dp)
+    end function recovery_state_has_valid_phase_space
+
+    logical function recovery_state_is_physical(z, expected_momentum)
+        real(dp), intent(in) :: z(5), expected_momentum
+
+        recovery_state_is_physical = recovery_state_has_valid_phase_space(z) .and. &
+            abs(z(4) - expected_momentum) <= &
+            MOMENTUM_SANITY_FRACTION*max(abs(expected_momentum), tiny(1.0_dp))
+    end function recovery_state_is_physical
+
+    subroutine orbit_timestep_recovery(fo, z, interval, tolerance, &
+            expected_momentum, ierr, method)
         use alpha_lifetime_sub, only: orbit_timestep_axis, &
             bstar_parallel_factor, orbit_timestep_toroidal_regularized
         use orbit_fo_boris, only: fo_state_t
 
         type(fo_state_t), intent(inout) :: fo
         real(dp), intent(inout) :: z(5)
-        real(dp), intent(in) :: interval, tolerance
+        real(dp), intent(in) :: interval, tolerance, expected_momentum
         integer, intent(out) :: ierr
         integer, intent(out) :: method
         real(dp) :: z_start(5)
@@ -110,16 +131,27 @@ contains
         z_start = z
         call orbit_timestep_axis(z, interval, interval, tolerance, ierr, &
             RK_RECOVERY_STEP_LIMIT)
+        if (ierr == 0) then
+            if (.not. recovery_state_is_physical(z, expected_momentum)) ierr = 2
+        else if (ierr == 1) then
+            if (.not. recovery_state_has_valid_phase_space(z)) ierr = 2
+        end if
         if (ierr /= 2) return
 
         call bstar_parallel_factor(z_start, bstar_factor)
         call integ_to_ref(z_start(1:3), x_reference)
         if (x_reference(1) < RK_RECOVERY_AXIS_ENTER .and. &
-                abs(bstar_factor) >= FO_BRIDGE_BSTAR_ENTER) then
+            abs(bstar_factor) >= FO_BRIDGE_BSTAR_ENTER) then
             z = z_start
             call orbit_timestep_axis(z, interval, interval, tolerance, ierr, &
                 RK_RECOVERY_STEP_LIMIT, RK_RECOVERY_AXIS_FLOOR, &
                 RK_RECOVERY_AXIS_ENTER)
+            if (ierr == 0) then
+                if (.not. recovery_state_is_physical(z, expected_momentum)) &
+                    ierr = 2
+            else if (ierr == 1) then
+                if (.not. recovery_state_has_valid_phase_space(z)) ierr = 2
+            end if
             if (ierr /= 2) then
                 method = RECOVERY_STEP_AXIS
                 return
@@ -131,17 +163,27 @@ contains
             max(tolerance, 1.0e-10_dp), ierr, &
             TOROIDAL_RECOVERY_STEP_LIMIT)
         if (ierr == 0) then
-            method = RECOVERY_STEP_TOROIDAL
-            call count_event(EVT_TOROIDAL_REGULARIZATION)
-            return
+            if (recovery_state_is_physical(z, expected_momentum)) then
+                method = RECOVERY_STEP_TOROIDAL
+                call count_event(EVT_TOROIDAL_REGULARIZATION)
+                return
+            end if
+            ierr = 2
+        end if
+        if (ierr == 1) then
+            if (.not. recovery_state_has_valid_phase_space(z)) ierr = 2
         end if
         if (ierr /= 2 .or. x_reference(1) >= FO_AXIS_ENTER) return
 
         z = z_start
         call orbit_timestep_fo_bridge(fo, z, interval, ierr)
         if (ierr == 0) then
-            method = RECOVERY_STEP_FULL_ORBIT
-            call count_event(EVT_AXIS_FO_BRIDGE)
+            if (recovery_state_is_physical(z, expected_momentum)) then
+                method = RECOVERY_STEP_FULL_ORBIT
+                call count_event(EVT_AXIS_FO_BRIDGE)
+            else
+                ierr = 2
+            end if
         end if
     end subroutine orbit_timestep_recovery
 
@@ -519,7 +561,7 @@ contains
                 canonical_grid_ntheta, canonical_grid_nphi, &
                 canonical_ode_relerr)
             if (isw_field_type == BOOZER .or. &
-                    isw_field_type == CANFLUX) then
+                isw_field_type == CANFLUX) then
                 call set_magfie_refcoords_field(field_temp)
             end if
             call print_phase_time('Canonical field initialization completed')
@@ -1781,13 +1823,9 @@ contains
         real(dp), intent(in) :: z_start(5), z_end(5), field_period
         real(dp), intent(out) :: z_event(5), event_fraction
         integer, intent(inout) :: ierr
-        real(dp), parameter :: radial_sanity_band = 0.05_dp
-        real(dp), parameter :: max_local_radial_step = 0.5_dp
-        real(dp) :: u_event(3)
 
         if (.not. all(ieee_is_finite(z_start)) .or. &
-            .not. all(ieee_is_finite(z_end)) .or. &
-            abs(z_end(1) - z_start(1)) > max_local_radial_step) then
+            .not. all(ieee_is_finite(z_end))) then
             z_event = z_start
             event_fraction = 0.0_dp
             ierr = 2
@@ -1796,19 +1834,82 @@ contains
 
         call locate_linear_lcfs(z_start, z_end, field_period, z_event, &
             event_fraction)
-        call integ_to_ref(z_event(1:3), u_event)
         if (all(ieee_is_finite(z_event)) .and. &
-            all(ieee_is_finite(u_event)) .and. &
-            abs(u_event(1) - 1.0_dp) <= radial_sanity_band) return
+            event_fraction >= 0.0_dp .and. event_fraction <= 1.0_dp .and. &
+            recovery_state_is_physical(z_event, z_start(4))) return
 
-        ! The legacy RK chamber flag is based on its first integration
-        ! coordinate. In a canonical map, a gross numerical jump can therefore
-        ! resemble an LCFS crossing. Do not turn that failure into a physical
-        ! loss unless the candidate is local and maps back to a finite LCFS point.
+        ! The legacy chamber is the native integration-coordinate surface
+        ! z(1)=1, which need not coincide with reference rho=1 for a perturbed
+        ! canonical map. Accept only a physical event inside the attempted
+        ! microstep; never extrapolate a chamber flag into a loss.
         z_event = z_start
         event_fraction = 0.0_dp
         ierr = 2
     end subroutine locate_validated_lcfs
+
+    logical function crosses_reference_boundary(z_start, z_end)
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+
+        real(dp), intent(in) :: z_start(5), z_end(5)
+        real(dp) :: u_start(3), u_end(3)
+
+        crosses_reference_boundary = .false.
+        if (.not. all(ieee_is_finite(z_start)) .or. &
+            .not. all(ieee_is_finite(z_end))) return
+        call integ_to_ref(z_start(1:3), u_start)
+        call integ_to_ref(z_end(1:3), u_end)
+        if (.not. all(ieee_is_finite(u_start)) .or. &
+            .not. all(ieee_is_finite(u_end))) return
+        crosses_reference_boundary = u_start(1) < 1.0_dp .and. &
+            u_end(1) >= 1.0_dp
+    end function crosses_reference_boundary
+
+    subroutine locate_reference_crossing(z_start, z_end, field_period, &
+            z_event, event_fraction, found)
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+
+        real(dp), intent(in) :: z_start(5), z_end(5), field_period
+        real(dp), intent(out) :: z_event(5), event_fraction
+        logical, intent(out) :: found
+        real(dp) :: delta(5), z_trial(5), u_start(3), u_end(3), u_trial(3)
+        real(dp) :: fraction_low, fraction_high, fraction_mid
+        integer :: iteration
+
+        found = .false.
+        z_event = z_start
+        event_fraction = 0.0_dp
+        if (.not. all(ieee_is_finite(z_start)) .or. &
+            .not. all(ieee_is_finite(z_end))) return
+        call integ_to_ref(z_start(1:3), u_start)
+        call integ_to_ref(z_end(1:3), u_end)
+        if (.not. all(ieee_is_finite(u_start)) .or. &
+            .not. all(ieee_is_finite(u_end))) return
+        if (u_start(1) >= 1.0_dp .or. u_end(1) < 1.0_dp) return
+
+        delta = z_end - z_start
+        delta(2) = modulo(delta(2) + 0.5_dp*twopi, twopi) - 0.5_dp*twopi
+        delta(3) = modulo(delta(3) + 0.5_dp*field_period, field_period) - &
+            0.5_dp*field_period
+        fraction_low = 0.0_dp
+        fraction_high = 1.0_dp
+        do iteration = 1, 64
+            fraction_mid = 0.5_dp*(fraction_low + fraction_high)
+            z_trial = z_start + fraction_mid*delta
+            call integ_to_ref(z_trial(1:3), u_trial)
+            if (.not. all(ieee_is_finite(u_trial))) return
+            if (u_trial(1) >= 1.0_dp) then
+                fraction_high = fraction_mid
+            else
+                fraction_low = fraction_mid
+            end if
+        end do
+        event_fraction = fraction_high
+        z_event = z_start + event_fraction*delta
+        call integ_to_ref(z_event(1:3), u_trial)
+        if (.not. all(ieee_is_finite(u_trial))) return
+        if (abs(u_trial(1) - 1.0_dp) > 0.05_dp) return
+        found = .true.
+    end subroutine locate_reference_crossing
 
     subroutine validate_rk_state(z_start, z_end, ierr, expected_momentum)
         use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
@@ -1817,11 +1918,7 @@ contains
         real(dp), intent(inout) :: z_end(5)
         integer, intent(inout) :: ierr
         real(dp), intent(in), optional :: expected_momentum
-        real(dp), parameter :: radial_sanity_band = 0.05_dp
-        real(dp), parameter :: max_local_radial_step = 0.5_dp
-        real(dp), parameter :: momentum_sanity_fraction = 0.005_dp
         real(dp) :: momentum_reference
-        real(dp) :: u_end(3)
         logical :: momentum_valid
 
         if (ierr /= 0) return
@@ -1830,22 +1927,59 @@ contains
         if (present(expected_momentum)) then
             momentum_reference = expected_momentum
             momentum_valid = abs(z_end(4) - momentum_reference) <= &
-                momentum_sanity_fraction* &
+                MOMENTUM_SANITY_FRACTION* &
                 max(abs(momentum_reference), tiny(1.0_dp))
         end if
         if (all(ieee_is_finite(z_end)) .and. z_end(4) > 0.0_dp .and. &
             abs(z_end(5)) <= 1.0_dp + 100.0_dp*epsilon(1.0_dp) .and. &
-            momentum_valid .and. &
-            abs(z_end(1) - z_start(1)) <= max_local_radial_step) then
-            call integ_to_ref(z_end(1:3), u_end)
-            if (all(ieee_is_finite(u_end)) .and. &
-                u_end(1) >= -radial_sanity_band .and. &
-                u_end(1) <= 1.0_dp + radial_sanity_band) return
-        end if
+            momentum_valid) return
 
         z_end = z_start
         ierr = 2
     end subroutine validate_rk_state
+
+    subroutine validate_rk_step_or_reference_boundary(z_start, z_candidate, &
+            field_period, expected_momentum, z, event_fraction, ierr, &
+            reference_boundary)
+        real(dp), intent(in) :: z_start(5), z_candidate(5), field_period
+        real(dp), intent(in) :: expected_momentum
+        real(dp), intent(inout) :: z(5)
+        real(dp), intent(out) :: event_fraction
+        integer, intent(inout) :: ierr
+        logical, intent(out) :: reference_boundary
+        integer :: step_ierr
+
+        reference_boundary = .false.
+        event_fraction = 0.0_dp
+        step_ierr = ierr
+        if (step_ierr /= 0 .and. step_ierr /= 1) return
+
+        if (isw_field_type == ALBERT) then
+            if (crosses_reference_boundary(z_start, z_candidate)) then
+                call locate_reference_crossing(z_start, z_candidate, &
+                    field_period, z, event_fraction, reference_boundary)
+                if (reference_boundary) then
+                    ierr = 0
+                    call validate_rk_state(z_start, z, ierr, expected_momentum)
+                    if (ierr == 0) then
+                        ierr = 1
+                        return
+                    end if
+                    reference_boundary = .false.
+                end if
+            end if
+        end if
+
+        if (step_ierr == 1) then
+            z = z_candidate
+            ierr = step_ierr
+            return
+        end if
+
+        z = z_candidate
+        ierr = 0
+        call validate_rk_state(z_start, z, ierr, expected_momentum)
+    end subroutine validate_rk_step_or_reference_boundary
 
     subroutine macrostep(anorb, z, kt, ierr_orbit, ntau_local, exit_step, &
             hold_streak, numerical_hold_any, rk_recovery)
@@ -1865,7 +1999,9 @@ contains
 
         integer :: hold_streak_local, ktau, recovery_method
         real(dp) :: z_step_start(5), z_step_end(5), loss_fraction
+        real(dp) :: u_event(3)
         logical :: numerical_hold, numerical_hold_any_local
+        logical :: reference_boundary
         type(rk_recovery_state_t) :: rk_recovery_local
         type(symplectic_integrator_t) :: si_step_start
         type(field_can_t) :: f_step_start
@@ -1879,6 +2015,7 @@ contains
 
         do ktau = 1, ntau_local
             numerical_hold = .false.
+            reference_boundary = .false.
             z_step_start = z
             if (orbit_model == ORBIT_FULL_ORBIT) then
                 call orbit_timestep_fo(anorb%fo, z, ierr_orbit)
@@ -1909,19 +2046,26 @@ contains
             if (integmode <= 0 .or. rk_recovery_local%active) then
                 if (rk_recovery_local%active) then
                     call orbit_timestep_recovery(anorb%fo, z, dtaumin, relerr, &
-                        ierr_orbit, recovery_method)
+                        merge(rk_recovery_local%momentum_reference, &
+                        z_step_start(4), &
+                        rk_recovery_local%has_momentum_reference), ierr_orbit, &
+                        recovery_method)
                 else
                     call orbit_timestep_axis(z, dtaumin, dtaumin, relerr, &
                         ierr_orbit)
                 end if
+                z_step_end = z
                 if (rk_recovery_local%has_momentum_reference) then
-                    call validate_rk_state(z_step_start, z, ierr_orbit, &
-                        rk_recovery_local%momentum_reference)
+                    call validate_rk_step_or_reference_boundary(z_step_start, &
+                        z_step_end, anorb%fper, &
+                        rk_recovery_local%momentum_reference, z, loss_fraction, &
+                        ierr_orbit, reference_boundary)
                 else
-                    call validate_rk_state(z_step_start, z, ierr_orbit, &
-                        z_step_start(4))
+                    call validate_rk_step_or_reference_boundary(z_step_start, &
+                        z_step_end, anorb%fper, z_step_start(4), z, &
+                        loss_fraction, ierr_orbit, reference_boundary)
                 end if
-                if (ierr_orbit == 1) then
+                if (ierr_orbit == 1 .and. .not. reference_boundary) then
                     z_step_end = z
                     call locate_validated_lcfs(z_step_start, z_step_end, &
                         anorb%fper, z, loss_fraction, ierr_orbit)
@@ -1932,7 +2076,14 @@ contains
                     end if
                     if (rk_recovery_local%active) then
                         anorb%si%last_step_fraction = loss_fraction
-                        anorb%si%last_event_radial_residual = abs(z(1) - 1.d0)
+                        if (reference_boundary) then
+                            call integ_to_ref(z(1:3), u_event)
+                            anorb%si%last_event_radial_residual = &
+                                abs(u_event(1) - 1.d0)
+                        else
+                            anorb%si%last_event_radial_residual = &
+                                abs(z(1) - 1.d0)
+                        end if
                         anorb%si%last_event_fraction_width = 1.d0
                         ierr_orbit = SYMPLECTIC_STEP_BOUNDARY
                     end if
@@ -1949,15 +2100,25 @@ contains
                     orbit_timestep_sympl, ierr_orbit)
                 if (ierr_orbit == 0) then
                     call to_standard_z_coordinates(anorb, z)
-                    call validate_rk_state(z_step_start, z, ierr_orbit, &
-                        si_step_start%pabs)
-                    if (ierr_orbit /= 0) then
+                    z_step_end = z
+                    call validate_rk_step_or_reference_boundary(z_step_start, &
+                        z_step_end, anorb%fper, si_step_start%pabs, z, &
+                        loss_fraction, ierr_orbit, reference_boundary)
+                    if (reference_boundary .and. ierr_orbit == 1) then
+                        call integ_to_ref(z(1:3), u_event)
+                        anorb%si%last_step_fraction = loss_fraction
+                        anorb%si%last_event_radial_residual = &
+                            abs(u_event(1) - 1.d0)
+                        anorb%si%last_event_fraction_width = 1.d0
+                        ierr_orbit = SYMPLECTIC_STEP_BOUNDARY
+                    else if (ierr_orbit /= 0) then
                         anorb%si = si_step_start
                         anorb%f = f_step_start
                     end if
                 end if
                 if (ierr_orbit == SYMPLECTIC_STEP_BOUNDARY) then
-                    call to_standard_z_coordinates(anorb, z)
+                    if (.not. reference_boundary) &
+                        call to_standard_z_coordinates(anorb, z)
                     if (present(exit_step)) exit_step = real(kt, dp) + &
                         anorb%si%last_step_fraction
                     exit
@@ -1973,10 +2134,12 @@ contains
                     z = z_step_start
                     z(4) = si_step_start%pabs
                     call orbit_timestep_recovery(anorb%fo, z, dtaumin, relerr, &
-                        ierr_orbit, recovery_method)
-                    call validate_rk_state(z_step_start, z, ierr_orbit, &
-                        si_step_start%pabs)
-                    if (ierr_orbit == 1) then
+                        si_step_start%pabs, ierr_orbit, recovery_method)
+                    z_step_end = z
+                    call validate_rk_step_or_reference_boundary(z_step_start, &
+                        z_step_end, anorb%fper, si_step_start%pabs, z, &
+                        loss_fraction, ierr_orbit, reference_boundary)
+                    if (ierr_orbit == 1 .and. .not. reference_boundary) then
                         z_step_end = z
                         call locate_validated_lcfs(z_step_start, z_step_end, &
                             anorb%fper, z, loss_fraction, ierr_orbit)
@@ -1990,7 +2153,14 @@ contains
                         hold_streak_local = 0
                     else if (ierr_orbit == 1) then
                         anorb%si%last_step_fraction = loss_fraction
-                        anorb%si%last_event_radial_residual = abs(z(1) - 1.d0)
+                        if (reference_boundary) then
+                            call integ_to_ref(z(1:3), u_event)
+                            anorb%si%last_event_radial_residual = &
+                                abs(u_event(1) - 1.d0)
+                        else
+                            anorb%si%last_event_radial_residual = &
+                                abs(z(1) - 1.d0)
+                        end if
                         anorb%si%last_event_fraction_width = 1.d0
                         if (present(exit_step)) exit_step = real(kt, dp) + &
                             loss_fraction
@@ -2157,6 +2327,7 @@ contains
         real(dp) :: boundary_fraction
         real(dp) :: wall_exit_step
         logical :: hit, numerical_hold, numerical_hold_any_local
+        logical :: reference_boundary
         type(rk_recovery_state_t) :: rk_recovery_local
         type(symplectic_integrator_t) :: si_step_start
         type(field_can_t) :: f_step_start
@@ -2170,24 +2341,32 @@ contains
         if (present(rk_recovery)) rk_recovery_local = rk_recovery
         do ktau = 1, ntau_local
             numerical_hold = .false.
+            reference_boundary = .false.
             segment_duration = 1.0_dp
             z_step_start = z
             if (integmode <= 0 .or. rk_recovery_local%active) then
                 if (rk_recovery_local%active) then
                     call orbit_timestep_recovery(anorb%fo, z, dtaumin, relerr, &
-                        ierr_orbit, recovery_method)
+                        merge(rk_recovery_local%momentum_reference, &
+                        z_step_start(4), &
+                        rk_recovery_local%has_momentum_reference), ierr_orbit, &
+                        recovery_method)
                 else
                     call orbit_timestep_axis(z, dtaumin, dtaumin, relerr, &
                         ierr_orbit)
                 end if
+                z_step_end = z
                 if (rk_recovery_local%has_momentum_reference) then
-                    call validate_rk_state(z_step_start, z, ierr_orbit, &
-                        rk_recovery_local%momentum_reference)
+                    call validate_rk_step_or_reference_boundary(z_step_start, &
+                        z_step_end, anorb%fper, &
+                        rk_recovery_local%momentum_reference, z, &
+                        boundary_fraction, ierr_orbit, reference_boundary)
                 else
-                    call validate_rk_state(z_step_start, z, ierr_orbit, &
-                        z_step_start(4))
+                    call validate_rk_step_or_reference_boundary(z_step_start, &
+                        z_step_end, anorb%fper, z_step_start(4), z, &
+                        boundary_fraction, ierr_orbit, reference_boundary)
                 end if
-                if (ierr_orbit == 1) then
+                if (ierr_orbit == 1 .and. .not. reference_boundary) then
                     z_step_end = z
                     call locate_validated_lcfs(z_step_start, z_step_end, &
                         anorb%fper, z, boundary_fraction, ierr_orbit)
@@ -2228,16 +2407,27 @@ contains
                     orbit_timestep_sympl, ierr_orbit, segment_duration)
                 if (ierr_orbit == 0) then
                     call to_standard_z_coordinates(anorb, z)
-                    call validate_rk_state(z_step_start, z, ierr_orbit, &
-                        si_step_start%pabs)
-                    if (ierr_orbit /= 0) then
+                    z_step_end = z
+                    call validate_rk_step_or_reference_boundary(z_step_start, &
+                        z_step_end, anorb%fper, si_step_start%pabs, z, &
+                        boundary_fraction, ierr_orbit, reference_boundary)
+                    if (reference_boundary .and. ierr_orbit == 1) then
+                        anorb%si%last_step_fraction = boundary_fraction
+                        anorb%si%last_event_fraction_width = 1.d0
+                        ierr_orbit = SYMPLECTIC_STEP_BOUNDARY
+                    else if (ierr_orbit /= 0) then
                         anorb%si = si_step_start
                         anorb%f = f_step_start
                     end if
                 end if
                 if (ierr_orbit == SYMPLECTIC_STEP_BOUNDARY) then
-                    call to_standard_z_coordinates(anorb, z)
+                    if (.not. reference_boundary) &
+                        call to_standard_z_coordinates(anorb, z)
                     call integ_to_ref(z(1:3), u_ref_cur)
+                    if (reference_boundary) then
+                        anorb%si%last_event_radial_residual = &
+                            abs(u_ref_cur(1) - 1.d0)
+                    end if
                     call ref_coords%evaluate_cart(u_ref_cur, x_cur)
                     x_cur_m = x_cur*chartmap_cart_scale_to_m
                     z_step_end = z
@@ -2260,10 +2450,12 @@ contains
                     z = z_step_start
                     z(4) = si_step_start%pabs
                     call orbit_timestep_recovery(anorb%fo, z, dtaumin, relerr, &
-                        ierr_orbit, recovery_method)
-                    call validate_rk_state(z_step_start, z, ierr_orbit, &
-                        si_step_start%pabs)
-                    if (ierr_orbit == 1) then
+                        si_step_start%pabs, ierr_orbit, recovery_method)
+                    z_step_end = z
+                    call validate_rk_step_or_reference_boundary(z_step_start, &
+                        z_step_end, anorb%fper, si_step_start%pabs, z, &
+                        boundary_fraction, ierr_orbit, reference_boundary)
+                    if (ierr_orbit == 1 .and. .not. reference_boundary) then
                         z_step_end = z
                         call locate_validated_lcfs(z_step_start, z_step_end, &
                             anorb%fper, z, boundary_fraction, ierr_orbit)

--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -3,7 +3,8 @@ module simple_main
     use omp_lib
     use util, only: sqrt2, twopi
     use simple, only: init_vmec, init_sympl, init_fo, orbit_timestep_fo, &
-        reseed_sympl, tracer_t, ORBIT_FO_LOSS, ORBIT_FO_NUMERICAL
+        orbit_timestep_fo_bridge, reseed_sympl, tracer_t, ORBIT_FO_LOSS, &
+        ORBIT_FO_NUMERICAL
     use diag_mod, only: icounter
     use collis_alp, only: loacol_alpha, stost, init_collision_profiles
     use samplers, only: sample
@@ -32,7 +33,8 @@ module simple_main
         canonical_grid_nphi, canonical_ode_relerr
     use diag_counters, only: diag_counters_init, count_event, &
         EVT_WARNING_STEP_SKIP, EVT_SYMPLECTIC_RK_RECOVERY, &
-        EVT_SYMPLECTIC_RESUME
+        EVT_SYMPLECTIC_RESUME, EVT_TOROIDAL_REGULARIZATION, &
+        EVT_AXIS_FO_BRIDGE
     use progress_monitor, only: progress_init, progress_tick, progress_finalize
     use restart_mod, only: particle_done, read_restart_data, restore_confined_counts
     use chartmap_metadata, only: chartmap_metadata_t, read_chartmap_metadata
@@ -60,74 +62,150 @@ module simple_main
     integer, parameter :: RK_RECOVERY_GENERIC = 1
     integer, parameter :: RK_RECOVERY_AXIS = 2
     integer, parameter :: RK_RECOVERY_EDGE = 3
-    real(dp), parameter :: RK_AXIS_ENTER = 0.01_dp
-    real(dp), parameter :: RK_AXIS_EXIT = 0.02_dp
+    real(dp), parameter :: RK_AXIS_ENTER = 0.1_dp
+    real(dp), parameter :: RK_AXIS_EXIT = 0.12_dp
+    real(dp), parameter :: FO_AXIS_ENTER = 0.02_dp
     real(dp), parameter :: RK_EDGE_ENTER = 0.98_dp
     integer, parameter :: RK_RECOVERY_STEP_LIMIT = 10000
+    integer, parameter :: TOROIDAL_RECOVERY_STEP_LIMIT = 100000
+    integer, parameter :: RK_SAFE_STREAK_TO_RESUME = 256
     real(dp), parameter :: RK_RECOVERY_AXIS_ENTER = 0.1_dp
     ! Retry only a failed legacy axis solve with a smoother, still axis-local
     ! Cartesian regularization. Successful release-era RK paths stay unchanged.
     real(dp), parameter :: RK_RECOVERY_AXIS_FLOOR = 1.0e-3_dp
+    real(dp), parameter :: FO_BRIDGE_BSTAR_ENTER = 0.2_dp
+    real(dp), parameter :: RK_RECOVERY_BSTAR_EXIT = 0.3_dp
+    integer, parameter :: RECOVERY_STEP_STANDARD = 0
+    integer, parameter :: RECOVERY_STEP_AXIS = 1
+    integer, parameter :: RECOVERY_STEP_TOROIDAL = 2
+    integer, parameter :: RECOVERY_STEP_FULL_ORBIT = 3
 
     type :: rk_recovery_state_t
         logical :: active = .false.
+        logical :: has_momentum_reference = .false.
         integer :: reason = RK_RECOVERY_GENERIC
         integer :: steps = 0
+        integer :: safe_steps = 0
         integer :: failures = 0
+        real(dp) :: momentum_reference = 0.0_dp
     end type rk_recovery_state_t
 
 contains
 
-    subroutine orbit_timestep_recovery(z, interval, tolerance, ierr)
-        use alpha_lifetime_sub, only: orbit_timestep_axis
+    subroutine orbit_timestep_recovery(fo, z, interval, tolerance, ierr, method)
+        use alpha_lifetime_sub, only: orbit_timestep_axis, &
+            bstar_parallel_factor, orbit_timestep_toroidal_regularized
+        use orbit_fo_boris, only: fo_state_t
 
+        type(fo_state_t), intent(inout) :: fo
         real(dp), intent(inout) :: z(5)
         real(dp), intent(in) :: interval, tolerance
         integer, intent(out) :: ierr
+        integer, intent(out) :: method
         real(dp) :: z_start(5)
+        real(dp) :: bstar_factor
+        real(dp) :: x_reference(3)
 
+        method = RECOVERY_STEP_STANDARD
         z_start = z
         call orbit_timestep_axis(z, interval, interval, tolerance, ierr, &
             RK_RECOVERY_STEP_LIMIT)
-        if (ierr /= 2 .or. z_start(1) >= RK_RECOVERY_AXIS_ENTER) return
+        if (ierr /= 2) return
+
+        call bstar_parallel_factor(z_start, bstar_factor)
+        call integ_to_ref(z_start(1:3), x_reference)
+        if (x_reference(1) < RK_RECOVERY_AXIS_ENTER .and. &
+                abs(bstar_factor) >= FO_BRIDGE_BSTAR_ENTER) then
+            z = z_start
+            call orbit_timestep_axis(z, interval, interval, tolerance, ierr, &
+                RK_RECOVERY_STEP_LIMIT, RK_RECOVERY_AXIS_FLOOR, &
+                RK_RECOVERY_AXIS_ENTER)
+            if (ierr /= 2) then
+                method = RECOVERY_STEP_AXIS
+                return
+            end if
+        end if
 
         z = z_start
-        call orbit_timestep_axis(z, interval, interval, tolerance, ierr, &
-            RK_RECOVERY_STEP_LIMIT, RK_RECOVERY_AXIS_FLOOR, &
-            RK_RECOVERY_AXIS_ENTER)
+        call orbit_timestep_toroidal_regularized(z, interval, &
+            max(tolerance, 1.0e-10_dp), ierr, &
+            TOROIDAL_RECOVERY_STEP_LIMIT)
+        if (ierr == 0) then
+            method = RECOVERY_STEP_TOROIDAL
+            call count_event(EVT_TOROIDAL_REGULARIZATION)
+            return
+        end if
+        if (ierr /= 2 .or. x_reference(1) >= FO_AXIS_ENTER) return
+
+        z = z_start
+        call orbit_timestep_fo_bridge(fo, z, interval, ierr)
+        if (ierr == 0) then
+            method = RECOVERY_STEP_FULL_ORBIT
+            call count_event(EVT_AXIS_FO_BRIDGE)
+        end if
     end subroutine orbit_timestep_recovery
 
-    pure subroutine activate_rk_recovery(state, radius)
+    subroutine activate_rk_recovery(state, z, momentum_reference)
         type(rk_recovery_state_t), intent(inout) :: state
-        real(dp), intent(in) :: radius
+        real(dp), intent(in) :: z(5), momentum_reference
+        real(dp) :: x_reference(3)
 
+        call integ_to_ref(z(1:3), x_reference)
         state%active = .true.
+        state%has_momentum_reference = .true.
         state%steps = 0
+        state%safe_steps = 0
+        state%momentum_reference = momentum_reference
         state%failures = min(state%failures + 1, 9)
-        if (radius < RK_AXIS_ENTER) then
+        if (x_reference(1) < RK_AXIS_ENTER) then
             state%reason = RK_RECOVERY_AXIS
-        else if (radius > RK_EDGE_ENTER) then
+        else if (x_reference(1) > RK_EDGE_ENTER) then
             state%reason = RK_RECOVERY_EDGE
         else
             state%reason = RK_RECOVERY_GENERIC
         end if
     end subroutine activate_rk_recovery
 
-    pure logical function should_resume_symplectic(state, radius)
+    logical function should_resume_symplectic(state, z)
         type(rk_recovery_state_t), intent(in) :: state
-        real(dp), intent(in) :: radius
+        real(dp), intent(in) :: z(5)
         integer :: cooldown
+        real(dp) :: x_reference(3)
 
+        call integ_to_ref(z(1:3), x_reference)
         select case (state%reason)
         case (RK_RECOVERY_AXIS)
-            should_resume_symplectic = radius >= RK_AXIS_EXIT
+            should_resume_symplectic = x_reference(1) >= RK_AXIS_EXIT .and. &
+                state%safe_steps >= RK_SAFE_STREAK_TO_RESUME
         case (RK_RECOVERY_EDGE)
-            should_resume_symplectic = radius <= RK_EDGE_ENTER
+            should_resume_symplectic = x_reference(1) <= RK_EDGE_ENTER .and. &
+                state%safe_steps >= RK_SAFE_STREAK_TO_RESUME
         case default
             cooldown = 2**(7 + state%failures)
-            should_resume_symplectic = state%steps >= cooldown
+            should_resume_symplectic = state%safe_steps >= cooldown
         end select
     end function should_resume_symplectic
+
+    subroutine update_recovery_streak(state, z, method)
+        use alpha_lifetime_sub, only: bstar_parallel_factor
+
+        type(rk_recovery_state_t), intent(inout) :: state
+        real(dp), intent(in) :: z(5)
+        integer, intent(in) :: method
+        real(dp) :: bstar_factor
+
+        state%steps = state%steps + 1
+        if (method /= RECOVERY_STEP_STANDARD) then
+            state%safe_steps = 0
+            return
+        end if
+        call bstar_parallel_factor(z, bstar_factor)
+        if (abs(bstar_factor) < RK_RECOVERY_BSTAR_EXIT) then
+            state%safe_steps = 0
+            return
+        end if
+        state%safe_steps = state%safe_steps + 1
+    end subroutine update_recovery_streak
 
     subroutine main
         use params, only: read_config, netcdffile, ns_s, ns_tp, multharm, &
@@ -440,6 +518,10 @@ contains
             call init_field_can(isw_field_type, field_temp, canonical_grid_nr, &
                 canonical_grid_ntheta, canonical_grid_nphi, &
                 canonical_ode_relerr)
+            if (isw_field_type == BOOZER .or. &
+                    isw_field_type == CANFLUX) then
+                call set_magfie_refcoords_field(field_temp)
+            end if
             call print_phase_time('Canonical field initialization completed')
         end if
     end subroutine init_field
@@ -1737,7 +1819,7 @@ contains
         real(dp), intent(in), optional :: expected_momentum
         real(dp), parameter :: radial_sanity_band = 0.05_dp
         real(dp), parameter :: max_local_radial_step = 0.5_dp
-        real(dp), parameter :: momentum_sanity_fraction = 0.05_dp
+        real(dp), parameter :: momentum_sanity_fraction = 0.005_dp
         real(dp) :: momentum_reference
         real(dp) :: u_end(3)
         logical :: momentum_valid
@@ -1781,7 +1863,7 @@ contains
         logical, intent(out), optional :: numerical_hold_any
         type(rk_recovery_state_t), intent(inout), optional :: rk_recovery
 
-        integer :: hold_streak_local, ktau
+        integer :: hold_streak_local, ktau, recovery_method
         real(dp) :: z_step_start(5), z_step_end(5), loss_fraction
         logical :: numerical_hold, numerical_hold_any_local
         type(rk_recovery_state_t) :: rk_recovery_local
@@ -1826,14 +1908,19 @@ contains
             end if
             if (integmode <= 0 .or. rk_recovery_local%active) then
                 if (rk_recovery_local%active) then
-                    call orbit_timestep_recovery(z, dtaumin, relerr, &
-                        ierr_orbit)
+                    call orbit_timestep_recovery(anorb%fo, z, dtaumin, relerr, &
+                        ierr_orbit, recovery_method)
                 else
                     call orbit_timestep_axis(z, dtaumin, dtaumin, relerr, &
                         ierr_orbit)
                 end if
-                call validate_rk_state(z_step_start, z, ierr_orbit, &
-                    z_step_start(4))
+                if (rk_recovery_local%has_momentum_reference) then
+                    call validate_rk_state(z_step_start, z, ierr_orbit, &
+                        rk_recovery_local%momentum_reference)
+                else
+                    call validate_rk_state(z_step_start, z, ierr_orbit, &
+                        z_step_start(4))
+                end if
                 if (ierr_orbit == 1) then
                     z_step_end = z
                     call locate_validated_lcfs(z_step_start, z_step_end, &
@@ -1884,8 +1971,9 @@ contains
                     ! in the failing axis/edge region; generic failures use an
                     ! exponentially backed-off probe interval.
                     z = z_step_start
-                    call orbit_timestep_recovery(z, dtaumin, relerr, &
-                        ierr_orbit)
+                    z(4) = si_step_start%pabs
+                    call orbit_timestep_recovery(anorb%fo, z, dtaumin, relerr, &
+                        ierr_orbit, recovery_method)
                     call validate_rk_state(z_step_start, z, ierr_orbit, &
                         si_step_start%pabs)
                     if (ierr_orbit == 1) then
@@ -1894,10 +1982,11 @@ contains
                             anorb%fper, z, loss_fraction, ierr_orbit)
                     end if
                     if (ierr_orbit == 0) then
-                        call reseed_sympl(anorb%si, anorb%f, z)
+                        call reseed_sympl(anorb%si, anorb%f, z, &
+                            si_step_start%pabs)
                         call count_event(EVT_SYMPLECTIC_RK_RECOVERY)
                         call activate_rk_recovery(rk_recovery_local, &
-                            z_step_start(1))
+                            z_step_start, si_step_start%pabs)
                         hold_streak_local = 0
                     else if (ierr_orbit == 1) then
                         anorb%si%last_step_fraction = loss_fraction
@@ -1929,16 +2018,27 @@ contains
             end if
             if (rk_recovery_local%active .and. .not. numerical_hold) then
                 hold_streak_local = 0
-                rk_recovery_local%steps = rk_recovery_local%steps + 1
-                if (should_resume_symplectic(rk_recovery_local, z(1))) then
-                    call reseed_sympl(anorb%si, anorb%f, z)
+                call update_recovery_streak(rk_recovery_local, z, &
+                    recovery_method)
+                if (should_resume_symplectic(rk_recovery_local, z)) then
+                    if (rk_recovery_local%has_momentum_reference) then
+                        call reseed_sympl(anorb%si, anorb%f, z, &
+                            rk_recovery_local%momentum_reference)
+                    else
+                        call reseed_sympl(anorb%si, anorb%f, z)
+                    end if
                     rk_recovery_local%active = .false.
                     call count_event(EVT_SYMPLECTIC_RESUME)
                 end if
             end if
             if (integmode <= 0 .or. rk_recovery_local%active) &
                 hold_streak_local = 0
-            if (swcoll) call collide(z, dtaumin) ! Collisions
+            if (swcoll) then
+                call collide(z, dtaumin) ! Collisions
+                if (rk_recovery_local%active) then
+                    rk_recovery_local%momentum_reference = z(4)
+                end if
+            end if
             kt = kt + 1
         end do
         if (present(hold_streak)) hold_streak = hold_streak_local
@@ -2051,7 +2151,7 @@ contains
         logical, intent(out), optional :: numerical_hold_any
         type(rk_recovery_state_t), intent(inout), optional :: rk_recovery
 
-        integer :: hold_streak_local, ktau
+        integer :: hold_streak_local, ktau, recovery_method
         real(dp) :: u_ref_prev(3), u_ref_cur(3), x_cur(3), x_cur_m(3)
         real(dp) :: z_step_start(5), z_step_end(5), segment_duration
         real(dp) :: boundary_fraction
@@ -2074,14 +2174,19 @@ contains
             z_step_start = z
             if (integmode <= 0 .or. rk_recovery_local%active) then
                 if (rk_recovery_local%active) then
-                    call orbit_timestep_recovery(z, dtaumin, relerr, &
-                        ierr_orbit)
+                    call orbit_timestep_recovery(anorb%fo, z, dtaumin, relerr, &
+                        ierr_orbit, recovery_method)
                 else
                     call orbit_timestep_axis(z, dtaumin, dtaumin, relerr, &
                         ierr_orbit)
                 end if
-                call validate_rk_state(z_step_start, z, ierr_orbit, &
-                    z_step_start(4))
+                if (rk_recovery_local%has_momentum_reference) then
+                    call validate_rk_state(z_step_start, z, ierr_orbit, &
+                        rk_recovery_local%momentum_reference)
+                else
+                    call validate_rk_state(z_step_start, z, ierr_orbit, &
+                        z_step_start(4))
+                end if
                 if (ierr_orbit == 1) then
                     z_step_end = z
                     call locate_validated_lcfs(z_step_start, z_step_end, &
@@ -2153,8 +2258,9 @@ contains
                 if (ierr_orbit .ne. 0 .and. &
                     symplectic_newton_warning_mode) then
                     z = z_step_start
-                    call orbit_timestep_recovery(z, dtaumin, relerr, &
-                        ierr_orbit)
+                    z(4) = si_step_start%pabs
+                    call orbit_timestep_recovery(anorb%fo, z, dtaumin, relerr, &
+                        ierr_orbit, recovery_method)
                     call validate_rk_state(z_step_start, z, ierr_orbit, &
                         si_step_start%pabs)
                     if (ierr_orbit == 1) then
@@ -2163,10 +2269,11 @@ contains
                             anorb%fper, z, boundary_fraction, ierr_orbit)
                     end if
                     if (ierr_orbit == 0) then
-                        call reseed_sympl(anorb%si, anorb%f, z)
+                        call reseed_sympl(anorb%si, anorb%f, z, &
+                            si_step_start%pabs)
                         call count_event(EVT_SYMPLECTIC_RK_RECOVERY)
                         call activate_rk_recovery(rk_recovery_local, &
-                            z_step_start(1))
+                            z_step_start, si_step_start%pabs)
                         hold_streak_local = 0
                     else if (ierr_orbit == 1) then
                         call integ_to_ref(z(1:3), u_ref_cur)
@@ -2226,13 +2333,24 @@ contains
                 exit
             end if
 
-            if (swcoll) call collide(z, dtaumin)
+            if (swcoll) then
+                call collide(z, dtaumin)
+                if (rk_recovery_local%active) then
+                    rk_recovery_local%momentum_reference = z(4)
+                end if
+            end if
             kt = kt + 1
             if (rk_recovery_local%active) then
                 hold_streak_local = 0
-                rk_recovery_local%steps = rk_recovery_local%steps + 1
-                if (should_resume_symplectic(rk_recovery_local, z(1))) then
-                    call reseed_sympl(anorb%si, anorb%f, z)
+                call update_recovery_streak(rk_recovery_local, z, &
+                    recovery_method)
+                if (should_resume_symplectic(rk_recovery_local, z)) then
+                    if (rk_recovery_local%has_momentum_reference) then
+                        call reseed_sympl(anorb%si, anorb%f, z, &
+                            rk_recovery_local%momentum_reference)
+                    else
+                        call reseed_sympl(anorb%si, anorb%f, z)
+                    end if
                     rk_recovery_local%active = .false.
                     call count_event(EVT_SYMPLECTIC_RESUME)
                 end if

--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -67,7 +67,7 @@ module simple_main
     real(dp), parameter :: RK_RECOVERY_AXIS_ENTER = 0.1_dp
     ! Retry only a failed legacy axis solve with a smoother, still axis-local
     ! Cartesian regularization. Successful release-era RK paths stay unchanged.
-    real(dp), parameter :: RK_RECOVERY_AXIS_FLOOR = 1.0e-6_dp
+    real(dp), parameter :: RK_RECOVERY_AXIS_FLOOR = 1.0e-3_dp
 
     type :: rk_recovery_state_t
         logical :: active = .false.

--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -27,7 +27,8 @@ module simple_main
         wall_hit_normal_cart, wall_hit_cos_incidence, wall_hit_angle_rad, &
         ntau_macro, kt_macro, checkpoint_interval, orbit_model, orbit_coord, &
         ORBIT_GC, ORBIT_FULL_ORBIT, ORBIT_EXIT_COMPLETED, ORBIT_EXIT_LCFS, &
-        ORBIT_EXIT_WALL, ORBIT_EXIT_SKIPPED, ORBIT_EXIT_NUMERICAL_DOMAIN, &
+        ORBIT_EXIT_WALL, ORBIT_EXIT_SKIPPED, ORBIT_EXIT_NUMERICAL_CONFINED, &
+        ORBIT_EXIT_NUMERICAL_DOMAIN, &
         ORBIT_EXIT_NUMERICAL_MAXITER, ORBIT_EXIT_NUMERICAL_LINEAR, &
         ORBIT_EXIT_NUMERICAL_EVENT, ORBIT_EXIT_NUMERICAL_FULL_ORBIT
     use params, only: canonical_grid_nr, canonical_grid_ntheta, &
@@ -71,6 +72,7 @@ module simple_main
     integer, parameter :: TOROIDAL_RECOVERY_STEP_LIMIT = 100000
     integer, parameter :: RK_SAFE_STREAK_TO_RESUME = 256
     real(dp), parameter :: RK_RECOVERY_AXIS_ENTER = 0.1_dp
+    real(dp), parameter :: NUMERICAL_CONFINED_S_MAX = 0.01_dp
     ! Retry only a failed legacy axis solve with a smoother, still axis-local
     ! Cartesian regularization. Successful release-era RK paths stay unchanged.
     real(dp), parameter :: RK_RECOVERY_AXIS_FLOOR = 1.0e-3_dp
@@ -1393,6 +1395,51 @@ contains
         end if
     end function classify_orbit_exit
 
+    pure real(dp) function normalized_flux_from_reference_radial( &
+            reference_radial, radial_is_rho)
+        real(dp), intent(in) :: reference_radial
+        logical, intent(in) :: radial_is_rho
+
+        normalized_flux_from_reference_radial = reference_radial
+        if (radial_is_rho .and. reference_radial >= 0.0_dp) &
+            normalized_flux_from_reference_radial = reference_radial**2
+    end function normalized_flux_from_reference_radial
+
+    real(dp) function reference_normalized_flux_s(reference_radial)
+        real(dp), intent(in) :: reference_radial
+        logical :: radial_is_rho
+
+        radial_is_rho = .false.
+        if (allocated(ref_coords)) then
+            select type (ref_coords)
+            class is (chartmap_coordinate_system_t)
+                radial_is_rho = .true.
+            class default
+                continue
+            end select
+        end if
+        reference_normalized_flux_s = normalized_flux_from_reference_radial( &
+            reference_radial, radial_is_rho)
+    end function reference_normalized_flux_s
+
+    pure logical function should_classify_numerically_confined(exit_code, &
+            model, mode, warning_mode, collisions_enabled, recovery_active, &
+            normalized_flux_s)
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+
+        integer, intent(in) :: exit_code, model, mode
+        logical, intent(in) :: warning_mode, collisions_enabled, recovery_active
+        real(dp), intent(in) :: normalized_flux_s
+
+        should_classify_numerically_confined = &
+            exit_code == ORBIT_EXIT_NUMERICAL_MAXITER .and. &
+            warning_mode .and. .not. collisions_enabled .and. &
+            model == ORBIT_GC .and. mode > 0 .and. recovery_active .and. &
+            ieee_is_finite(normalized_flux_s) .and. &
+            normalized_flux_s >= 0.0_dp .and. &
+            normalized_flux_s < NUMERICAL_CONFINED_S_MAX
+    end function should_classify_numerically_confined
+
     subroutine trace_orbit(anorb, ipart, orbit_traj, orbit_times)
         use classification, only: trace_orbit_with_classifiers, &
             classification_result_t, &
@@ -1411,12 +1458,14 @@ contains
         integer :: first_unresolved_it, hold_streak
         integer(8) :: kt
         logical :: passing, faulted, numerical_hold, physical_exit
+        logical :: numerically_confined
         type(rk_recovery_state_t) :: rk_recovery
         type(classification_result_t) :: class_result
 
         ierr_orbit = 0
         faulted = .false.
         physical_exit = .false.
+        numerically_confined = .false.
         first_unresolved_it = 0
         hold_streak = 0
         rk_recovery = rk_recovery_state_t()
@@ -1505,6 +1554,23 @@ contains
                 orbit_exit_code(ipart) = classify_orbit_exit( &
                     ierr_orbit, orbit_model, integmode, map_boundary_exit_code)
                 it_final = it
+                call integ_to_ref(z(1:3), u_ref_prev)
+                numerically_confined = should_classify_numerically_confined( &
+                    orbit_exit_code(ipart), orbit_model, integmode, &
+                    symplectic_newton_warning_mode, swcoll, rk_recovery%active, &
+                    reference_normalized_flux_s(u_ref_prev(1)))
+                if (numerically_confined) then
+                    ! All pushers failed from the same validated state in the
+                    ! axis-local core (VMEC s<0.01, or chartmap rho<0.1).
+                    ! This is neither a wall nor an LCFS event. Preserve it as
+                    ! an explicit audited outcome and apply the established
+                    ! numerical-fault-as-
+                    ! confined convention instead of fabricating a loss.
+                    orbit_exit_code(ipart) = ORBIT_EXIT_NUMERICAL_CONFINED
+                    do it_f = it, ntimstep
+                        call increase_confined_count(it_f, passing)
+                    end do
+                end if
                 physical_exit = orbit_exit_code(ipart) == ORBIT_EXIT_LCFS .or. &
                     orbit_exit_code(ipart) == ORBIT_EXIT_WALL
                 if (physical_exit) then
@@ -1518,7 +1584,7 @@ contains
                         boundary_event_time_width(ipart) = &
                             anorb%si%last_event_fraction_width*dtaumin/v0
                     end if
-                else
+                else if (.not. numerically_confined) then
                     if (first_unresolved_it == 0) first_unresolved_it = it
                     faulted = .true.
                 end if
@@ -1557,6 +1623,8 @@ contains
         zend(4:5, ipart) = z(4:5)
         if (physical_exit) then
             times_lost(ipart) = exit_step*dtaumin/v0
+        else if (numerically_confined) then
+            times_lost(ipart) = trace_time
         else if (faulted) then
             times_lost(ipart) = ieee_value(0.0d0, ieee_quiet_nan)
         else

--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -64,6 +64,9 @@ module simple_main
     real(dp), parameter :: RK_AXIS_EXIT = 0.02_dp
     real(dp), parameter :: RK_EDGE_ENTER = 0.98_dp
     integer, parameter :: RK_RECOVERY_STEP_LIMIT = 10000
+    ! Retry only a failed legacy axis solve with a smoother, still axis-local
+    ! Cartesian regularization. Successful release-era RK paths stay unchanged.
+    real(dp), parameter :: RK_RECOVERY_AXIS_FLOOR = 1.0e-6_dp
 
     type :: rk_recovery_state_t
         logical :: active = .false.
@@ -73,6 +76,24 @@ module simple_main
     end type rk_recovery_state_t
 
 contains
+
+    subroutine orbit_timestep_recovery(z, interval, tolerance, ierr)
+        use alpha_lifetime_sub, only: orbit_timestep_axis
+
+        real(dp), intent(inout) :: z(5)
+        real(dp), intent(in) :: interval, tolerance
+        integer, intent(out) :: ierr
+        real(dp) :: z_start(5)
+
+        z_start = z
+        call orbit_timestep_axis(z, interval, interval, tolerance, ierr, &
+            RK_RECOVERY_STEP_LIMIT)
+        if (ierr /= 2 .or. z_start(1) >= RK_AXIS_ENTER) return
+
+        z = z_start
+        call orbit_timestep_axis(z, interval, interval, tolerance, ierr, &
+            RK_RECOVERY_STEP_LIMIT, RK_RECOVERY_AXIS_FLOOR)
+    end subroutine orbit_timestep_recovery
 
     pure subroutine activate_rk_recovery(state, radius)
         type(rk_recovery_state_t), intent(inout) :: state
@@ -1705,19 +1726,32 @@ contains
         ierr = 2
     end subroutine locate_validated_lcfs
 
-    subroutine validate_rk_state(z_start, z_end, ierr)
+    subroutine validate_rk_state(z_start, z_end, ierr, expected_momentum)
         use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
 
         real(dp), intent(in) :: z_start(5)
         real(dp), intent(inout) :: z_end(5)
         integer, intent(inout) :: ierr
+        real(dp), intent(in), optional :: expected_momentum
         real(dp), parameter :: radial_sanity_band = 0.05_dp
         real(dp), parameter :: max_local_radial_step = 0.5_dp
+        real(dp), parameter :: momentum_sanity_fraction = 0.05_dp
+        real(dp) :: momentum_reference
         real(dp) :: u_end(3)
+        logical :: momentum_valid
 
         if (ierr /= 0) return
+        momentum_reference = z_start(4)
+        momentum_valid = .true.
+        if (present(expected_momentum)) then
+            momentum_reference = expected_momentum
+            momentum_valid = abs(z_end(4) - momentum_reference) <= &
+                momentum_sanity_fraction* &
+                max(abs(momentum_reference), tiny(1.0_dp))
+        end if
         if (all(ieee_is_finite(z_end)) .and. z_end(4) > 0.0_dp .and. &
             abs(z_end(5)) <= 1.0_dp + 100.0_dp*epsilon(1.0_dp) .and. &
+            momentum_valid .and. &
             abs(z_end(1) - z_start(1)) <= max_local_radial_step) then
             call integ_to_ref(z_end(1:3), u_end)
             if (all(ieee_is_finite(u_end)) .and. &
@@ -1790,13 +1824,14 @@ contains
             end if
             if (integmode <= 0 .or. rk_recovery_local%active) then
                 if (rk_recovery_local%active) then
-                    call orbit_timestep_axis(z, dtaumin, dtaumin, relerr, &
-                        ierr_orbit, RK_RECOVERY_STEP_LIMIT)
+                    call orbit_timestep_recovery(z, dtaumin, relerr, &
+                        ierr_orbit)
                 else
                     call orbit_timestep_axis(z, dtaumin, dtaumin, relerr, &
                         ierr_orbit)
                 end if
-                call validate_rk_state(z_step_start, z, ierr_orbit)
+                call validate_rk_state(z_step_start, z, ierr_orbit, &
+                    z_step_start(4))
                 if (ierr_orbit == 1) then
                     z_step_end = z
                     call locate_validated_lcfs(z_step_start, z_step_end, &
@@ -1825,7 +1860,8 @@ contains
                     orbit_timestep_sympl, ierr_orbit)
                 if (ierr_orbit == 0) then
                     call to_standard_z_coordinates(anorb, z)
-                    call validate_rk_state(z_step_start, z, ierr_orbit)
+                    call validate_rk_state(z_step_start, z, ierr_orbit, &
+                        si_step_start%pabs)
                     if (ierr_orbit /= 0) then
                         anorb%si = si_step_start
                         anorb%f = f_step_start
@@ -1846,9 +1882,10 @@ contains
                     ! in the failing axis/edge region; generic failures use an
                     ! exponentially backed-off probe interval.
                     z = z_step_start
-                    call orbit_timestep_axis(z, dtaumin, dtaumin, relerr, &
-                        ierr_orbit, RK_RECOVERY_STEP_LIMIT)
-                    call validate_rk_state(z_step_start, z, ierr_orbit)
+                    call orbit_timestep_recovery(z, dtaumin, relerr, &
+                        ierr_orbit)
+                    call validate_rk_state(z_step_start, z, ierr_orbit, &
+                        si_step_start%pabs)
                     if (ierr_orbit == 1) then
                         z_step_end = z
                         call locate_validated_lcfs(z_step_start, z_step_end, &
@@ -2035,13 +2072,14 @@ contains
             z_step_start = z
             if (integmode <= 0 .or. rk_recovery_local%active) then
                 if (rk_recovery_local%active) then
-                    call orbit_timestep_axis(z, dtaumin, dtaumin, relerr, &
-                        ierr_orbit, RK_RECOVERY_STEP_LIMIT)
+                    call orbit_timestep_recovery(z, dtaumin, relerr, &
+                        ierr_orbit)
                 else
                     call orbit_timestep_axis(z, dtaumin, dtaumin, relerr, &
                         ierr_orbit)
                 end if
-                call validate_rk_state(z_step_start, z, ierr_orbit)
+                call validate_rk_state(z_step_start, z, ierr_orbit, &
+                    z_step_start(4))
                 if (ierr_orbit == 1) then
                     z_step_end = z
                     call locate_validated_lcfs(z_step_start, z_step_end, &
@@ -2083,7 +2121,8 @@ contains
                     orbit_timestep_sympl, ierr_orbit, segment_duration)
                 if (ierr_orbit == 0) then
                     call to_standard_z_coordinates(anorb, z)
-                    call validate_rk_state(z_step_start, z, ierr_orbit)
+                    call validate_rk_state(z_step_start, z, ierr_orbit, &
+                        si_step_start%pabs)
                     if (ierr_orbit /= 0) then
                         anorb%si = si_step_start
                         anorb%f = f_step_start
@@ -2112,9 +2151,10 @@ contains
                 if (ierr_orbit .ne. 0 .and. &
                     symplectic_newton_warning_mode) then
                     z = z_step_start
-                    call orbit_timestep_axis(z, dtaumin, dtaumin, relerr, &
-                        ierr_orbit, RK_RECOVERY_STEP_LIMIT)
-                    call validate_rk_state(z_step_start, z, ierr_orbit)
+                    call orbit_timestep_recovery(z, dtaumin, relerr, &
+                        ierr_orbit)
+                    call validate_rk_state(z_step_start, z, ierr_orbit, &
+                        si_step_start%pabs)
                     if (ierr_orbit == 1) then
                         z_step_end = z
                         call locate_validated_lcfs(z_step_start, z_step_end, &

--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -18,6 +18,7 @@ module simple_main
         fast_class, generate_start_only, ntcut, iclass, bmin, bmax, zstart, &
         zend, trap_par, perp_inv, sbeg, ntimstep, should_skip, &
         reset_seed_if_deterministic, field_input, isw_field_type, reuse_batch, &
+        max_consecutive_warning_holds, &
         coord_input, wall_input, wall_units, wall_hit, wall_hit_cart, &
         wall_query_rho_lcfs, &
         chart_boundary_kind, chart_boundary_kind_effective, &
@@ -1773,14 +1774,9 @@ contains
                             exit_step = real(kt, dp) + loss_fraction
                         end if
                     else if (symplectic_newton_warning_mode) then
-                        ! Preserve the historical warning-mode single-step hold
-                        ! for full-orbit numerical inversion faults.
-                        z = z_step_start
-                        call count_event(EVT_WARNING_STEP_SKIP)
-                        hold_streak_local = ierr_orbit
-                        numerical_hold = .true.
-                        numerical_hold_any_local = .true.
-                        ierr_orbit = 0
+                        call hold_isolated_warning_failure(z, z_step_start, &
+                            ierr_orbit, hold_streak_local, numerical_hold, &
+                            numerical_hold_any_local)
                     end if
                     if (ierr_orbit .ne. 0) exit
                 end if
@@ -1817,8 +1813,9 @@ contains
                         ierr_orbit = SYMPLECTIC_STEP_BOUNDARY
                     end if
                 else if (ierr_orbit /= 0) then
-                    z = z_step_start
-                    hold_streak_local = ierr_orbit
+                    call hold_isolated_warning_failure(z, z_step_start, &
+                        ierr_orbit, hold_streak_local, numerical_hold, &
+                        numerical_hold_any_local)
                 end if
             else
                 if (swcoll) call update_momentum(anorb, z)
@@ -1875,7 +1872,9 @@ contains
                         z = z_step_start
                         anorb%si = si_step_start
                         anorb%f = f_step_start
-                        hold_streak_local = ierr_orbit
+                        call hold_isolated_warning_failure(z, z_step_start, &
+                            ierr_orbit, hold_streak_local, numerical_hold, &
+                            numerical_hold_any_local)
                     end if
                 else if (ierr_orbit == 0) then
                     call to_standard_z_coordinates(anorb, z)
@@ -1908,6 +1907,27 @@ contains
             numerical_hold_any = numerical_hold_any_local
         if (present(rk_recovery)) rk_recovery = rk_recovery_local
     end subroutine macrostep
+
+    subroutine hold_isolated_warning_failure(z, z_step_start, ierr_orbit, &
+            hold_streak, numerical_hold, numerical_hold_any)
+        real(dp), intent(inout) :: z(5)
+        real(dp), intent(in) :: z_step_start(5)
+        integer, intent(inout) :: ierr_orbit, hold_streak
+        logical, intent(inout) :: numerical_hold, numerical_hold_any
+
+        z = z_step_start
+        if (.not. symplectic_newton_warning_mode) return
+        if (hold_streak >= max_consecutive_warning_holds) return
+
+        ! Preserve the historical warning-level behavior for one isolated
+        ! unresolved microstep. Unlike the former permanent latch, the next
+        ! microstep retries both pushers; a successful step resets the streak.
+        call count_event(EVT_WARNING_STEP_SKIP)
+        hold_streak = hold_streak + 1
+        numerical_hold = .true.
+        numerical_hold_any = .true.
+        ierr_orbit = 0
+    end subroutine hold_isolated_warning_failure
 
     subroutine locate_wall_segment(z, z_start, z_end, ipart, x_start_m, &
             u_start, x_end_m, u_end, field_period, start_step, segment_steps, &
@@ -2051,8 +2071,9 @@ contains
                     end if
                     exit
                 else if (ierr_orbit /= 0) then
-                    z = z_step_start
-                    hold_streak_local = ierr_orbit
+                    call hold_isolated_warning_failure(z, z_step_start, &
+                        ierr_orbit, hold_streak_local, numerical_hold, &
+                        numerical_hold_any_local)
                 end if
             else
                 if (swcoll) call update_momentum(anorb, z)
@@ -2134,7 +2155,9 @@ contains
                         z = z_step_start
                         anorb%si = si_step_start
                         anorb%f = f_step_start
-                        hold_streak_local = ierr_orbit
+                        call hold_isolated_warning_failure(z, z_step_start, &
+                            ierr_orbit, hold_streak_local, numerical_hold, &
+                            numerical_hold_any_local)
                     end if
                 else if (ierr_orbit == 0) then
                     call to_standard_z_coordinates(anorb, z)

--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -64,6 +64,7 @@ module simple_main
     real(dp), parameter :: RK_AXIS_EXIT = 0.02_dp
     real(dp), parameter :: RK_EDGE_ENTER = 0.98_dp
     integer, parameter :: RK_RECOVERY_STEP_LIMIT = 10000
+    real(dp), parameter :: RK_RECOVERY_AXIS_ENTER = 0.1_dp
     ! Retry only a failed legacy axis solve with a smoother, still axis-local
     ! Cartesian regularization. Successful release-era RK paths stay unchanged.
     real(dp), parameter :: RK_RECOVERY_AXIS_FLOOR = 1.0e-6_dp
@@ -88,11 +89,12 @@ contains
         z_start = z
         call orbit_timestep_axis(z, interval, interval, tolerance, ierr, &
             RK_RECOVERY_STEP_LIMIT)
-        if (ierr /= 2 .or. z_start(1) >= RK_AXIS_ENTER) return
+        if (ierr /= 2 .or. z_start(1) >= RK_RECOVERY_AXIS_ENTER) return
 
         z = z_start
         call orbit_timestep_axis(z, interval, interval, tolerance, ierr, &
-            RK_RECOVERY_STEP_LIMIT, RK_RECOVERY_AXIS_FLOOR)
+            RK_RECOVERY_STEP_LIMIT, RK_RECOVERY_AXIS_FLOOR, &
+            RK_RECOVERY_AXIS_ENTER)
     end subroutine orbit_timestep_recovery
 
     pure subroutine activate_rk_recovery(state, radius)
@@ -1091,7 +1093,7 @@ contains
         potato%j_perp = potato_values(2)
         potato%p_phi = potato_values(3)
         call potato_to_simple_invariants(potato, psi_axis, psi_edge, v0_ratio, &
-                                         converted)
+            converted)
         simple_values = [converted%h0, converted%j_perp, converted%p_phi]
     end subroutine potato_invariants_to_simple_flat
 
@@ -1135,12 +1137,12 @@ contains
             end if
         end do
         call sort_invariant_starts(states, metadata, residuals, cylindrical, &
-                                   n_solutions)
+            n_solutions)
         if (size(result%starts) > max_solutions) status = INVARIANT_CAPACITY
     end subroutine states_from_invariants_flat
 
     subroutine sort_invariant_starts(states, metadata, residuals, cylindrical, &
-                                     count)
+            count)
         real(dp), intent(inout) :: states(:, :), residuals(:), cylindrical(:, :)
         integer, intent(inout) :: metadata(:, :)
         integer, intent(in) :: count
@@ -1986,7 +1988,7 @@ contains
         hit = .false.
         hit_step = start_step + segment_steps
         if (wall_query_rho_lcfs >= 0.0_dp .and. &
-                u_end(1) <= wall_query_rho_lcfs) return
+            u_end(1) <= wall_query_rho_lcfs) return
         call stl_wall_first_hit_segment_with_normal( &
             wall, x_start_m, x_end_m, hit, x_hit_m, normal_m)
         if (.not. hit) return

--- a/src/simple_main.f90
+++ b/src/simple_main.f90
@@ -19,6 +19,7 @@ module simple_main
         zend, trap_par, perp_inv, sbeg, ntimstep, should_skip, &
         reset_seed_if_deterministic, field_input, isw_field_type, reuse_batch, &
         coord_input, wall_input, wall_units, wall_hit, wall_hit_cart, &
+        chart_boundary_kind, chart_boundary_kind_effective, &
         wall_hit_normal_cart, wall_hit_cos_incidence, wall_hit_angle_rad, &
         ntau_macro, kt_macro, checkpoint_interval, orbit_model, orbit_coord, &
         ORBIT_GC, ORBIT_FULL_ORBIT, ORBIT_EXIT_COMPLETED, ORBIT_EXIT_LCFS, &
@@ -50,7 +51,7 @@ module simple_main
     integer, parameter :: dp = kind(1.0d0)
 
     logical, save :: wall_enabled = .false.
-    logical, save :: map_boundary_is_lcfs = .true.
+    integer, save :: map_boundary_exit_code = ORBIT_EXIT_LCFS
     real(dp), save :: chartmap_cart_scale_to_m = -1.0d0
     type(stl_wall_t), save :: wall
 
@@ -67,7 +68,6 @@ module simple_main
         integer :: reason = RK_RECOVERY_GENERIC
         integer :: steps = 0
         integer :: failures = 0
-        logical :: both_methods_failed = .false.
     end type rk_recovery_state_t
 
 contains
@@ -78,7 +78,6 @@ contains
 
         state%active = .true.
         state%steps = 0
-        state%both_methods_failed = .false.
         state%failures = min(state%failures + 1, 9)
         if (radius < RK_AXIS_ENTER) then
             state%reason = RK_RECOVERY_AXIS
@@ -299,7 +298,8 @@ contains
         logical :: use_boozer_chartmap, use_spectre
 
         self%integmode = aintegmode
-        map_boundary_is_lcfs = .true.
+        map_boundary_exit_code = ORBIT_EXIT_LCFS
+        chart_boundary_kind_effective = 'lcfs'
 
         ! Check if field_input is a Boozer chartmap or SPECTRE file (no VMEC needed)
         use_boozer_chartmap = .false.
@@ -495,7 +495,8 @@ contains
         character(len=16) :: units
 
         wall_enabled = .false.
-        map_boundary_is_lcfs = .true.
+        map_boundary_exit_code = ORBIT_EXIT_LCFS
+        chart_boundary_kind_effective = 'lcfs'
         chartmap_cart_scale_to_m = -1.0d0
 
         if (.not. allocated(ref_coords)) then
@@ -507,7 +508,25 @@ contains
         class is (chartmap_coordinate_system_t)
             call read_chartmap_metadata(coord_file, meta)
             chartmap_cart_scale_to_m = meta%cart_scale_to_m
-            map_boundary_is_lcfs = abs(meta%rho_lcfs - 1d0) <= 1d-12
+            select case (trim(chart_boundary_kind))
+            case ('auto')
+                if (abs(meta%rho_lcfs - 1d0) <= 1d-12) then
+                    map_boundary_exit_code = ORBIT_EXIT_LCFS
+                    chart_boundary_kind_effective = 'lcfs'
+                else
+                    map_boundary_exit_code = ORBIT_EXIT_NUMERICAL_DOMAIN
+                    chart_boundary_kind_effective = 'domain'
+                end if
+            case ('lcfs')
+                map_boundary_exit_code = ORBIT_EXIT_LCFS
+                chart_boundary_kind_effective = 'lcfs'
+            case ('wall')
+                map_boundary_exit_code = ORBIT_EXIT_WALL
+                chart_boundary_kind_effective = 'wall'
+            case ('domain')
+                map_boundary_exit_code = ORBIT_EXIT_NUMERICAL_DOMAIN
+                chart_boundary_kind_effective = 'domain'
+            end select
         class default
             if (len_trim(wall_input) == 0) return
             error stop "wall_input requires chartmap reference coordinates"
@@ -1177,9 +1196,9 @@ contains
         status = 0
     end subroutine trace_to_cut_flat
     pure integer function classify_orbit_exit(ierr_orbit, model, mode, &
-            boundary_is_lcfs)
+            boundary_exit_code)
         integer, intent(in) :: ierr_orbit, model, mode
-        logical, intent(in) :: boundary_is_lcfs
+        integer, intent(in) :: boundary_exit_code
 
         if (ierr_orbit == 0) then
             classify_orbit_exit = ORBIT_EXIT_COMPLETED
@@ -1187,30 +1206,20 @@ contains
             classify_orbit_exit = ORBIT_EXIT_WALL
         else if (model == ORBIT_FULL_ORBIT) then
             if (ierr_orbit == ORBIT_FO_LOSS) then
-                if (boundary_is_lcfs) then
-                    classify_orbit_exit = ORBIT_EXIT_LCFS
-                else
-                    classify_orbit_exit = ORBIT_EXIT_NUMERICAL_DOMAIN
-                end if
+                classify_orbit_exit = boundary_exit_code
             else
                 classify_orbit_exit = ORBIT_EXIT_NUMERICAL_FULL_ORBIT
             end if
         else if (mode <= 0) then
-            if (ierr_orbit == 1 .and. boundary_is_lcfs) then
-                classify_orbit_exit = ORBIT_EXIT_LCFS
-            else if (ierr_orbit == 1) then
-                classify_orbit_exit = ORBIT_EXIT_NUMERICAL_DOMAIN
+            if (ierr_orbit == 1) then
+                classify_orbit_exit = boundary_exit_code
             else
                 classify_orbit_exit = ORBIT_EXIT_NUMERICAL_EVENT
             end if
         else
             select case (ierr_orbit)
             case (SYMPLECTIC_STEP_BOUNDARY)
-                if (boundary_is_lcfs) then
-                    classify_orbit_exit = ORBIT_EXIT_LCFS
-                else
-                    classify_orbit_exit = ORBIT_EXIT_NUMERICAL_DOMAIN
-                end if
+                classify_orbit_exit = boundary_exit_code
             case (SYMPLECTIC_STEP_OUTSIDE_DOMAIN)
                 classify_orbit_exit = ORBIT_EXIT_NUMERICAL_DOMAIN
             case (SYMPLECTIC_STEP_MAXITER)
@@ -1337,7 +1346,7 @@ contains
 
             if (ierr_orbit .ne. 0) then
                 orbit_exit_code(ipart) = classify_orbit_exit( &
-                    ierr_orbit, orbit_model, integmode, map_boundary_is_lcfs)
+                    ierr_orbit, orbit_model, integmode, map_boundary_exit_code)
                 it_final = it
                 physical_exit = orbit_exit_code(ipart) == ORBIT_EXIT_LCFS .or. &
                     orbit_exit_code(ipart) == ORBIT_EXIT_WALL
@@ -1743,19 +1752,6 @@ contains
         do ktau = 1, ntau_local
             numerical_hold = .false.
             z_step_start = z
-            if (rk_recovery_local%both_methods_failed) then
-                ! This autonomous step has already failed from the same accepted
-                ! state with both pushers. Repeating the identical adaptive-RK
-                ! solve can consume millions of rejected substeps without new
-                ! information, so retain the intervention for the remaining
-                ! intervals and keep its held-time accounting explicit.
-                call count_event(EVT_WARNING_STEP_SKIP)
-                numerical_hold = .true.
-                numerical_hold_any_local = .true.
-                ierr_orbit = 0
-                kt = kt + 1
-                cycle
-            end if
             if (orbit_model == ORBIT_FULL_ORBIT) then
                 call orbit_timestep_fo(anorb%fo, z, ierr_orbit)
                 if (ierr_orbit .ne. 0) then
@@ -1768,10 +1764,8 @@ contains
                             exit_step = real(kt, dp) + loss_fraction
                         end if
                     else if (symplectic_newton_warning_mode) then
-                        ! The full-orbit pusher retains its last resolved state.
-                        ! Default production mode advances the clock past this
-                        ! one unresolved microstep and retries the next step;
-                        ! numerical inversion faults are never physical losses.
+                        ! Preserve the historical warning-mode single-step hold
+                        ! for full-orbit numerical inversion faults.
                         z = z_step_start
                         call count_event(EVT_WARNING_STEP_SKIP)
                         hold_streak_local = ierr_orbit
@@ -1813,18 +1807,9 @@ contains
                         anorb%si%last_event_fraction_width = 1.d0
                         ierr_orbit = SYMPLECTIC_STEP_BOUNDARY
                     end if
-                else if (ierr_orbit /= 0 .and. &
-                        symplectic_newton_warning_mode) then
-                    ! The RK driver rolls back failed integration to the last
-                    ! accepted state. Apply the same bounded warning convention
-                    ! as the symplectic and full-orbit paths.
-                    if (rk_recovery_local%active) &
-                        rk_recovery_local%both_methods_failed = .true.
-                    call count_event(EVT_WARNING_STEP_SKIP)
+                else if (ierr_orbit /= 0) then
+                    z = z_step_start
                     hold_streak_local = ierr_orbit
-                    numerical_hold = .true.
-                    numerical_hold_any_local = .true.
-                    ierr_orbit = 0
                 end if
             else
                 if (swcoll) call update_momentum(anorb, z)
@@ -1879,12 +1864,9 @@ contains
                         exit
                     else
                         z = z_step_start
-                        rk_recovery_local%both_methods_failed = .true.
-                        call count_event(EVT_WARNING_STEP_SKIP)
+                        anorb%si = si_step_start
+                        anorb%f = f_step_start
                         hold_streak_local = ierr_orbit
-                        numerical_hold = .true.
-                        numerical_hold_any_local = .true.
-                        ierr_orbit = 0
                     end if
                 else if (ierr_orbit == 0) then
                     call to_standard_z_coordinates(anorb, z)
@@ -2020,14 +2002,6 @@ contains
             numerical_hold = .false.
             segment_duration = 1.0_dp
             z_step_start = z
-            if (rk_recovery_local%both_methods_failed) then
-                call count_event(EVT_WARNING_STEP_SKIP)
-                numerical_hold = .true.
-                numerical_hold_any_local = .true.
-                ierr_orbit = 0
-                kt = kt + 1
-                cycle
-            end if
             if (integmode <= 0 .or. rk_recovery_local%active) then
                 if (rk_recovery_local%active) then
                     call orbit_timestep_axis(z, dtaumin, dtaumin, relerr, &
@@ -2065,15 +2039,9 @@ contains
                         end if
                     end if
                     exit
-                else if (ierr_orbit /= 0 .and. &
-                        symplectic_newton_warning_mode) then
-                    if (rk_recovery_local%active) &
-                        rk_recovery_local%both_methods_failed = .true.
-                    call count_event(EVT_WARNING_STEP_SKIP)
+                else if (ierr_orbit /= 0) then
+                    z = z_step_start
                     hold_streak_local = ierr_orbit
-                    numerical_hold = .true.
-                    numerical_hold_any_local = .true.
-                    ierr_orbit = 0
                 end if
             else
                 if (swcoll) call update_momentum(anorb, z)
@@ -2153,12 +2121,9 @@ contains
                         exit
                     else
                         z = z_step_start
-                        rk_recovery_local%both_methods_failed = .true.
-                        call count_event(EVT_WARNING_STEP_SKIP)
+                        anorb%si = si_step_start
+                        anorb%f = f_step_start
                         hold_streak_local = ierr_orbit
-                        numerical_hold = .true.
-                        numerical_hold_any_local = .true.
-                        ierr_orbit = 0
                     end if
                 else if (ierr_orbit == 0) then
                     call to_standard_z_coordinates(anorb, z)

--- a/src/spectre_sympl_orbit.f90
+++ b/src/spectre_sympl_orbit.f90
@@ -19,7 +19,8 @@ module spectre_sympl_orbit
         ref_to_integ
     use field_can_spectre, only: set_spectre_volume_lock
     use orbit_symplectic_base, only: symplectic_integrator_t, &
-        symplectic_newton_warning_mode, SYMPLECTIC_STEP_OUTSIDE_DOMAIN
+        symplectic_newton_warning_mode, symplectic_spectre_newton_warning_factor, &
+        SYMPLECTIC_STEP_OUTSIDE_DOMAIN
     use orbit_symplectic, only: orbit_timestep_sympl, orbit_sympl_init
     use interface_crossing, only: apply_crossing, crossing_info_t, &
         crossing_log_record, CROSS_LOSS, CROSS_STOP, CROSS_RECOVERY, CROSS_INVALID, &
@@ -206,6 +207,7 @@ contains
 
         ierr = SYMPL_SPECTRE_OK
         t_frac = 1.0_dp
+        si%warning_factor = symplectic_spectre_newton_warning_factor
         budget = state%dt_std
         used = 0.0_dp
         h_try = budget
@@ -831,6 +833,7 @@ contains
         z(1:3) = xinteg
         z(4) = recanon_pphi(f, y(4), y(5))
         call orbit_sympl_init(si, f, z, state%dt_std, 1, si%rtol, state%mode)
+        si%warning_factor = symplectic_spectre_newton_warning_factor
     end subroutine recanonicalize
 
     pure function recanon_pphi(f, p, lambda) result(pphi)

--- a/src/sub_alpha_lifetime_can.f90
+++ b/src/sub_alpha_lifetime_can.f90
@@ -4,12 +4,7 @@ module alpha_lifetime_sub
 
     implicit none
 
-    integer, parameter :: axis_tensor_count = 14
-
-    type :: magfie_data_t
-        real(dp) :: bmod, sqrtg
-        real(dp) :: bder(3), hcovar(3), hctrvr(3), hcurl(3)
-    end type magfie_data_t
+    integer, parameter :: axis_rhs_count = 5
 
 contains
 
@@ -368,112 +363,41 @@ contains
             real(dp), intent(in) :: z_axis(:)
             real(dp), intent(out) :: vz_axis(:)
             real(dp), intent(in) :: s_floor
-            real(dp) :: derphi(3)
-            type(magfie_data_t) :: field
-
-            ! Pull back the complete magfie tensor set before evaluating the
-            ! coordinate-covariant guiding-centre equation. Transforming only
-            ! the final polar velocity makes a radius floor select an arbitrary
-            ! approach ray at the axis.
-            call evaluate_axis_field(z_axis(1), z_axis(2), z_axis(3), &
-                s_floor, field)
-            derphi=0.d0
-            call guiding_center_velocity(z_axis, field, derphi, vz_axis)
+            call evaluate_axis_rhs(tau, z_axis, s_floor, vz_axis)
         end subroutine velo_axis_regularized
 
-        subroutine guiding_center_velocity(z, field, derphi, vz)
-            use parmot_mod, only : rmu,ro0
-            real(dp), intent(in) :: z(:), derphi(3)
-            type(magfie_data_t), intent(in) :: field
-            real(dp), intent(out) :: vz(:)
-            integer :: i
-            real(dp) :: p,alambd,p2,ovmu,gamma2,gamma,ppar,vpa,coala
-            real(dp) :: rmumag,rovsqg,rosqgb,rovbm
-            real(dp) :: a_phi(3),a_b(3),a_c(3),hstar(3)
-            real(dp) :: s_hc,hpstar,phidot,blodot,bra
-
-            p=z(4)
-            alambd=z(5)
-            p2=p*p
-            ovmu=2.d0/rmu
-            gamma2=p2*ovmu+1.d0
-            gamma=dsqrt(gamma2)
-            ppar=p*alambd
-            vpa=ppar/gamma
-            coala=(1.d0-alambd**2)
-            rmumag=.5d0*p2*coala/field%bmod
-
-            rovsqg=ro0/field%sqrtg
-            rosqgb=.5d0*rovsqg/field%bmod
-            rovbm=ro0/field%bmod
-
-            a_phi(1)=(field%hcovar(2)*derphi(3) &
-                -field%hcovar(3)*derphi(2))*rosqgb
-            a_b(1)=(field%hcovar(2)*field%bder(3) &
-                -field%hcovar(3)*field%bder(2))*rovsqg
-            a_phi(2)=(field%hcovar(3)*derphi(1) &
-                -field%hcovar(1)*derphi(3))*rosqgb
-            a_b(2)=(field%hcovar(3)*field%bder(1) &
-                -field%hcovar(1)*field%bder(3))*rovsqg
-            a_phi(3)=(field%hcovar(1)*derphi(2) &
-                -field%hcovar(2)*derphi(1))*rosqgb
-            a_b(3)=(field%hcovar(1)*field%bder(2) &
-                -field%hcovar(2)*field%bder(1))*rovsqg
-
-            s_hc=0.d0
-            do i=1,3
-                a_c(i)=field%hcurl(i)*rovbm
-                s_hc=s_hc+a_c(i)*field%hcovar(i)
-                hstar(i)=field%hctrvr(i)+ppar*a_c(i)
-            enddo
-            hpstar=1.d0+ppar*s_hc
-
-            phidot=0.d0
-            blodot=0.d0
-            do i=1,3
-                bra=vpa*hstar(i)+a_phi(i)+a_b(i)*rmumag/gamma
-                vz(i)=bra/hpstar
-                phidot=phidot+vz(i)*derphi(i)
-                blodot=blodot+vz(i)*field%bder(i)
-            enddo
-
-            vz(4)=-0.5d0*gamma*phidot/p
-            vz(5)=-(0.5d0*coala/hpstar)*(sum(hstar*derphi)/p &
-                +p*sum(hstar*field%bder)/gamma &
-                +alambd*sum(a_phi*field%bder))
-        end subroutine guiding_center_velocity
-
-        subroutine evaluate_axis_field(x, y, phi, sample_s, field)
-            real(dp), intent(in) :: x, y, phi, sample_s
-            type(magfie_data_t), intent(out) :: field
+        subroutine evaluate_axis_rhs(tau, z_axis, sample_s, vz_axis)
+            real(dp), intent(in) :: tau, z_axis(:), sample_s
+            real(dp), intent(out) :: vz_axis(:)
             integer, parameter :: nang = 8
-            real(dp) :: values(axis_tensor_count, nang, 2)
-            real(dp) :: mean(axis_tensor_count, 2)
-            real(dp) :: m1c(axis_tensor_count, 2), m1s(axis_tensor_count, 2)
-            real(dp) :: m2c(axis_tensor_count, 2), m2s(axis_tensor_count, 2)
-            real(dp) :: coeff(axis_tensor_count), packed(axis_tensor_count)
-            real(dp) :: raw_packed(axis_tensor_count)
+            real(dp) :: values(axis_rhs_count, nang, 2)
+            real(dp) :: mean(axis_rhs_count, 2)
+            real(dp) :: m1c(axis_rhs_count, 2), m1s(axis_rhs_count, 2)
+            real(dp) :: m2c(axis_rhs_count, 2), m2s(axis_rhs_count, 2)
+            real(dp) :: coeff(axis_rhs_count), reconstructed(axis_rhs_count)
+            real(dp) :: raw(axis_rhs_count), zsample(axis_rhs_count)
             real(dp) :: angle, radius, radius0, r2, blend, blend_arg
             integer :: iangle, iring
-            type(magfie_data_t) :: sample
 
-            r2=x*x+y*y
+            r2=z_axis(1)*z_axis(1)+z_axis(2)*z_axis(2)
             if(r2.ge.sample_s) then
-                call evaluate_axis_field_raw(x, y, phi, field)
+                call evaluate_axis_rhs_raw(tau, z_axis, vz_axis)
                 return
             endif
 
-            ! Resolve the regular Cartesian modes through quadratic order on
-            ! two circles. The second radius removes the leading radial
-            ! contamination from the axis value and linear harmonics.
+            ! Reconstruct the physical guiding-centre vector field itself in
+            ! regular Cartesian modes. Unlike independent tensor fits, this
+            ! retains all algebraic identities among the magfie quantities.
             radius0=sqrt(sample_s)
+            zsample(3:5)=z_axis(3:5)
             do iring=1,2
                 radius=real(iring,dp)*radius0
                 do iangle=1,nang
                     angle=2.d0*acos(-1.d0)*real(iangle-1,dp)/real(nang,dp)
-                    call evaluate_axis_field_raw(radius*cos(angle), &
-                        radius*sin(angle), phi, sample)
-                    call pack_axis_field(sample, values(:,iangle,iring))
+                    zsample(1)=radius*cos(angle)
+                    zsample(2)=radius*sin(angle)
+                    call evaluate_axis_rhs_raw(tau, zsample, &
+                        values(:,iangle,iring))
                 enddo
             enddo
 
@@ -498,99 +422,51 @@ contains
             m2c=2.d0*m2c/real(nang,dp)
             m2s=2.d0*m2s/real(nang,dp)
 
-            packed=(4.d0*mean(:,1)-mean(:,2))/3.d0
+            reconstructed=(4.d0*mean(:,1)-mean(:,2))/3.d0
             coeff=(4.d0*m1c(:,1)/radius0 &
                 -m1c(:,2)/(2.d0*radius0))/3.d0
-            packed=packed+coeff*x
+            reconstructed=reconstructed+coeff*z_axis(1)
             coeff=(4.d0*m1s(:,1)/radius0 &
                 -m1s(:,2)/(2.d0*radius0))/3.d0
-            packed=packed+coeff*y
+            reconstructed=reconstructed+coeff*z_axis(2)
             coeff=(mean(:,2)-mean(:,1))/(3.d0*sample_s)
-            packed=packed+coeff*r2
+            reconstructed=reconstructed+coeff*r2
             coeff=(4.d0*m2c(:,1)/sample_s &
                 -m2c(:,2)/(4.d0*sample_s))/3.d0
-            packed=packed+coeff*(x*x-y*y)
+            reconstructed=reconstructed+coeff* &
+                (z_axis(1)*z_axis(1)-z_axis(2)*z_axis(2))
             coeff=(4.d0*m2s(:,1)/sample_s &
                 -m2s(:,2)/(4.d0*sample_s))/3.d0
-            packed=packed+coeff*(2.d0*x*y)
+            reconstructed=reconstructed+coeff* &
+                (2.d0*z_axis(1)*z_axis(2))
 
             ! Join the reconstruction to the exact pullback with a C1
             ! smoothstep in the outer half of the disk.
             if(r2.gt.0.25d0*sample_s) then
-                call evaluate_axis_field_raw(x, y, phi, sample)
-                call pack_axis_field(sample, raw_packed)
+                call evaluate_axis_rhs_raw(tau, z_axis, raw)
                 blend_arg=2.d0*sqrt(r2/sample_s)-1.d0
                 blend=blend_arg*blend_arg*(3.d0-2.d0*blend_arg)
-                packed=(1.d0-blend)*packed+blend*raw_packed
+                reconstructed=(1.d0-blend)*reconstructed+blend*raw
             endif
-            call unpack_axis_field(packed, field)
-        end subroutine evaluate_axis_field
+            vz_axis=reconstructed
+        end subroutine evaluate_axis_rhs
 
-        subroutine evaluate_axis_field_raw(x, y, phi, field)
-            use magfie_sub, only : magfie
-            real(dp), intent(in) :: x, y, phi
-            type(magfie_data_t), intent(out) :: field
-            real(dp) :: s, theta, xpolar(3)
-            real(dp) :: bder(3), hcovar(3), hctrvr(3), hcurl(3)
+        subroutine evaluate_axis_rhs_raw(tau, z_axis, vz_axis)
+            real(dp), intent(in) :: tau, z_axis(:)
+            real(dp), intent(out) :: vz_axis(:)
+            real(dp) :: s, zpolar(5), vpolar(5)
 
-            s=x*x+y*y
+            s=z_axis(1)*z_axis(1)+z_axis(2)*z_axis(2)
             if(.not.(s.gt.0.d0)) error stop &
-                'raw axis-field evaluation requires nonzero radius'
-            theta=atan2(y,x)
-            xpolar=[s,theta,phi]
-            call magfie(xpolar, field%bmod, field%sqrtg, bder, hcovar, &
-                hctrvr, hcurl)
-
-            ! ds = 2X dX + 2Y dY and
-            ! dtheta = (-Y dX + X dY)/s; det(dx/dq) = 2 > 0.
-            field%sqrtg=2.d0*field%sqrtg
-            call polar_covector_to_axis(x, y, s, bder, field%bder)
-            call polar_covector_to_axis(x, y, s, hcovar, field%hcovar)
-            call polar_vector_to_axis(x, y, s, hctrvr, field%hctrvr)
-            call polar_vector_to_axis(x, y, s, hcurl, field%hcurl)
-        end subroutine evaluate_axis_field_raw
-
-        pure subroutine polar_covector_to_axis(x, y, s, polar, axis)
-            real(dp), intent(in) :: x, y, s, polar(3)
-            real(dp), intent(out) :: axis(3)
-
-            axis(1)=2.d0*x*polar(1)-y*polar(2)/s
-            axis(2)=2.d0*y*polar(1)+x*polar(2)/s
-            axis(3)=polar(3)
-        end subroutine polar_covector_to_axis
-
-        pure subroutine polar_vector_to_axis(x, y, s, polar, axis)
-            real(dp), intent(in) :: x, y, s, polar(3)
-            real(dp), intent(out) :: axis(3)
-
-            axis(1)=x*polar(1)/(2.d0*s)-y*polar(2)
-            axis(2)=y*polar(1)/(2.d0*s)+x*polar(2)
-            axis(3)=polar(3)
-        end subroutine polar_vector_to_axis
-
-        pure subroutine pack_axis_field(field, packed)
-            type(magfie_data_t), intent(in) :: field
-            real(dp), intent(out) :: packed(axis_tensor_count)
-
-            packed(1)=field%bmod
-            packed(2)=field%sqrtg
-            packed(3:5)=field%bder
-            packed(6:8)=field%hcovar
-            packed(9:11)=field%hctrvr
-            packed(12:14)=field%hcurl
-        end subroutine pack_axis_field
-
-        pure subroutine unpack_axis_field(packed, field)
-            real(dp), intent(in) :: packed(axis_tensor_count)
-            type(magfie_data_t), intent(out) :: field
-
-            field%bmod=packed(1)
-            field%sqrtg=packed(2)
-            field%bder=packed(3:5)
-            field%hcovar=packed(6:8)
-            field%hctrvr=packed(9:11)
-            field%hcurl=packed(12:14)
-        end subroutine unpack_axis_field
+                'raw axis-RHS evaluation requires nonzero radius'
+            zpolar=[s,atan2(z_axis(2),z_axis(1)),z_axis(3:5)]
+            call velo_can(tau,zpolar,vpolar)
+            vz_axis(1)=0.5d0*vpolar(1)*z_axis(1)/s &
+                -vpolar(2)*z_axis(2)
+            vz_axis(2)=0.5d0*vpolar(1)*z_axis(2)/s &
+                +vpolar(2)*z_axis(1)
+            vz_axis(3:5)=vpolar(3:5)
+        end subroutine evaluate_axis_rhs_raw
         !
         !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
         !
@@ -648,7 +524,7 @@ contains
         end subroutine velo_axis_context
 
         subroutine orbit_timestep_axis(z,dtau,dtaumin,relerr,ierr,step_limit, &
-                axis_floor)
+                axis_floor,near_axis_limit)
             use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
             use odeint_allroutines_sub, only : odeint_has_failed
             use chamb_sub, only : chamb_can
@@ -656,14 +532,12 @@ contains
             implicit none
             !
             integer, parameter          :: ndim=5, nstepmax=1000000
-            real(dp), parameter :: snear_axis=0.01d0
-            !
             logical :: near_axis
             integer :: ierr
             integer, intent(in), optional :: step_limit
-            real(dp), intent(in), optional :: axis_floor
+            real(dp), intent(in), optional :: axis_floor,near_axis_limit
             real(dp) :: dtau,dtaumin,phi,tau1,tau2,z1,z2,axis_floor_local
-            real(dp) :: relerr
+            real(dp) :: relerr,snear_axis
             !
             real(dp), dimension(2)    :: y
             real(dp), dimension(ndim) :: z, z_initial
@@ -676,9 +550,13 @@ contains
             !
             ierr=0
             axis_floor_local=1.d-8
+            snear_axis=0.01d0
             if(present(axis_floor)) axis_floor_local=axis_floor
+            if(present(near_axis_limit)) snear_axis=near_axis_limit
             if(.not.ieee_is_finite(axis_floor_local) .or. &
-                axis_floor_local.le.0.d0) then
+                axis_floor_local.le.0.d0 .or. &
+                .not.ieee_is_finite(snear_axis) .or. &
+                snear_axis.le.axis_floor_local .or. snear_axis.gt.1.d0) then
                 ierr=2
                 return
             endif

--- a/src/sub_alpha_lifetime_can.f90
+++ b/src/sub_alpha_lifetime_can.f90
@@ -4,6 +4,13 @@ module alpha_lifetime_sub
 
     implicit none
 
+    integer, parameter :: axis_tensor_count = 14
+
+    type :: magfie_data_t
+        real(dp) :: bmod, sqrtg
+        real(dp) :: bder(3), hcovar(3), hctrvr(3), hcurl(3)
+    end type magfie_data_t
+
 contains
 
     !ToDo make module from all global things like this one
@@ -361,37 +368,229 @@ contains
             real(dp), intent(in) :: z_axis(:)
             real(dp), intent(out) :: vz_axis(:)
             real(dp), intent(in) :: s_floor
-            real(dp) :: derlogsqs
-            real(dp) :: r2,scale,x_eval,y_eval
-            real(dp), dimension(5) :: z,vz
-            !
-            r2=z_axis(1)**2+z_axis(2)**2
-            if(r2.lt.s_floor) then
-                if(r2.gt.0.d0) then
-                    scale=sqrt(s_floor/r2)
-                    x_eval=scale*z_axis(1)
-                    y_eval=scale*z_axis(2)
-                else
-                    x_eval=sqrt(s_floor)
-                    y_eval=0.d0
-                endif
-                z(1)=s_floor
-            else
-                x_eval=z_axis(1)
-                y_eval=z_axis(2)
-                z(1)=r2
-            endif
-            z(2)=atan2(y_eval,x_eval)
-            z(3:5)=z_axis(3:5)
-            !
-            call velo_can(tau,z,vz)
-            !
-            derlogsqs=0.5d0*vz(1)/z(1)
-            vz_axis(1)=derlogsqs*x_eval-vz(2)*y_eval
-            vz_axis(2)=derlogsqs*y_eval+vz(2)*x_eval
-            vz_axis(3:5)=vz(3:5)
-            !
+            real(dp) :: derphi(3)
+            type(magfie_data_t) :: field
+
+            ! Pull back the complete magfie tensor set before evaluating the
+            ! coordinate-covariant guiding-centre equation. Transforming only
+            ! the final polar velocity makes a radius floor select an arbitrary
+            ! approach ray at the axis.
+            call evaluate_axis_field(z_axis(1), z_axis(2), z_axis(3), &
+                s_floor, field)
+            derphi=0.d0
+            call guiding_center_velocity(z_axis, field, derphi, vz_axis)
         end subroutine velo_axis_regularized
+
+        subroutine guiding_center_velocity(z, field, derphi, vz)
+            use parmot_mod, only : rmu,ro0
+            real(dp), intent(in) :: z(:), derphi(3)
+            type(magfie_data_t), intent(in) :: field
+            real(dp), intent(out) :: vz(:)
+            integer :: i
+            real(dp) :: p,alambd,p2,ovmu,gamma2,gamma,ppar,vpa,coala
+            real(dp) :: rmumag,rovsqg,rosqgb,rovbm
+            real(dp) :: a_phi(3),a_b(3),a_c(3),hstar(3)
+            real(dp) :: s_hc,hpstar,phidot,blodot,bra
+
+            p=z(4)
+            alambd=z(5)
+            p2=p*p
+            ovmu=2.d0/rmu
+            gamma2=p2*ovmu+1.d0
+            gamma=dsqrt(gamma2)
+            ppar=p*alambd
+            vpa=ppar/gamma
+            coala=(1.d0-alambd**2)
+            rmumag=.5d0*p2*coala/field%bmod
+
+            rovsqg=ro0/field%sqrtg
+            rosqgb=.5d0*rovsqg/field%bmod
+            rovbm=ro0/field%bmod
+
+            a_phi(1)=(field%hcovar(2)*derphi(3) &
+                -field%hcovar(3)*derphi(2))*rosqgb
+            a_b(1)=(field%hcovar(2)*field%bder(3) &
+                -field%hcovar(3)*field%bder(2))*rovsqg
+            a_phi(2)=(field%hcovar(3)*derphi(1) &
+                -field%hcovar(1)*derphi(3))*rosqgb
+            a_b(2)=(field%hcovar(3)*field%bder(1) &
+                -field%hcovar(1)*field%bder(3))*rovsqg
+            a_phi(3)=(field%hcovar(1)*derphi(2) &
+                -field%hcovar(2)*derphi(1))*rosqgb
+            a_b(3)=(field%hcovar(1)*field%bder(2) &
+                -field%hcovar(2)*field%bder(1))*rovsqg
+
+            s_hc=0.d0
+            do i=1,3
+                a_c(i)=field%hcurl(i)*rovbm
+                s_hc=s_hc+a_c(i)*field%hcovar(i)
+                hstar(i)=field%hctrvr(i)+ppar*a_c(i)
+            enddo
+            hpstar=1.d0+ppar*s_hc
+
+            phidot=0.d0
+            blodot=0.d0
+            do i=1,3
+                bra=vpa*hstar(i)+a_phi(i)+a_b(i)*rmumag/gamma
+                vz(i)=bra/hpstar
+                phidot=phidot+vz(i)*derphi(i)
+                blodot=blodot+vz(i)*field%bder(i)
+            enddo
+
+            vz(4)=-0.5d0*gamma*phidot/p
+            vz(5)=-(0.5d0*coala/hpstar)*(sum(hstar*derphi)/p &
+                +p*sum(hstar*field%bder)/gamma &
+                +alambd*sum(a_phi*field%bder))
+        end subroutine guiding_center_velocity
+
+        subroutine evaluate_axis_field(x, y, phi, sample_s, field)
+            real(dp), intent(in) :: x, y, phi, sample_s
+            type(magfie_data_t), intent(out) :: field
+            integer, parameter :: nang = 8
+            real(dp) :: values(axis_tensor_count, nang, 2)
+            real(dp) :: mean(axis_tensor_count, 2)
+            real(dp) :: m1c(axis_tensor_count, 2), m1s(axis_tensor_count, 2)
+            real(dp) :: m2c(axis_tensor_count, 2), m2s(axis_tensor_count, 2)
+            real(dp) :: coeff(axis_tensor_count), packed(axis_tensor_count)
+            real(dp) :: raw_packed(axis_tensor_count)
+            real(dp) :: angle, radius, radius0, r2, blend, blend_arg
+            integer :: iangle, iring
+            type(magfie_data_t) :: sample
+
+            r2=x*x+y*y
+            if(r2.ge.sample_s) then
+                call evaluate_axis_field_raw(x, y, phi, field)
+                return
+            endif
+
+            ! Resolve the regular Cartesian modes through quadratic order on
+            ! two circles. The second radius removes the leading radial
+            ! contamination from the axis value and linear harmonics.
+            radius0=sqrt(sample_s)
+            do iring=1,2
+                radius=real(iring,dp)*radius0
+                do iangle=1,nang
+                    angle=2.d0*acos(-1.d0)*real(iangle-1,dp)/real(nang,dp)
+                    call evaluate_axis_field_raw(radius*cos(angle), &
+                        radius*sin(angle), phi, sample)
+                    call pack_axis_field(sample, values(:,iangle,iring))
+                enddo
+            enddo
+
+            mean=0.d0
+            m1c=0.d0
+            m1s=0.d0
+            m2c=0.d0
+            m2s=0.d0
+            do iring=1,2
+                do iangle=1,nang
+                    angle=2.d0*acos(-1.d0)*real(iangle-1,dp)/real(nang,dp)
+                    mean(:,iring)=mean(:,iring)+values(:,iangle,iring)
+                    m1c(:,iring)=m1c(:,iring)+values(:,iangle,iring)*cos(angle)
+                    m1s(:,iring)=m1s(:,iring)+values(:,iangle,iring)*sin(angle)
+                    m2c(:,iring)=m2c(:,iring)+values(:,iangle,iring)*cos(2.d0*angle)
+                    m2s(:,iring)=m2s(:,iring)+values(:,iangle,iring)*sin(2.d0*angle)
+                enddo
+            enddo
+            mean=mean/real(nang,dp)
+            m1c=2.d0*m1c/real(nang,dp)
+            m1s=2.d0*m1s/real(nang,dp)
+            m2c=2.d0*m2c/real(nang,dp)
+            m2s=2.d0*m2s/real(nang,dp)
+
+            packed=(4.d0*mean(:,1)-mean(:,2))/3.d0
+            coeff=(4.d0*m1c(:,1)/radius0 &
+                -m1c(:,2)/(2.d0*radius0))/3.d0
+            packed=packed+coeff*x
+            coeff=(4.d0*m1s(:,1)/radius0 &
+                -m1s(:,2)/(2.d0*radius0))/3.d0
+            packed=packed+coeff*y
+            coeff=(mean(:,2)-mean(:,1))/(3.d0*sample_s)
+            packed=packed+coeff*r2
+            coeff=(4.d0*m2c(:,1)/sample_s &
+                -m2c(:,2)/(4.d0*sample_s))/3.d0
+            packed=packed+coeff*(x*x-y*y)
+            coeff=(4.d0*m2s(:,1)/sample_s &
+                -m2s(:,2)/(4.d0*sample_s))/3.d0
+            packed=packed+coeff*(2.d0*x*y)
+
+            ! Join the reconstruction to the exact pullback with a C1
+            ! smoothstep in the outer half of the disk.
+            if(r2.gt.0.25d0*sample_s) then
+                call evaluate_axis_field_raw(x, y, phi, sample)
+                call pack_axis_field(sample, raw_packed)
+                blend_arg=2.d0*sqrt(r2/sample_s)-1.d0
+                blend=blend_arg*blend_arg*(3.d0-2.d0*blend_arg)
+                packed=(1.d0-blend)*packed+blend*raw_packed
+            endif
+            call unpack_axis_field(packed, field)
+        end subroutine evaluate_axis_field
+
+        subroutine evaluate_axis_field_raw(x, y, phi, field)
+            use magfie_sub, only : magfie
+            real(dp), intent(in) :: x, y, phi
+            type(magfie_data_t), intent(out) :: field
+            real(dp) :: s, theta, xpolar(3)
+            real(dp) :: bder(3), hcovar(3), hctrvr(3), hcurl(3)
+
+            s=x*x+y*y
+            if(.not.(s.gt.0.d0)) error stop &
+                'raw axis-field evaluation requires nonzero radius'
+            theta=atan2(y,x)
+            xpolar=[s,theta,phi]
+            call magfie(xpolar, field%bmod, field%sqrtg, bder, hcovar, &
+                hctrvr, hcurl)
+
+            ! ds = 2X dX + 2Y dY and
+            ! dtheta = (-Y dX + X dY)/s; det(dx/dq) = 2 > 0.
+            field%sqrtg=2.d0*field%sqrtg
+            call polar_covector_to_axis(x, y, s, bder, field%bder)
+            call polar_covector_to_axis(x, y, s, hcovar, field%hcovar)
+            call polar_vector_to_axis(x, y, s, hctrvr, field%hctrvr)
+            call polar_vector_to_axis(x, y, s, hcurl, field%hcurl)
+        end subroutine evaluate_axis_field_raw
+
+        pure subroutine polar_covector_to_axis(x, y, s, polar, axis)
+            real(dp), intent(in) :: x, y, s, polar(3)
+            real(dp), intent(out) :: axis(3)
+
+            axis(1)=2.d0*x*polar(1)-y*polar(2)/s
+            axis(2)=2.d0*y*polar(1)+x*polar(2)/s
+            axis(3)=polar(3)
+        end subroutine polar_covector_to_axis
+
+        pure subroutine polar_vector_to_axis(x, y, s, polar, axis)
+            real(dp), intent(in) :: x, y, s, polar(3)
+            real(dp), intent(out) :: axis(3)
+
+            axis(1)=x*polar(1)/(2.d0*s)-y*polar(2)
+            axis(2)=y*polar(1)/(2.d0*s)+x*polar(2)
+            axis(3)=polar(3)
+        end subroutine polar_vector_to_axis
+
+        pure subroutine pack_axis_field(field, packed)
+            type(magfie_data_t), intent(in) :: field
+            real(dp), intent(out) :: packed(axis_tensor_count)
+
+            packed(1)=field%bmod
+            packed(2)=field%sqrtg
+            packed(3:5)=field%bder
+            packed(6:8)=field%hcovar
+            packed(9:11)=field%hctrvr
+            packed(12:14)=field%hcurl
+        end subroutine pack_axis_field
+
+        pure subroutine unpack_axis_field(packed, field)
+            real(dp), intent(in) :: packed(axis_tensor_count)
+            type(magfie_data_t), intent(out) :: field
+
+            field%bmod=packed(1)
+            field%sqrtg=packed(2)
+            field%bder=packed(3:5)
+            field%hcovar=packed(6:8)
+            field%hctrvr=packed(9:11)
+            field%hcurl=packed(12:14)
+        end subroutine unpack_axis_field
         !
         !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
         !

--- a/src/sub_alpha_lifetime_can.f90
+++ b/src/sub_alpha_lifetime_can.f90
@@ -342,6 +342,15 @@ contains
         !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
         !
         subroutine velo_axis(tau,z_axis,vz_axis)
+            real(dp), intent(in) :: tau
+            real(dp), intent(in) :: z_axis(:)
+            real(dp), intent(out) :: vz_axis(:)
+            real(dp), parameter :: legacy_s_floor = 1.d-8
+
+            call velo_axis_regularized(tau, z_axis, vz_axis, legacy_s_floor)
+        end subroutine velo_axis
+
+        subroutine velo_axis_regularized(tau,z_axis,vz_axis,s_floor)
             !
             ! Here variables z(1)=s and z(2)=theta are replaced with
             ! x_axis(1)=x=sqrt(s)*cos(theta) and x_axis(2)=y=sqrt(s)*sin(theta)
@@ -351,7 +360,7 @@ contains
             real(dp), intent(in) :: tau
             real(dp), intent(in) :: z_axis(:)
             real(dp), intent(out) :: vz_axis(:)
-            real(dp), parameter :: s_floor=1.d-8
+            real(dp), intent(in) :: s_floor
             real(dp) :: derlogsqs
             real(dp) :: r2,scale,x_eval,y_eval
             real(dp), dimension(5) :: z,vz
@@ -382,21 +391,22 @@ contains
             vz_axis(2)=derlogsqs*y_eval+vz(2)*x_eval
             vz_axis(3:5)=vz(3:5)
             !
-        end subroutine velo_axis
+        end subroutine velo_axis_regularized
         !
         !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
         !
-        subroutine integrate_axis_segment(z,tau1,tau2,relerr,near_axis,step_limit)
+        subroutine integrate_axis_segment(z,tau1,tau2,relerr,near_axis, &
+                axis_floor,step_limit)
             use odeint_allroutines_sub, only : odeint_allroutines
             implicit none
             logical, intent(in) :: near_axis
             integer, intent(in), optional :: step_limit
-            real(dp), intent(in) :: tau1,tau2,relerr
+            real(dp), intent(in) :: tau1,tau2,relerr,axis_floor
             real(dp), intent(inout) :: z(5)
-            integer :: context
+            real(dp) :: context
 
+            context=axis_floor
             if(present(step_limit)) then
-                context=0
                 if(near_axis) then
                     call odeint_allroutines(z,5,context,tau1,tau2,relerr, &
                         velo_axis_context,step_limit=step_limit)
@@ -405,7 +415,8 @@ contains
                         velo_can_context,step_limit=step_limit)
                 endif
             else if(near_axis) then
-                call odeint_allroutines(z,5,tau1,tau2,relerr,velo_axis)
+                call odeint_allroutines(z,5,context,tau1,tau2,relerr, &
+                    velo_axis_context)
             else
                 call odeint_allroutines(z,5,tau1,tau2,relerr,velo_can)
             endif
@@ -430,12 +441,15 @@ contains
             real(dp), intent(out) :: vz(:)
 
             select type(context)
-                type is(integer)
+                type is(real(dp))
+                call velo_axis_regularized(tau,z,vz,context)
+            class default
+                error stop 'invalid axis ODE context'
             end select
-            call velo_axis(tau,z,vz)
         end subroutine velo_axis_context
 
-        subroutine orbit_timestep_axis(z,dtau,dtaumin,relerr,ierr,step_limit)
+        subroutine orbit_timestep_axis(z,dtau,dtaumin,relerr,ierr,step_limit, &
+                axis_floor)
             use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
             use odeint_allroutines_sub, only : odeint_has_failed
             use chamb_sub, only : chamb_can
@@ -448,7 +462,8 @@ contains
             logical :: near_axis
             integer :: ierr
             integer, intent(in), optional :: step_limit
-            real(dp) :: dtau,dtaumin,phi,tau1,tau2,z1,z2
+            real(dp), intent(in), optional :: axis_floor
+            real(dp) :: dtau,dtaumin,phi,tau1,tau2,z1,z2,axis_floor_local
             real(dp) :: relerr
             !
             real(dp), dimension(2)    :: y
@@ -461,6 +476,13 @@ contains
             endif
             !
             ierr=0
+            axis_floor_local=1.d-8
+            if(present(axis_floor)) axis_floor_local=axis_floor
+            if(.not.ieee_is_finite(axis_floor_local) .or. &
+                axis_floor_local.le.0.d0) then
+                ierr=2
+                return
+            endif
             z_initial=z
             y(1)=z(1)
             y(2)=z(2)
@@ -483,7 +505,8 @@ contains
                         z(1)=z1
                         z(2)=z2
                         !
-                        call integrate_axis_segment(z,tau1,tau2,relerr,.false.,step_limit)
+                        call integrate_axis_segment(z,tau1,tau2,relerr,.false., &
+                            axis_floor_local,step_limit)
                         if (odeint_has_failed() .or. .not. all(ieee_is_finite(z))) then
                             z=z_initial
                             ierr=2
@@ -499,7 +522,8 @@ contains
                         if(ierr.eq.1) return
                     else
                         !
-                        call integrate_axis_segment(z,tau1,tau2,relerr,.true.,step_limit)
+                        call integrate_axis_segment(z,tau1,tau2,relerr,.true., &
+                            axis_floor_local,step_limit)
                         if (odeint_has_failed() .or. .not. all(ieee_is_finite(z))) then
                             z=z_initial
                             ierr=2
@@ -515,7 +539,8 @@ contains
                         z(1)=z1
                         z(2)=z2
                         !
-                        call integrate_axis_segment(z,tau1,tau2,relerr,.true.,step_limit)
+                        call integrate_axis_segment(z,tau1,tau2,relerr,.true., &
+                            axis_floor_local,step_limit)
                         if (odeint_has_failed() .or. .not. all(ieee_is_finite(z))) then
                             z=z_initial
                             ierr=2
@@ -524,7 +549,8 @@ contains
                         !
                     else
                         !
-                        call integrate_axis_segment(z,tau1,tau2,relerr,.false.,step_limit)
+                        call integrate_axis_segment(z,tau1,tau2,relerr,.false., &
+                            axis_floor_local,step_limit)
                         if (odeint_has_failed() .or. .not. all(ieee_is_finite(z))) then
                             z=z_initial
                             ierr=2
@@ -555,7 +581,8 @@ contains
                     z(1)=z1
                     z(2)=z2
                     !
-                    call integrate_axis_segment(z,tau1,tau2,relerr,.false.,step_limit)
+                    call integrate_axis_segment(z,tau1,tau2,relerr,.false., &
+                        axis_floor_local,step_limit)
                     if (odeint_has_failed() .or. .not. all(ieee_is_finite(z))) then
                         z=z_initial
                         ierr=2
@@ -571,7 +598,8 @@ contains
                     if(ierr.eq.1) return
                 else
                     !
-                    call integrate_axis_segment(z,tau1,tau2,relerr,.true.,step_limit)
+                    call integrate_axis_segment(z,tau1,tau2,relerr,.true., &
+                        axis_floor_local,step_limit)
                     if (odeint_has_failed() .or. .not. all(ieee_is_finite(z))) then
                         z=z_initial
                         ierr=2
@@ -587,7 +615,8 @@ contains
                     z(1)=z1
                     z(2)=z2
                     !
-                    call integrate_axis_segment(z,tau1,tau2,relerr,.true.,step_limit)
+                    call integrate_axis_segment(z,tau1,tau2,relerr,.true., &
+                        axis_floor_local,step_limit)
                     if (odeint_has_failed() .or. .not. all(ieee_is_finite(z))) then
                         z=z_initial
                         ierr=2
@@ -596,7 +625,8 @@ contains
                     !
                 else
                     !
-                    call integrate_axis_segment(z,tau1,tau2,relerr,.false.,step_limit)
+                    call integrate_axis_segment(z,tau1,tau2,relerr,.false., &
+                        axis_floor_local,step_limit)
                     if (odeint_has_failed() .or. .not. all(ieee_is_finite(z))) then
                         z=z_initial
                         ierr=2

--- a/src/sub_alpha_lifetime_can.f90
+++ b/src/sub_alpha_lifetime_can.f90
@@ -6,7 +6,296 @@ module alpha_lifetime_sub
 
     integer, parameter :: axis_rhs_count = 5
 
+    type :: toroidal_regularization_context_t
+        real(dp) :: mu = 0.0_dp
+        real(dp) :: major_radius_cm = 1.0_dp
+    end type toroidal_regularization_context_t
+
+    ! The Burby--Ellison position map is retained only through first order in
+    ! gyroradius. Near a mirror point, its neglected second-order terms can put
+    ! the mapped state just below the original constant-momentum energy shell.
+    ! Clamp only that small mismatch; a larger negative radicand is a failed
+    ! regularized step and must fall through to the next recovery method.
+    real(dp), parameter :: toroidal_energy_shell_tolerance = 1.0e-5_dp
+
 contains
+
+    subroutine bstar_parallel_factor(z, factor)
+        use parmot_mod, only: ro0
+        use magfie_sub, only: magfie
+        real(dp), intent(in) :: z(5)
+        real(dp), intent(out) :: factor
+        real(dp) :: bmod, sqrtg, bder(3), hcovar(3), hctrvr(3), hcurl(3)
+
+        call magfie(z(1:3), bmod, sqrtg, bder, hcovar, hctrvr, hcurl)
+        factor = 1.0_dp + z(4)*z(5)*(ro0/bmod)*dot_product(hcurl, hcovar)
+    end subroutine bstar_parallel_factor
+
+    subroutine toroidal_regularized_position_map(x, ppar, direction, x_mapped, &
+            ierr)
+        !> Leading near-identity map from Burby and Ellison, Phys. Plasmas 24,
+        !> 110703 (2017), Eq. (13). direction=1 maps the conventional guiding
+        !> centre to the toroidally regularized coordinate; direction=-1
+        !> numerically inverts that first-order map. The toroidal component is
+        !> unchanged, which preserves field-period closure without an angular
+        !> seam.
+        real(dp), intent(in) :: x(3), ppar
+        integer, intent(in) :: direction
+        real(dp), intent(out) :: x_mapped(3)
+        integer, intent(out) :: ierr
+        real(dp), parameter :: derivative_step = 1.0e-6_dp
+        real(dp) :: shift(3), shift_plus(3), shift_minus(3)
+        real(dp) :: residual(2), residual_trial(2), jacobian(2, 2), delta(2)
+        real(dp) :: x_plus(3), x_minus(3), x_trial(3), determinant, damping
+        real(dp) :: residual_norm, trial_norm
+        integer :: iteration, line_search, shift_error
+
+        ierr = 2
+        x_mapped = x
+        if (abs(direction) /= 1) return
+        if (direction == 1) then
+            call toroidal_position_shift(x, ppar, shift, shift_error)
+            if (shift_error /= 0) return
+            x_mapped = x + shift
+            ierr = 0
+            return
+        end if
+
+        ! Invert x_regular=x_standard+shift(x_standard) with a damped two-
+        ! dimensional Newton solve. Fixed-point inversion is not contractive
+        ! near the conventional B_parallel_star singularity.
+        do iteration = 1, 20
+            call toroidal_position_shift(x_mapped, ppar, shift, shift_error)
+            if (shift_error /= 0) then
+                x_mapped = x
+                return
+            end if
+            residual = x_mapped(1:2) + shift(1:2) - x(1:2)
+            residual_norm = maxval(abs(residual))
+            if (residual_norm <= &
+                    1.0e-12_dp*max(1.0_dp, maxval(abs(x)))) then
+                ierr = 0
+                return
+            end if
+            do line_search = 1, 2
+                x_plus = x_mapped
+                x_minus = x_mapped
+                x_plus(line_search) = x_plus(line_search) + derivative_step
+                x_minus(line_search) = x_minus(line_search) - derivative_step
+                call toroidal_position_shift(x_plus, ppar, shift_plus, &
+                    shift_error)
+                if (shift_error /= 0) then
+                    x_mapped = x
+                    return
+                end if
+                call toroidal_position_shift(x_minus, ppar, shift_minus, &
+                    shift_error)
+                if (shift_error /= 0) then
+                    x_mapped = x
+                    return
+                end if
+                jacobian(:, line_search) = &
+                    (shift_plus(1:2) - shift_minus(1:2))/ &
+                    (2.0_dp*derivative_step)
+                jacobian(line_search, line_search) = &
+                    jacobian(line_search, line_search) + 1.0_dp
+            end do
+            determinant = jacobian(1, 1)*jacobian(2, 2) - &
+                jacobian(1, 2)*jacobian(2, 1)
+            if (abs(determinant) <= 100.0_dp*tiny(1.0_dp)) then
+                x_mapped = x
+                return
+            end if
+            delta(1) = (-jacobian(2, 2)*residual(1) + &
+                jacobian(1, 2)*residual(2))/determinant
+            delta(2) = (jacobian(2, 1)*residual(1) - &
+                jacobian(1, 1)*residual(2))/determinant
+
+            damping = 1.0_dp
+            do line_search = 1, 12
+                x_trial = x_mapped
+                x_trial(1:2) = x_trial(1:2) + damping*delta
+                if (x_trial(1) < 0.0_dp) then
+                    damping = 0.5_dp*damping
+                    cycle
+                end if
+                call toroidal_position_shift(x_trial, ppar, shift_plus, &
+                    shift_error)
+                if (shift_error /= 0) then
+                    damping = 0.5_dp*damping
+                    cycle
+                end if
+                residual_trial = x_trial(1:2) + shift_plus(1:2) - x(1:2)
+                trial_norm = maxval(abs(residual_trial))
+                if (trial_norm < residual_norm) then
+                    x_mapped = x_trial
+                    exit
+                end if
+                damping = 0.5_dp*damping
+            end do
+            if (line_search > 12) then
+                x_mapped = x
+                return
+            end if
+        end do
+        x_mapped = x
+    end subroutine toroidal_regularized_position_map
+
+    subroutine toroidal_position_shift(x, ppar, shift, ierr)
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+        use parmot_mod, only: ro0
+        use magfie_sub, only: magfie_refcoords
+        real(dp), intent(in) :: x(3), ppar
+        real(dp), intent(out) :: shift(3)
+        integer, intent(out) :: ierr
+        real(dp) :: bmod, sqrtg, bder(3), hcovar(3), hctrvr(3), hcurl(3)
+        real(dp) :: bphi
+
+        ierr = 2
+        shift = 0.0_dp
+        call magfie_refcoords(x, bmod, sqrtg, bder, hcovar, hctrvr, hcurl)
+        bphi = bmod*hctrvr(3)
+        if (abs(sqrtg*bphi) <= 100.0_dp*tiny(1.0_dp)) return
+        shift(1) = ro0*ppar*hcovar(2)/(sqrtg*bphi)
+        shift(2) = -ro0*ppar*hcovar(1)/(sqrtg*bphi)
+        if (.not. all(ieee_is_finite(shift))) then
+            shift = 0.0_dp
+            return
+        end if
+        ierr = 0
+    end subroutine toroidal_position_shift
+
+    subroutine toroidal_regularized_rhs(tau, y, dy, context)
+        use parmot_mod, only: rmu, ro0
+        use magfie_sub, only: magfie_refcoords
+        real(dp), intent(in) :: tau, y(:)
+        real(dp), intent(out) :: dy(:)
+        class(*), intent(in) :: context
+        real(dp), parameter :: derivative_step = 1.0e-5_dp
+        real(dp) :: bmod, sqrtg, bder(3), hcovar(3), hctrvr(3), hcurl(3)
+        real(dp) :: bp, gp, bdp(3), hcp(3), htp(3), hxp(3)
+        real(dp) :: bm, gm, bdm(3), hcm(3), htm(3), hxm(3)
+        real(dp) :: xwork(3), dq(3), dkinetic(3), q, u, ppar, vpa
+        real(dp) :: drift_scale, gamma
+        real(dp) :: h
+        integer :: i
+
+        select type (ctx => context)
+        type is (toroidal_regularization_context_t)
+            call magfie_refcoords(y(1:3), bmod, sqrtg, bder, hcovar, &
+                hctrvr, hcurl)
+            q = ctx%major_radius_cm*hctrvr(3)
+            if (abs(q) <= 100.0_dp*tiny(1.0_dp)) then
+                dy = huge(1.0_dp)
+                return
+            end if
+
+            do i = 1, 3
+                h = derivative_step
+                xwork = y(1:3)
+                xwork(i) = xwork(i) + h
+                call magfie_refcoords(xwork, bp, gp, bdp, hcp, htp, hxp)
+                xwork(i) = y(i) - h
+                call magfie_refcoords(xwork, bm, gm, bdm, hcm, htm, hxm)
+                dq(i) = ctx%major_radius_cm*(htp(3) - htm(3))/(2.0_dp*h)
+            end do
+
+            u = y(4)
+            ppar = q*u
+            gamma = sqrt(1.0_dp + &
+                2.0_dp*(ppar**2 + 2.0_dp*ctx%mu*bmod)/rmu)
+            vpa = ppar/gamma
+            dkinetic = (u*u*q*dq + ctx%mu*bmod*bder)/gamma
+            drift_scale = ro0/(sqrtg*bmod*hctrvr(3))
+            dy(1) = vpa*hctrvr(1) - drift_scale*dkinetic(2)
+            dy(2) = vpa*hctrvr(2) + drift_scale*dkinetic(1)
+            dy(3) = vpa*hctrvr(3)
+            dy(4) = -dot_product(hctrvr, dkinetic)/q
+        class default
+            dy = huge(1.0_dp)
+        end select
+    end subroutine toroidal_regularized_rhs
+
+    subroutine orbit_timestep_toroidal_regularized(z, dtau, relerr, ierr, &
+            step_limit)
+        use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+        use odeint_allroutines_sub, only: odeint_allroutines, &
+            odeint_has_failed
+        use chamb_sub, only: chamb_can
+        use magfie_sub, only: magfie_refcoords, has_magfie_refcoords_field
+        use field_can_mod, only: integ_to_ref, ref_to_integ
+        use new_vmec_stuff_mod, only: rmajor
+        real(dp), intent(inout) :: z(5)
+        real(dp), intent(in) :: dtau, relerr
+        integer, intent(out) :: ierr
+        integer, intent(in) :: step_limit
+        type(toroidal_regularization_context_t) :: context
+        real(dp) :: z_initial(5), y(4), chamber_y(2)
+        real(dp) :: x_standard(3), x_regular(3)
+        real(dp) :: bmod, sqrtg, bder(3), hcovar(3), hctrvr(3), hcurl(3)
+        real(dp) :: q, ppar, ppar_raw, ppar_squared
+        integer :: map_error
+
+        z_initial = z
+        if (.not. has_magfie_refcoords_field()) then
+            ierr = 2
+            return
+        end if
+        call integ_to_ref(z(1:3), x_standard)
+        call magfie_refcoords(x_standard, bmod, sqrtg, bder, hcovar, hctrvr, &
+            hcurl)
+        context%major_radius_cm = 100.0_dp*rmajor
+        context%mu = 0.5_dp*z(4)**2*(1.0_dp - z(5)**2)/bmod
+        ppar = z(4)*z(5)
+        call toroidal_regularized_position_map(x_standard, ppar, 1, x_regular, &
+            map_error)
+        if (map_error /= 0) then
+            ierr = 2
+            return
+        end if
+        y(1:3) = x_regular
+        call magfie_refcoords(y(1:3), bmod, sqrtg, bder, hcovar, hctrvr, hcurl)
+        q = context%major_radius_cm*hctrvr(3)
+        if (abs(q) <= 100.0_dp*tiny(1.0_dp)) then
+            ierr = 2
+            return
+        end if
+        y(4) = ppar/q
+
+        call odeint_allroutines(y, 4, context, 0.0_dp, dtau, relerr, &
+            toroidal_regularized_rhs, step_limit=step_limit)
+        if (odeint_has_failed() .or. .not. all(ieee_is_finite(y))) then
+            z = z_initial
+            ierr = 2
+            return
+        end if
+
+        call magfie_refcoords(y(1:3), bmod, sqrtg, bder, hcovar, hctrvr, hcurl)
+        q = context%major_radius_cm*hctrvr(3)
+        ppar_raw = q*y(4)
+        call toroidal_regularized_position_map(y(1:3), ppar_raw, -1, &
+            x_standard, map_error)
+        if (map_error /= 0) then
+            z = z_initial
+            ierr = 2
+            return
+        end if
+        call magfie_refcoords(x_standard, bmod, sqrtg, bder, hcovar, hctrvr, &
+            hcurl)
+        ppar_squared = z_initial(4)**2 - 2.0_dp*context%mu*bmod
+        if (ppar_squared < &
+                -toroidal_energy_shell_tolerance*z_initial(4)**2) then
+            z = z_initial
+            ierr = 2
+            return
+        end if
+        ppar = sign(sqrt(max(ppar_squared, 0.0_dp)), ppar_raw)
+        call ref_to_integ(x_standard, z(1:3))
+        z(4) = z_initial(4)
+        z(5) = ppar/z(4)
+        chamber_y = z(1:2)
+        call chamb_can(chamber_y, z(3), ierr)
+    end subroutine orbit_timestep_toroidal_regularized
 
     !ToDo make module from all global things like this one
     !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/test/golden_record/compare_golden_results.sh
+++ b/test/golden_record/compare_golden_results.sh
@@ -141,6 +141,35 @@ compare_cases() {
                 result=$?
             fi
 
+            # Diagnostics used to overwrite these files, so this case only
+            # compared field diagnostics and silently ignored orbit changes.
+            # They now run in an isolated directory; enforce the orbit result
+            # in addition to the diagnostic contract.
+            REF_EXIT="$REFERENCE_DIR/$CASE/orbit_exit_code.dat"
+            CUR_EXIT="$CURRENT_DIR/$CASE/orbit_exit_code.dat"
+            echo "  (also comparing orbit results)"
+            if [ -f "$REF_EXIT" ] && [ -f "$CUR_EXIT" ]; then
+                python "$SCRIPT_DIR/compare_orbit_results.py" \
+                    "$REFERENCE_DIR/$CASE" "$CURRENT_DIR/$CASE" \
+                    --rtol "$GOLDEN_RECORD_RTOL" --atol "$GOLDEN_RECORD_ATOL"
+                orbit_result=$?
+                if [ $orbit_result -eq 3 ]; then
+                    recovery_transition=1
+                    orbit_result=0
+                fi
+            else
+                GOLDEN_RECORD_RTOL="$GOLDEN_RECORD_RTOL" \
+                    GOLDEN_RECORD_ATOL="$GOLDEN_RECORD_ATOL" \
+                    python "$SCRIPT_DIR/compare_files.py" \
+                    "$REFERENCE_DIR/$CASE/times_lost.dat" \
+                    "$CURRENT_DIR/$CASE/times_lost.dat"
+                orbit_result=$?
+            fi
+            if [ $orbit_result -ne 0 ]; then
+                echo "  FAILED: Orbit results differ"
+                result=$orbit_result
+            fi
+
             if [ $result -eq 0 ]; then
                 echo "  ✓ PASSED"
                 passed_cases=$((passed_cases + 1))

--- a/test/golden_record/golden_record.sh
+++ b/test/golden_record/golden_record.sh
@@ -27,7 +27,7 @@ fi
 RUN_DIR_REF="$GOLDEN_RECORD_BASE_DIR/runs/run_$REF_VER"
 RUN_DIR_CUR="$GOLDEN_RECORD_BASE_DIR/runs/run_$CUR_VER"
 TEST_DATA_DIR="$GOLDEN_RECORD_BASE_DIR/test_data"
-GOLDEN_LIBNEO_REF=${GOLDEN_LIBNEO_REF:-cbb57e125390cd21ea906cc0ec9bff5b28c6fc26}
+GOLDEN_LIBNEO_REF=${GOLDEN_LIBNEO_REF:-e2b281b1bc9f9f48f9526622445e0b2c0f8a4984}
 
 # Find test cases - they should be copied by CMake to the golden_record directory
 if [ -n "$SINGLE_CASE" ]; then

--- a/test/golden_record/run_golden_tests.sh
+++ b/test/golden_record/run_golden_tests.sh
@@ -125,6 +125,9 @@ for test_case in $TEST_CASES; do
 
     # Copy input file from project being tested
     cp "$PROJECT_TEST_DIR/$test_case/simple.in" "$test_dir/"
+    if [ -f "$PROJECT_TEST_DIR/$test_case/start.dat" ]; then
+        cp "$PROJECT_TEST_DIR/$test_case/start.dat" "$test_dir/"
+    fi
 
     # Determine which wout and coils files to use based on test case
     if [[ "$test_case" == *"_coils"* ]]; then
@@ -169,11 +172,25 @@ for test_case in $TEST_CASES; do
 
     # Run albert diagnostic for albert_coils test cases
     if [[ "$test_case" == "albert_coils" ]]; then
+        # The diagnostic programs initialize SIMPLE and write the normal orbit
+        # output files as a side effect.  Keep those files away from the orbit
+        # run above so the golden comparison sees the actual 32-particle result.
+        diag_dir="$test_dir/diagnostics"
+        mkdir -p "$diag_dir"
+        rm -f "$diag_dir/albert_coils_diagnostic.dat" \
+            "$diag_dir/albert_intermediate.dat" \
+            "$test_dir/albert_coils_diagnostic.dat" \
+            "$test_dir/albert_intermediate.dat"
+        ln -sfn ../simple.in "$diag_dir/simple.in"
+        ln -sfn ../wout.nc "$diag_dir/wout.nc"
+        ln -sfn ../coils.simple "$diag_dir/coils.simple"
+
         ALBERT_DIAG_BIN="$PROJECT_ROOT/build/test/tests/field_can/test_field_can_albert_coils_diagnostic.x"
         if [ -x "$ALBERT_DIAG_BIN" ]; then
             echo "Running Albert coordinate diagnostic..."
-            "$ALBERT_DIAG_BIN" >> simple.log 2>&1
-            if [ $? -ne 0 ]; then
+            if (cd "$diag_dir" && "$ALBERT_DIAG_BIN") >> simple.log 2>&1; then
+                cp "$diag_dir/albert_coils_diagnostic.dat" "$test_dir/"
+            else
                 echo "Warning: Albert diagnostic failed (non-fatal)"
             fi
         fi
@@ -181,8 +198,9 @@ for test_case in $TEST_CASES; do
         ALBERT_INTER_BIN="$PROJECT_ROOT/build/test/tests/field_can/test_albert_intermediate.x"
         if [ -x "$ALBERT_INTER_BIN" ]; then
             echo "Running Albert intermediate values diagnostic..."
-            "$ALBERT_INTER_BIN" >> simple.log 2>&1
-            if [ $? -ne 0 ]; then
+            if (cd "$diag_dir" && "$ALBERT_INTER_BIN") >> simple.log 2>&1; then
+                cp "$diag_dir/albert_intermediate.dat" "$test_dir/"
+            else
                 echo "Warning: Albert intermediate diagnostic failed (non-fatal)"
             fi
         fi

--- a/test/golden_record_sanity/test_golden_record_sanity_simple.sh
+++ b/test/golden_record_sanity/test_golden_record_sanity_simple.sh
@@ -131,6 +131,48 @@ else
     status=1
 fi
 
+SANITY_TMP=$(mktemp -d)
+trap 'rm -rf "$SANITY_TMP"' EXIT
+for variant in reference matching non_matching; do
+    mkdir -p "$SANITY_TMP/$variant/albert_coils"
+    printf '1.0 2.0\n' > \
+        "$SANITY_TMP/$variant/albert_coils/albert_coils_diagnostic.dat"
+    printf '3.0 4.0\n' > \
+        "$SANITY_TMP/$variant/albert_coils/albert_intermediate.dat"
+    printf '1 0 1.0e-4 0 0\n' > \
+        "$SANITY_TMP/$variant/albert_coils/orbit_exit_code.dat"
+    printf '&config\ntrace_time = 1.0e-4\n/\n' > \
+        "$SANITY_TMP/$variant/albert_coils/simple.in"
+    printf '1.0\n' > \
+        "$SANITY_TMP/$variant/albert_coils/runtime_seconds.txt"
+done
+printf '1 1.0e-4 0.5 0.3 0.1 0.3 0 0 1 0\n' > \
+    "$SANITY_TMP/reference/albert_coils/times_lost.dat"
+cp "$SANITY_TMP/reference/albert_coils/times_lost.dat" \
+    "$SANITY_TMP/matching/albert_coils/times_lost.dat"
+printf '1 1.0e-4 0.6 0.3 0.1 0.3 0 0 1 0\n' > \
+    "$SANITY_TMP/non_matching/albert_coils/times_lost.dat"
+
+echo -n "Test 11: Albert diagnostics and orbit results matching... "
+if "$GOLDEN_RECORD_DIR/compare_golden_results.sh" \
+        "$SANITY_TMP/reference" "$SANITY_TMP/matching" \
+        "albert_coils"; then
+    echo "PASSED"
+else
+    echo "FAILED"
+    status=1
+fi
+
+echo -n "Test 12: Albert orbit difference is detected... "
+if "$GOLDEN_RECORD_DIR/compare_golden_results.sh" \
+        "$SANITY_TMP/reference" "$SANITY_TMP/non_matching" \
+        "albert_coils"; then
+    echo "FAILED (diagnostics hid an orbit difference)"
+    status=1
+else
+    echo "PASSED (correctly detected orbit difference)"
+fi
+
 echo ""
 echo "All tests completed!"
 exit "$status"

--- a/test/python/test_netcdf_results.py
+++ b/test/python/test_netcdf_results.py
@@ -90,6 +90,13 @@ class TestNetCDFResultsOutput:
                 assert ds.canonical_grid_ntheta == 63
                 assert ds.canonical_grid_nphi == 64
                 assert ds.canonical_ode_relerr == 1e-11
+                assert ds.symplectic_newton_warning_factor == 100.0
+                assert ds.symplectic_spectre_newton_warning_factor == 10.0
+                assert ds.chart_boundary_kind == 'auto'
+                assert ds.chart_boundary_kind_effective == 'lcfs'
+                assert ds.diagnostic_midpoint_maxit >= 0
+                assert ds.diagnostic_warning_maxit_accept >= 0
+                assert ds.diagnostic_retry_exhausted >= 0
                 assert ds.multharm == 5
                 assert ds.contr_pp == -1e10
                 assert ds.notrace_passing == 0

--- a/test/python/test_netcdf_results.py
+++ b/test/python/test_netcdf_results.py
@@ -95,6 +95,7 @@ class TestNetCDFResultsOutput:
                 assert ds.chart_boundary_kind == 'auto'
                 assert ds.chart_boundary_kind_effective == 'lcfs'
                 assert ds.wall_query_rho_lcfs == -1.0
+                assert ds.max_consecutive_warning_holds == 1
                 assert ds.diagnostic_midpoint_maxit >= 0
                 assert ds.diagnostic_warning_maxit_accept >= 0
                 assert ds.diagnostic_retry_exhausted >= 0

--- a/test/python/test_netcdf_results.py
+++ b/test/python/test_netcdf_results.py
@@ -98,6 +98,7 @@ class TestNetCDFResultsOutput:
                 assert ds.max_consecutive_warning_holds == 1
                 assert ds.diagnostic_midpoint_maxit >= 0
                 assert ds.diagnostic_warning_maxit_accept >= 0
+                assert ds.diagnostic_warning_axis_crossing_accept >= 0
                 assert ds.diagnostic_retry_exhausted >= 0
                 assert ds.multharm == 5
                 assert ds.contr_pp == -1e10

--- a/test/python/test_netcdf_results.py
+++ b/test/python/test_netcdf_results.py
@@ -94,6 +94,7 @@ class TestNetCDFResultsOutput:
                 assert ds.symplectic_spectre_newton_warning_factor == 10.0
                 assert ds.chart_boundary_kind == 'auto'
                 assert ds.chart_boundary_kind_effective == 'lcfs'
+                assert ds.wall_query_rho_lcfs == -1.0
                 assert ds.diagnostic_midpoint_maxit >= 0
                 assert ds.diagnostic_warning_maxit_accept >= 0
                 assert ds.diagnostic_retry_exhausted >= 0

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -368,6 +368,15 @@ if (ENABLE_OPENMP)
         LABELS "integration"
         TIMEOUT 120)
 
+    add_executable(test_axis_regular_rhs.x test_axis_regular_rhs.f90)
+    target_link_libraries(test_axis_regular_rhs.x simple)
+    add_test(NAME test_axis_regular_rhs
+        COMMAND test_axis_regular_rhs.x
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    set_tests_properties(test_axis_regular_rhs PROPERTIES
+        LABELS "integration"
+        TIMEOUT 120)
+
     # Full-orbit (FO) Boris pusher: energy bound, near-axis crossing, no spurious
     # loss, on the reactor-scale Boozer field (wout.nc symlinked above).
     add_executable(test_fo_boris.x test_fo_boris.f90)

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -661,16 +661,23 @@ add_test(NAME test_boundary_event_config_fraction_inf
     COMMAND test_boundary_event_config.x fraction_inf)
 add_test(NAME test_boundary_event_config_radial_nan
     COMMAND test_boundary_event_config.x radial_nan)
+add_test(NAME test_chart_boundary_config_valid
+    COMMAND test_boundary_event_config.x chart_valid)
+add_test(NAME test_chart_boundary_config_invalid
+    COMMAND test_boundary_event_config.x chart_invalid)
 set_tests_properties(
     test_boundary_event_config_valid
     test_boundary_event_config_fraction_nan
     test_boundary_event_config_fraction_inf
     test_boundary_event_config_radial_nan
+    test_chart_boundary_config_valid
+    test_chart_boundary_config_invalid
     PROPERTIES LABELS "unit")
 set_tests_properties(
     test_boundary_event_config_fraction_nan
     test_boundary_event_config_fraction_inf
     test_boundary_event_config_radial_nan
+    test_chart_boundary_config_invalid
     PROPERTIES WILL_FAIL TRUE)
 
 add_executable(test_field_base.x test_field_base.f90)

--- a/test/tests/field_can/test_spectre_sympl_crossing.f90
+++ b/test/tests/field_can/test_spectre_sympl_crossing.f90
@@ -40,7 +40,8 @@ program test_spectre_sympl_crossing
     use field_can_mod, only: field_can_t, eval_field => evaluate, get_val, &
                              integ_to_ref, ref_to_integ
     use field_can_spectre, only: spectre_mvol, set_spectre_volume_lock
-    use orbit_symplectic_base, only: symplectic_integrator_t
+    use orbit_symplectic_base, only: symplectic_integrator_t, &
+        symplectic_spectre_newton_warning_factor
     use spectre_sympl_orbit, only: sympl_spectre_state_t, sympl_spectre_reset, &
                                    orbit_microstep_sympl_spectre, recanon_pphi, &
                                    sympl_landing_stats_reset, &
@@ -315,8 +316,12 @@ contains
         nrec_got = 0
         do k = 1, NSTEP
             call orbit_microstep_sympl_spectre(state, si, f, im, &
-                                               real(k - 1, dp)*dtaumin/v0, &
-                                               dtaumin/v0, ierr, t_frac)
+                real(k - 1, dp)*dtaumin/v0, &
+                dtaumin/v0, ierr, t_frac)
+            if (si%warning_factor /= &
+                symplectic_spectre_newton_warning_factor) then
+                error stop 'SPECTRE lost its strict Newton warning bound'
+            end if
             if (ierr /= SYMPL_SPECTRE_OK) exit
             if (mod(k, NSAMPLE) == 0) then
                 nrec_got = nrec_got + 1

--- a/test/tests/test_axis_regular_rhs.f90
+++ b/test/tests/test_axis_regular_rhs.f90
@@ -1,0 +1,101 @@
+program test_axis_regular_rhs
+    !> The RK recovery field in (X,Y,phi) must have a unique axis limit,
+    !> preserve the established polar RHS outside its reconstruction disk,
+    !> join without a handoff seam, and close after one field period.
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use util, only: twopi
+    use simple, only: tracer_t, init_params
+    use simple_main, only: init_field
+    use params, only: field_input, coord_input
+    use velo_mod, only: isw_field_type
+    use magfie_sub, only: BOOZER, init_magfie
+    use alpha_lifetime_sub, only: velo_axis_regularized, velo_can
+
+    implicit none
+
+    integer, parameter :: nray = 8
+    real(dp), parameter :: sample_s = 1.0e-6_dp
+    real(dp), parameter :: probe_rho = 1.0e-12_dp
+    real(dp), parameter :: axis_limit_tol = 1.0e-8_dp
+    type(tracer_t) :: norb
+    real(dp) :: angle, spread, rho, s, theta
+    real(dp) :: zaxis(5), vaxis(5), vprobe(5), zpolar(5), vpolar(5)
+    real(dp) :: vexpected(5), vperiodic(5)
+    integer :: iray
+    logical :: failed
+
+    isw_field_type = BOOZER
+    field_input = 'wout.nc'
+    coord_input = 'wout.nc'
+    call init_field(norb, 'wout.nc', 5, 5, 5, 1)
+    call init_params(norb, 2, 4, 3.5e6_dp, 256, 1, 1.0e-12_dp)
+    call init_magfie(BOOZER)
+
+    failed = .false.
+    zaxis = [0.0_dp, 0.0_dp, 0.1_dp, 1.0_dp, -0.3_dp]
+    call velo_axis_regularized(0.0_dp, zaxis, vaxis, sample_s)
+    spread = 0.0_dp
+    do iray = 0, nray - 1
+        angle = twopi*real(iray, dp)/real(nray, dp)
+        zaxis(1) = probe_rho*cos(angle)
+        zaxis(2) = probe_rho*sin(angle)
+        call velo_axis_regularized(0.0_dp, zaxis, vprobe, sample_s)
+        spread = max(spread, maxval(abs(vprobe - vaxis)))
+    end do
+    if (spread > axis_limit_tol) then
+        print *, 'FAIL: axis RHS depends on approach ray, spread = ', spread
+        failed = .true.
+    end if
+
+    rho = 2.0e-2_dp
+    theta = 0.7_dp
+    s = rho*rho
+    zaxis = [rho*cos(theta), rho*sin(theta), 0.1_dp, 1.0_dp, -0.3_dp]
+    zpolar = [s, theta, zaxis(3), zaxis(4), zaxis(5)]
+    call velo_can(0.0_dp, zpolar, vpolar)
+    call polar_rhs_to_axis(zaxis, s, vpolar, vexpected)
+    call velo_axis_regularized(0.0_dp, zaxis, vprobe, sample_s)
+    if (maxval(abs(vprobe - vexpected)) > 1.0e-12_dp) then
+        print *, 'FAIL: tensor pullback changed the outer RHS, error = ', &
+            maxval(abs(vprobe - vexpected))
+        failed = .true.
+    end if
+
+    rho = 0.999_dp*sqrt(sample_s)
+    s = rho*rho
+    zaxis(1:2) = [rho*cos(theta), rho*sin(theta)]
+    zpolar(1:2) = [s, theta]
+    call velo_can(0.0_dp, zpolar, vpolar)
+    call polar_rhs_to_axis(zaxis, s, vpolar, vexpected)
+    call velo_axis_regularized(0.0_dp, zaxis, vprobe, sample_s)
+    if (maxval(abs(vprobe - vexpected)) > 1.0e-7_dp) then
+        print *, 'FAIL: reconstructed axis RHS has a handoff seam, error = ', &
+            maxval(abs(vprobe - vexpected))
+        failed = .true.
+    end if
+
+    zaxis = [0.0_dp, 0.0_dp, 0.1_dp, 1.0_dp, -0.3_dp]
+    call velo_axis_regularized(0.0_dp, zaxis, vaxis, sample_s)
+    zaxis(3) = zaxis(3) + norb%fper
+    call velo_axis_regularized(0.0_dp, zaxis, vperiodic, sample_s)
+    if (maxval(abs(vperiodic - vaxis)) > 1.0e-10_dp) then
+        print *, 'FAIL: axis RHS is not field-periodic, error = ', &
+            maxval(abs(vperiodic - vaxis))
+        failed = .true.
+    end if
+
+    if (failed) error stop 1
+    print *, 'test_axis_regular_rhs PASSED'
+
+contains
+
+    pure subroutine polar_rhs_to_axis(zaxis, s, vpolar, vaxis)
+        real(dp), intent(in) :: zaxis(5), s, vpolar(5)
+        real(dp), intent(out) :: vaxis(5)
+
+        vaxis(1) = 0.5_dp*vpolar(1)*zaxis(1)/s - vpolar(2)*zaxis(2)
+        vaxis(2) = 0.5_dp*vpolar(1)*zaxis(2)/s + vpolar(2)*zaxis(1)
+        vaxis(3:5) = vpolar(3:5)
+    end subroutine polar_rhs_to_axis
+
+end program test_axis_regular_rhs

--- a/test/tests/test_axis_regular_rhs.f90
+++ b/test/tests/test_axis_regular_rhs.f90
@@ -14,7 +14,7 @@ program test_axis_regular_rhs
     implicit none
 
     integer, parameter :: nray = 8
-    real(dp), parameter :: sample_s = 1.0e-6_dp
+    real(dp), parameter :: sample_s = 1.0e-3_dp
     real(dp), parameter :: probe_rho = 1.0e-12_dp
     real(dp), parameter :: axis_limit_tol = 1.0e-8_dp
     type(tracer_t) :: norb
@@ -47,7 +47,7 @@ program test_axis_regular_rhs
         failed = .true.
     end if
 
-    rho = 2.0e-2_dp
+    rho = 5.0e-2_dp
     theta = 0.7_dp
     s = rho*rho
     zaxis = [rho*cos(theta), rho*sin(theta), 0.1_dp, 1.0_dp, -0.3_dp]

--- a/test/tests/test_axis_regular_rhs.f90
+++ b/test/tests/test_axis_regular_rhs.f90
@@ -56,7 +56,7 @@ program test_axis_regular_rhs
     call polar_rhs_to_axis(zaxis, s, vpolar, vexpected)
     call velo_axis_regularized(0.0_dp, zaxis, vprobe, sample_s)
     if (maxval(abs(vprobe - vexpected)) > 1.0e-12_dp) then
-        print *, 'FAIL: tensor pullback changed the outer RHS, error = ', &
+        print *, 'FAIL: regular chart changed the outer RHS, error = ', &
             maxval(abs(vprobe - vexpected))
         failed = .true.
     end if

--- a/test/tests/test_boundary_event_config.f90
+++ b/test/tests/test_boundary_event_config.f90
@@ -2,7 +2,8 @@ program test_boundary_event_config
     use, intrinsic :: ieee_arithmetic, only: ieee_positive_inf, ieee_quiet_nan, &
         ieee_value
     use params, only: boundary_event_fraction_tolerance, &
-        boundary_event_radial_tolerance, validate_boundary_event_tolerances
+        boundary_event_radial_tolerance, chart_boundary_kind, &
+        validate_boundary_event_tolerances, validate_chart_boundary_kind
 
     implicit none
 
@@ -20,6 +21,14 @@ program test_boundary_event_config
         boundary_event_fraction_tolerance = ieee_value(0.0d0, ieee_positive_inf)
     case ('radial_nan')
         boundary_event_radial_tolerance = ieee_value(0.0d0, ieee_quiet_nan)
+    case ('chart_valid')
+        chart_boundary_kind = 'wall'
+        call validate_chart_boundary_kind
+        stop
+    case ('chart_invalid')
+        chart_boundary_kind = 'surface'
+        call validate_chart_boundary_kind
+        stop
     case default
         error stop 'unknown boundary event configuration test mode'
     end select

--- a/test/tests/test_fo_boris.f90
+++ b/test/tests/test_fo_boris.f90
@@ -10,9 +10,10 @@ program test_fo_boris
   !   (2) NEAR-AXIS: a particle whose orbit reaches small s crosses the axis region
   !       with energy still bounded and no integrator failure,
   !   (3) a confined particle stays 0 < s < 1 over the run (no spurious loss).
+  use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
   use, intrinsic :: iso_fortran_env, only: dp => real64
   use parmot_mod, only: ro0
-  use simple, only: init_params, tracer_t
+  use simple, only: init_params, orbit_timestep_fo_bridge, tracer_t
   use simple_main, only: init_field
   use orbit_fo_boris, only: fo_state_t, fo_init, fo_step, &
     fo_energy, fo_mu, fo_to_gc, accept_or_fail, FO_OK, FO_LOCATE_FAIL
@@ -20,7 +21,9 @@ program test_fo_boris
   use reference_coordinates, only: ref_coords
   use params, only: field_input, coord_input, integmode, relerr, dtaumin, orbit_coord
   use velo_mod, only: isw_field_type
-  use magfie_sub, only: BOOZER
+  use magfie_sub, only: BOOZER, magfie_refcoords, magfie_vmec
+  use alpha_lifetime_sub, only: toroidal_regularized_position_map
+  use field_can_mod, only: integ_to_ref, ref_to_integ
   use boozer_coordinates_mod, only: use_B_r, use_del_tp_B
   use boozer_sub, only: get_boozer_coordinates
   implicit none
@@ -45,6 +48,9 @@ program test_fo_boris
   ! field assembly and the Cartesian inverse Newton both rely on it; a transposed
   ! Jacobian flips the field while Boris still conserves energy, so check it here.
   call check_covariant_basis_convention(nfail)
+  call check_reference_fallback_field(nfail)
+  call check_reference_axis_bridge(nfail)
+  call check_toroidal_position_map(nfail)
 
   ! passing (lambda=0.9), trapped (lambda=0.2), and an inner orbit driven toward
   ! the axis (small s, lambda=0.7) to exercise the near-axis crossing.
@@ -64,6 +70,70 @@ program test_fo_boris
   end if
 
 contains
+
+  subroutine check_reference_axis_bridge(nfail)
+    integer, intent(inout) :: nfail
+    real(dp) :: z(5), x_reference(3)
+    integer :: ierr
+
+    x_reference = [0.01_dp, 0.7_dp, 0.2_dp]
+    call ref_to_integ(x_reference, z(1:3))
+    z(4:5) = [1.0_dp, 0.2_dp]
+    call orbit_timestep_fo_bridge(norb%fo, z, dtaumin, ierr)
+    call check('native-reference axis bridge succeeds', ierr == 0, nfail)
+    if (ierr /= 0) return
+    call integ_to_ref(z(1:3), x_reference)
+    call check('native-reference axis bridge stays finite', &
+      all(ieee_is_finite(x_reference)) .and. all(ieee_is_finite(z(4:5))), &
+      nfail)
+    call check('native-reference axis bridge preserves momentum shell', &
+      z(4) == 1.0_dp, nfail)
+  end subroutine check_reference_axis_bridge
+
+  subroutine check_reference_fallback_field(nfail)
+    integer, intent(inout) :: nfail
+    real(dp), parameter :: x(3) = [0.36_dp, 0.7_dp, 0.2_dp]
+    real(dp) :: bmod, sqrtg, bder(3), hcov(3), hctr(3), hcurl(3)
+    real(dp) :: bmod_ref, sqrtg_ref, bder_ref(3), hcov_ref(3)
+    real(dp) :: hctr_ref(3), hcurl_ref(3), relative_derivative_error
+
+    call magfie_refcoords(x, bmod, sqrtg, bder, hcov, hctr, hcurl)
+    call magfie_vmec(x, bmod_ref, sqrtg_ref, bder_ref, hcov_ref, hctr_ref, &
+      hcurl_ref)
+    call check('generic fallback field is finite', &
+      ieee_is_finite(bmod) .and. ieee_is_finite(sqrtg) .and. &
+      all(ieee_is_finite(bder)) .and. all(ieee_is_finite(hcov)) .and. &
+      all(ieee_is_finite(hctr)) .and. all(ieee_is_finite(hcurl)), nfail)
+    call check('generic fallback field preserves B', &
+      abs(bmod - bmod_ref) <= 1.0e-12_dp*abs(bmod_ref), nfail)
+    relative_derivative_error = maxval(abs(bder - bder_ref))/ &
+      max(maxval(abs(bder_ref)), 1.0e-12_dp)
+    call check('generic fallback field derivatives match VMEC', &
+      relative_derivative_error < 1.0e-4_dp, nfail)
+  end subroutine check_reference_fallback_field
+
+  subroutine check_toroidal_position_map(nfail)
+    integer, intent(inout) :: nfail
+    real(dp), parameter :: x(3) = [0.36_dp, 0.7_dp, 0.2_dp]
+    real(dp) :: x_regular(3), x_roundtrip(3), displacement, closure
+    integer :: ierr
+
+    call toroidal_regularized_position_map(x, 0.5_dp, 1, x_regular, ierr)
+    call check('toroidal position map succeeds', ierr == 0, nfail)
+    if (ierr /= 0) return
+    call toroidal_regularized_position_map(x_regular, 0.5_dp, -1, &
+      x_roundtrip, ierr)
+    call check('inverse toroidal position map succeeds', ierr == 0, nfail)
+    if (ierr /= 0) return
+    displacement = maxval(abs(x_regular - x))
+    closure = maxval(abs(x_roundtrip - x))
+    print '(a,es10.2,a,es10.2)', '  toroidal map displacement=', displacement, &
+      ' first-order closure=', closure
+    call check('toroidal position map leaves phi unchanged', &
+      x_regular(3) == x(3) .and. x_roundtrip(3) == x(3), nfail)
+    call check('toroidal position map closes to first order', &
+      closure < max(0.01_dp*displacement, 1.0e-10_dp), nfail)
+  end subroutine check_toroidal_position_map
 
   ! accept_or_fail must LOCATE (FO_OK) a marker that clamped to the edge while its warm
   ! guess was already near the edge -- a genuine LCFS exit, so fo_to_gc can flag the

--- a/test/tests/test_newton_solver_status.f90
+++ b/test/tests/test_newton_solver_status.f90
@@ -309,21 +309,34 @@ contains
     tolref = [1.0_dp, 2.0_dp]
     accepted = previous + [5.0e-12_dp, 1.0e-11_dp]
     symplectic_newton_warning_mode = .true.
-    if (.not. accept_warning_maxiter(accepted, previous, tolref, 1.0e-12_dp)) then
-      error stop 'warning mode rejected a bounded Newton correction'
-    end if
-    accepted(1) = huge(1.0_dp)
-    if (accept_warning_maxiter(accepted, previous, tolref, 1.0e-12_dp)) then
-      error stop 'warning mode accepted an unbounded Newton correction'
-    end if
+        if (.not. accept_warning_maxiter(accepted, previous, tolref, 1.0e-12_dp, &
+            10.0_dp)) then
+            error stop 'warning mode rejected a bounded Newton correction'
+        end if
+        accepted = previous + [50.0e-12_dp, 100.0e-12_dp]
+        if (.not. accept_warning_maxiter(accepted, previous, tolref, 1.0e-12_dp, &
+            100.0_dp)) then
+            error stop 'generic warning mode rejected a roundoff plateau correction'
+        end if
+        if (accept_warning_maxiter(accepted, previous, tolref, 1.0e-12_dp, &
+            10.0_dp)) then
+            error stop 'SPECTRE warning bound accepted a generic-only correction'
+        end if
+        accepted(1) = huge(1.0_dp)
+        if (accept_warning_maxiter(accepted, previous, tolref, 1.0e-12_dp, &
+            100.0_dp)) then
+            error stop 'warning mode accepted an unbounded Newton correction'
+        end if
     accepted = previous
     accepted(1) = ieee_value(0.0_dp, ieee_quiet_nan)
-    if (accept_warning_maxiter(accepted, previous, tolref, 1.0e-12_dp)) then
+        if (accept_warning_maxiter(accepted, previous, tolref, 1.0e-12_dp, &
+            100.0_dp)) then
       error stop 'warning mode accepted a non-finite Newton correction'
     end if
     accepted = previous
     symplectic_newton_warning_mode = .false.
-    if (accept_warning_maxiter(accepted, previous, tolref, 1.0e-12_dp)) then
+        if (accept_warning_maxiter(accepted, previous, tolref, 1.0e-12_dp, &
+            100.0_dp)) then
       error stop 'strict mode accepted a Newton max-iteration state'
     end if
   end subroutine test_newton_warning_mode
@@ -362,18 +375,18 @@ contains
     retry_calls = 0
     call advance_symplectic_with_retry(retry_integrator, retry_field, &
       second_half_fails_step, step_status, accepted_fraction)
-    if (step_status /= SYMPLECTIC_STEP_OK) then
-      error stop 'warning mode discarded a recoverable first half'
-    end if
-    if (abs(retry_integrator%z(1) - 1.0_dp) > 1.0e-14_dp .or. &
-        abs(retry_field%H - 0.5_dp) > 1.0e-14_dp) then
-      error stop 'failed second half rolled back accepted progress'
+        if (step_status /= SYMPLECTIC_STEP_MAXITER) then
+            error stop 'warning mode hid a failed second half'
+        end if
+        if (any(retry_integrator%z /= initial_state) .or. &
+            retry_field%H /= 0.0_dp) then
+            error stop 'failed second half did not roll back the full interval'
     end if
     if (retry_integrator%dt /= 1.0_dp) then
       error stop 'partial retry did not restore the configured timestep'
     end if
-    if (abs(accepted_fraction - 0.5_dp) > 1.0e-14_dp) then
-      error stop 'partial retry reported the wrong accepted duration'
+        if (accepted_fraction /= 0.0_dp) then
+            error stop 'failed retry reported an accepted duration'
     end if
 
     retry_integrator%z = initial_state

--- a/test/tests/test_newton_solver_status.f90
+++ b/test/tests/test_newton_solver_status.f90
@@ -135,6 +135,7 @@ end module linear_radial_field_backend
 program test_newton_solver_status
   use, intrinsic :: ieee_arithmetic, only: ieee_quiet_nan, ieee_value
   use, intrinsic :: iso_fortran_env, only: dp => real64
+  use util, only: twopi
   use field_can_mod, only: field_can_t, eval_field => evaluate
   use linear_radial_field_backend, only: basin_limited_step, &
     evaluate_linear_radial, failed_boundary_step, nonlinear_boundary_step, &
@@ -144,6 +145,7 @@ program test_newton_solver_status
     newton_midpoint, orbit_sympl_init, &
     orbit_timestep_sympl, matrix3_near_singular, solve_newton_system, &
     get_boundary_event_tolerances, accept_warning_maxiter, &
+    accept_warning_axis_crossing, &
     limit_radial_newton_step
   use orbit_symplectic_base, only: symplectic_integrator_t, sympl_rmax, &
     EXPL_IMPL_EULER, IMPL_EXPL_EULER, MIDPOINT, GAUSS1, GAUSS2, GAUSS3, &
@@ -283,6 +285,7 @@ contains
     type(symplectic_integrator_t) :: strict_integrator
     type(field_can_t) :: strict_field
     real(dp) :: initial_state(4), accepted(2), previous(2), tolref(2)
+    real(dp) :: axis_iterate(5), axis_previous(5), axis_tolref(5)
     integer :: mode_index, step_status
 
     eval_field => evaluate_linear_radial
@@ -338,6 +341,39 @@ contains
         if (accept_warning_maxiter(accepted, previous, tolref, 1.0e-12_dp, &
             100.0_dp)) then
       error stop 'strict mode accepted a Newton max-iteration state'
+    end if
+
+    strict_integrator%z = [5.0e-7_dp, 1.0_dp, 2.0_dp, 3.0_dp]
+    axis_iterate = [-4.0e-7_dp, 1.0_dp, 2.0_dp, 3.0_dp, -2.0e-7_dp]
+    axis_previous = [0.01_dp, 1.0_dp, 2.0_dp, 3.0_dp, 0.01_dp]
+    axis_tolref = [1.0_dp, twopi, twopi, 10.0_dp, 1.0_dp]
+    symplectic_newton_warning_mode = .true.
+    if (.not. accept_warning_axis_crossing(strict_integrator, axis_iterate, &
+        axis_previous, axis_tolref, 1.0e-12_dp)) then
+      error stop 'warning mode rejected a local converged axis crossing'
+    end if
+    axis_iterate(1) = abs(axis_iterate(1))
+    if (accept_warning_axis_crossing(strict_integrator, axis_iterate, &
+        axis_previous, axis_tolref, 1.0e-12_dp)) then
+      error stop 'axis recovery accepted a non-crossing max-iteration state'
+    end if
+    axis_iterate(1) = -4.0e-7_dp
+    axis_iterate(2) = axis_iterate(2) + 1.0e-6_dp
+    if (accept_warning_axis_crossing(strict_integrator, axis_iterate, &
+        axis_previous, axis_tolref, 1.0e-12_dp)) then
+      error stop 'axis recovery accepted an unconverged angular correction'
+    end if
+    axis_iterate(2) = axis_previous(2)
+    strict_integrator%z(1) = 0.1_dp
+    if (accept_warning_axis_crossing(strict_integrator, axis_iterate, &
+        axis_previous, axis_tolref, 1.0e-12_dp)) then
+      error stop 'axis recovery accepted a crossing from outside the axis chart'
+    end if
+    strict_integrator%z(1) = 5.0e-7_dp
+    symplectic_newton_warning_mode = .false.
+    if (accept_warning_axis_crossing(strict_integrator, axis_iterate, &
+        axis_previous, axis_tolref, 1.0e-12_dp)) then
+      error stop 'strict mode accepted an axis max-iteration state'
     end if
   end subroutine test_newton_warning_mode
 

--- a/test/tests/test_restart_io.f90
+++ b/test/tests/test_restart_io.f90
@@ -3,7 +3,7 @@ program test_restart_io
     use params, only: ntestpart, times_lost, trap_par, perp_inv, zend, zstart, &
                       orbit_exit_code, boundary_event_radial_residual, &
                       boundary_event_time_width, ORBIT_EXIT_COMPLETED, &
-                      ORBIT_EXIT_LCFS, &
+                      ORBIT_EXIT_LCFS, ORBIT_EXIT_NUMERICAL_CONFINED, &
                       confpart_pass, confpart_trap, ntimstep, kt_macro, &
                       v0, dtaumin, trace_time
     use restart_mod, only: particle_done, read_restart_data, restore_confined_counts
@@ -15,6 +15,7 @@ program test_restart_io
     nerr = 0
     call test_read_restart()
     call test_legacy_restart_retraces_early_exit()
+    call test_numerically_confined_restart()
     call test_restore_counts()
 
     if (nerr > 0) then
@@ -136,6 +137,42 @@ contains
                     boundary_event_time_width, trap_par, perp_inv, zend, zstart, &
                     particle_done)
     end subroutine test_legacy_restart_retraces_early_exit
+
+    subroutine test_numerically_confined_restart()
+        integer :: unit
+
+        ntestpart = 1
+        trace_time = 1.0d0
+        allocate (times_lost(1), trap_par(1), perp_inv(1), orbit_exit_code(1))
+        allocate (boundary_event_radial_residual(1), boundary_event_time_width(1))
+        allocate (zend(5, 1), zstart(5, 1))
+        times_lost = -1.0d0
+        orbit_exit_code = ORBIT_EXIT_COMPLETED
+        trap_par = 0.0d0
+        perp_inv = 0.0d0
+        zend = 0.0d0
+        zstart = 0.0d0
+
+        open (newunit=unit, file='times_lost.dat', recl=1024)
+        write (unit, *) 1, trace_time, 0.0d0, 0.0d0, 0.0d0, zend(:, 1)
+        close (unit)
+        open (newunit=unit, file='orbit_exit_code.dat', recl=1024)
+        write (unit, *) 1, ORBIT_EXIT_NUMERICAL_CONFINED, trace_time, &
+            -1.0d0, -1.0d0
+        close (unit)
+
+        call read_restart_data()
+        call assert(particle_done(1), &
+            'numerically confined marker is reusable', 1)
+        call assert(orbit_exit_code(1) == ORBIT_EXIT_NUMERICAL_CONFINED, &
+            'numerically confined exit code restored', 1)
+        call assert_eq(times_lost(1), trace_time, &
+            'numerically confined trace time restored', 1)
+
+        deallocate (times_lost, orbit_exit_code, boundary_event_radial_residual, &
+                    boundary_event_time_width, trap_par, perp_inv, zend, zstart, &
+                    particle_done)
+    end subroutine test_numerically_confined_restart
 
     subroutine test_restore_counts()
         integer :: it

--- a/test/tests/test_result_accounting.f90
+++ b/test/tests/test_result_accounting.f90
@@ -8,7 +8,7 @@ program test_result_accounting
         zstart, zend, boundary_event_radial_residual, &
         boundary_event_time_width, isw_field_type, class_plot, &
         ntcut, ORBIT_EXIT_COMPLETED, ORBIT_EXIT_LCFS, &
-        ORBIT_EXIT_NUMERICAL_MAXITER
+        ORBIT_EXIT_NUMERICAL_CONFINED, ORBIT_EXIT_NUMERICAL_MAXITER
     use simple_main, only: write_results
     implicit none
 
@@ -17,6 +17,7 @@ program test_result_accounting
     nerr = 0
     call setup_results()
     call test_resolved_denominator()
+    call test_numerically_confined_denominator()
     call test_zero_resolved()
     call teardown_results()
 
@@ -86,6 +87,35 @@ contains
             'unresolved fraction keeps total denominator')
         call assert_true(total_count == 3, 'unresolved denominator is total')
     end subroutine test_resolved_denominator
+
+    subroutine test_numerically_confined_denominator()
+        integer :: unit, resolved_count, total_count
+        real(dp) :: time, pass_fraction, trap_fraction, unresolved_fraction
+
+        confpart_pass = 2.0_dp
+        confpart_trap = 0.0_dp
+        unresolved_orbits = 0
+        times_lost = [10.0_dp, 5.0_dp, 10.0_dp]
+        orbit_exit_code = [ORBIT_EXIT_COMPLETED, ORBIT_EXIT_LCFS, &
+            ORBIT_EXIT_NUMERICAL_CONFINED]
+
+        call write_results()
+
+        open (newunit=unit, file='confined_fraction.dat', status='old')
+        read (unit, *) time, pass_fraction, trap_fraction, resolved_count
+        close (unit)
+        call assert_close(pass_fraction, 2.0_dp/3.0_dp, &
+            'numerically confined marker remains resolved')
+        call assert_true(resolved_count == 3, &
+            'numerically confined marker stays in denominator')
+
+        open (newunit=unit, file='unresolved_fraction.dat', status='old')
+        read (unit, *) time, unresolved_fraction, total_count
+        close (unit)
+        call assert_close(unresolved_fraction, 0.0_dp, &
+            'numerically confined marker is not unresolved')
+        call assert_true(total_count == 3, 'total population remains three')
+    end subroutine test_numerically_confined_denominator
 
     subroutine test_zero_resolved()
         integer :: unit, resolved_count

--- a/test/tests/test_stl_wall_intersection.f90
+++ b/test/tests/test_stl_wall_intersection.f90
@@ -6,7 +6,8 @@ program test_stl_wall_intersection
     use simple_main, only: main_wall => wall, chartmap_cart_scale_to_m, &
                            locate_wall_segment
     use params, only: wall_hit, wall_hit_cart, wall_hit_normal_cart, &
-                      wall_hit_cos_incidence, wall_hit_angle_rad
+                      wall_hit_cos_incidence, wall_hit_angle_rad, &
+                      wall_query_rho_lcfs
     use reference_coordinates, only: ref_coords
     use cartesian_coordinates, only: cartesian_coordinate_system_t
     implicit none
@@ -46,8 +47,27 @@ program test_stl_wall_intersection
     chartmap_cart_scale_to_m = 1.0_dp
     z_start = [p0, 4.0_dp, 5.0_dp]
     z_end = [p1, 11.0_dp, 19.0_dp]
+
+    ! A Cartesian chord can intersect a non-convex external wall even though
+    ! its accepted endpoint remains inside the LCFS. Such a chord is not a
+    ! physical wall loss and must not be queried.
+    wall_query_rho_lcfs = 1.0_dp
+    u_start = [0.25_dp, 0.25_dp, 0.25_dp]
+    u_end = [0.50_dp, 0.25_dp, 0.25_dp]
     z = z_end
-    call locate_wall_segment(z, z_start, z_end, 1, p0, p0, p1, p1, 6.0_dp, &
+    call locate_wall_segment(z, z_start, z_end, 1, p0, u_start, p1, u_end, &
+        6.0_dp, 8.0_dp, 7.0_dp, hit, hit_step)
+    call check(.not. hit, "interior-LCFS chord was queried against wall", errors)
+    call check(wall_hit(1) == 0_int8, "interior chord set wall hit flag", errors)
+    call check_close_vec(z, z_end, 1.0e-12_dp, &
+        "interior chord changed orbit state", errors)
+    call check_close(hit_step, 15.0_dp, 1.0e-12_dp, &
+        "interior chord changed event time", errors)
+
+    u_start = p0
+    u_end = p1
+    z = z_end
+    call locate_wall_segment(z, z_start, z_end, 1, p0, u_start, p1, u_end, 6.0_dp, &
         8.0_dp, 7.0_dp, hit, hit_step)
     call check(hit, "wall event locator missed crossing", errors)
     call check_close_vec(z(1:3), hit_p, 1.0e-12_dp, &
@@ -77,6 +97,7 @@ program test_stl_wall_intersection
     call check_close(z(3), 3.0_dp, 1.0e-12_dp, &
         "wall event field-period seam mismatch", errors)
     call stl_wall_finalize(main_wall)
+    wall_query_rho_lcfs = -1.0_dp
 
     call write_tetra_stl_mm("tetra_mm.stl")
     call stl_wall_init(main_wall, "tetra_mm.stl", 1.0e-3_dp)

--- a/test/tests/test_sympl_testfield.f90
+++ b/test/tests/test_sympl_testfield.f90
@@ -42,7 +42,9 @@ program test_sympl_testfield
         locate_validated_lcfs, macrostep, macrostep_with_wall_check, &
         recovery_state_has_valid_phase_space, recovery_state_is_physical, &
         rk_recovery_state_t, validate_rk_state, &
-        activate_rk_recovery, should_resume_symplectic
+        activate_rk_recovery, should_resume_symplectic, &
+        normalized_flux_from_reference_radial, &
+        should_classify_numerically_confined
     use simple, only : tracer_t, init_sympl, reseed_sympl, ORBIT_FO_LOSS, &
         ORBIT_FO_NUMERICAL
     use params, only : isw_field_type, field_input, coord_input, integmode, &
@@ -101,6 +103,7 @@ program test_sympl_testfield
     call test_failed_step_preserves_state
     call test_rk_recovery_regions
     call test_exit_classification
+    call test_numerically_confined_classification
     call test_fo_lcfs_location
     call test_validated_rk_lcfs_location
     call test_rk_state_validation
@@ -363,6 +366,49 @@ contains
             error stop 'classifier mode promoted an RK fault to a physical loss'
         end if
     end subroutine test_exit_classification
+
+    subroutine test_numerically_confined_classification
+        if (abs(normalized_flux_from_reference_radial(0.1_dp, .true.) - &
+                0.01_dp) > epsilon(1.0_dp)) then
+            error stop 'chartmap rho was not converted to normalized flux s'
+        end if
+        if (normalized_flux_from_reference_radial(0.1_dp, .false.) /= 0.1_dp) then
+            error stop 'VMEC normalized flux s was incorrectly rescaled'
+        end if
+        if (.not. should_classify_numerically_confined( &
+                ORBIT_EXIT_NUMERICAL_MAXITER, ORBIT_GC, 1, .true., .false., &
+                .true., 0.0099_dp)) then
+            error stop 'eligible core recovery failure was not classified confined'
+        end if
+        if (should_classify_numerically_confined(ORBIT_EXIT_NUMERICAL_MAXITER, &
+                ORBIT_GC, 1, .true., .false., .true., 0.01_dp)) then
+            error stop 'axis fallback included its outer radial boundary'
+        end if
+        if (should_classify_numerically_confined(ORBIT_EXIT_NUMERICAL_MAXITER, &
+                ORBIT_GC, 1, .true., .true., .true., 0.01_dp)) then
+            error stop 'collisional marker was classified numerically confined'
+        end if
+        if (should_classify_numerically_confined(ORBIT_EXIT_NUMERICAL_MAXITER, &
+                ORBIT_GC, 1, .false., .false., .true., 0.01_dp)) then
+            error stop 'strict-mode marker was classified numerically confined'
+        end if
+        if (should_classify_numerically_confined(ORBIT_EXIT_NUMERICAL_MAXITER, &
+                ORBIT_GC, 1, .true., .false., .false., 0.01_dp)) then
+            error stop 'failure without exhausted recovery was classified confined'
+        end if
+        if (should_classify_numerically_confined(ORBIT_EXIT_NUMERICAL_MAXITER, &
+                ORBIT_FULL_ORBIT, 1, .true., .false., .true., 0.01_dp)) then
+            error stop 'full-orbit marker was classified numerically confined'
+        end if
+        if (should_classify_numerically_confined(ORBIT_EXIT_NUMERICAL_MAXITER, &
+                ORBIT_GC, 0, .true., .false., .true., 0.01_dp)) then
+            error stop 'non-symplectic marker was classified numerically confined'
+        end if
+        if (should_classify_numerically_confined(ORBIT_EXIT_NUMERICAL_DOMAIN, &
+                ORBIT_GC, 1, .true., .false., .true., 0.01_dp)) then
+            error stop 'domain failure was classified numerically confined'
+        end if
+    end subroutine test_numerically_confined_classification
 
     subroutine test_fo_lcfs_location
         real(dp), parameter :: z_before(5) = [0.9_dp, 6.2_dp, 3.0_dp, 1.0_dp, &

--- a/test/tests/test_sympl_testfield.f90
+++ b/test/tests/test_sympl_testfield.f90
@@ -42,13 +42,14 @@ program test_sympl_testfield
         locate_validated_lcfs, macrostep, macrostep_with_wall_check, &
         rk_recovery_state_t, validate_rk_state, &
         activate_rk_recovery, should_resume_symplectic
-    use simple, only : tracer_t, init_sympl, ORBIT_FO_LOSS, ORBIT_FO_NUMERICAL
+    use simple, only : tracer_t, init_sympl, reseed_sympl, ORBIT_FO_LOSS, &
+        ORBIT_FO_NUMERICAL
     use params, only : isw_field_type, field_input, coord_input, integmode, &
         swcoll, orbit_model, ORBIT_GC, ORBIT_FULL_ORBIT, ORBIT_EXIT_LCFS, &
         ORBIT_EXIT_WALL, ORBIT_EXIT_NUMERICAL_DOMAIN, &
         ORBIT_EXIT_NUMERICAL_MAXITER, ORBIT_EXIT_NUMERICAL_EVENT, &
         ORBIT_EXIT_NUMERICAL_FULL_ORBIT
-    use magfie_sub, only : TEST
+    use magfie_sub, only : TEST, init_magfie
     use field_can_mod, only : evaluate
     use orbit_symplectic, only : orbit_timestep_sympl
     use orbit_symplectic_base, only: SYMPLECTIC_STEP_BOUNDARY, &
@@ -70,6 +71,7 @@ program test_sympl_testfield
     integmode = 1
 
     call init_field(norb, vmec_file, ans_s, ans_tp, amultharm, integmode)
+    call init_magfie(TEST)
 
     if (.not. associated(evaluate)) then
         print *, 'evaluate pointer not associated for TEST field'
@@ -101,6 +103,7 @@ program test_sympl_testfield
     call test_fo_lcfs_location
     call test_validated_rk_lcfs_location
     call test_rk_state_validation
+    call test_reseed_momentum_reference
 
     print *, 'TEST field symplectic step succeeded'
 
@@ -211,45 +214,78 @@ contains
 
     subroutine test_rk_recovery_regions
         type(rk_recovery_state_t) :: recovery
+        real(dp) :: z(5)
 
-        call activate_rk_recovery(recovery, 0.005_dp)
+        z = [0.005_dp, 0.0_dp, 0.0_dp, 1.0_dp, 0.0_dp]
+        call activate_rk_recovery(recovery, z, 1.0_dp)
         if (.not. recovery%active) error stop 'near-axis RK recovery did not start'
-        if (should_resume_symplectic(recovery, 0.015_dp)) then
+        if (.not. recovery%has_momentum_reference) then
+            error stop 'RK recovery did not retain its momentum reference'
+        end if
+        if (recovery%momentum_reference /= 1.0_dp) then
+            error stop 'RK recovery changed its momentum reference'
+        end if
+        recovery%safe_steps = 255
+        z(1) = 0.12_dp
+        if (should_resume_symplectic(recovery, z)) then
             error stop 'near-axis recovery resumed inside its hysteresis band'
         end if
-        if (.not. should_resume_symplectic(recovery, 0.02_dp)) then
-            error stop 'near-axis recovery did not resume outside the axis band'
+        recovery%safe_steps = 256
+        if (.not. should_resume_symplectic(recovery, z)) then
+            error stop 'near-axis recovery did not resume after a safe streak'
         end if
 
         recovery = rk_recovery_state_t()
-        call activate_rk_recovery(recovery, 0.5_dp)
-        recovery%steps = 255
-        if (should_resume_symplectic(recovery, 0.5_dp)) then
+        z(1) = 0.5_dp
+        call activate_rk_recovery(recovery, z, 1.0_dp)
+        recovery%safe_steps = 255
+        if (should_resume_symplectic(recovery, z)) then
             error stop 'generic recovery ignored its first cooldown'
         end if
-        recovery%steps = 256
-        if (.not. should_resume_symplectic(recovery, 0.5_dp)) then
+        recovery%safe_steps = 256
+        if (.not. should_resume_symplectic(recovery, z)) then
             error stop 'generic recovery did not probe after its cooldown'
         end if
-        call activate_rk_recovery(recovery, 0.5_dp)
-        recovery%steps = 511
-        if (should_resume_symplectic(recovery, 0.5_dp)) then
+        call activate_rk_recovery(recovery, z, 1.0_dp)
+        recovery%safe_steps = 511
+        if (should_resume_symplectic(recovery, z)) then
             error stop 'repeated generic recovery did not back off'
         end if
-        recovery%steps = 512
-        if (.not. should_resume_symplectic(recovery, 0.5_dp)) then
+        recovery%safe_steps = 512
+        if (.not. should_resume_symplectic(recovery, z)) then
             error stop 'backed-off generic recovery never resumed probing'
         end if
 
         recovery = rk_recovery_state_t()
-        call activate_rk_recovery(recovery, 0.995_dp)
-        if (should_resume_symplectic(recovery, 0.99_dp)) then
+        z(1) = 0.995_dp
+        call activate_rk_recovery(recovery, z, 1.0_dp)
+        recovery%safe_steps = 256
+        z(1) = 0.99_dp
+        if (should_resume_symplectic(recovery, z)) then
             error stop 'edge recovery resumed before moving safely inward'
         end if
-        if (.not. should_resume_symplectic(recovery, 0.98_dp)) then
+        z(1) = 0.98_dp
+        if (.not. should_resume_symplectic(recovery, z)) then
             error stop 'edge recovery did not resume after moving inward'
         end if
     end subroutine test_rk_recovery_regions
+
+    subroutine test_reseed_momentum_reference
+        real(dp) :: z(5)
+
+        z = [0.2_dp, 1.0_dp, 0.0_dp, 1.02_dp, 0.25_dp]
+        call reseed_sympl(norb%si, norb%f, z, 1.0_dp)
+        if (norb%si%pabs /= 1.0_dp) then
+            error stop 'reseed ratcheted the symplectic momentum reference'
+        end if
+        if (abs(norb%f%H - 1.0_dp) > 100.0_dp*epsilon(1.0_dp)) then
+            error stop 'reseed did not project onto the reference energy shell'
+        end if
+        if (abs(norb%f%vpar/sqrt(2.0_dp) - 0.25_dp) > &
+                100.0_dp*epsilon(1.0_dp)) then
+            error stop 'momentum-shell projection changed the pitch coordinate'
+        end if
+    end subroutine test_reseed_momentum_reference
 
     subroutine test_exit_classification
         logical :: classifier_lost
@@ -398,10 +434,17 @@ contains
             error stop 'wrong-energy adaptive-RK branch was committed'
         endif
 
-        z_after = [0.21_dp, 0.4_dp, 0.5_dp, 1.01_dp, 0.5_dp]
+        z_after = [0.21_dp, 0.4_dp, 0.5_dp, 1.004_dp, 0.5_dp]
         step_error = 0
         call validate_rk_state(z_before, z_after, step_error, 1.0_dp)
         if (step_error /= 0) error stop 'bounded adaptive-RK momentum drift was rejected'
+
+        z_after = [0.21_dp, 0.4_dp, 0.5_dp, 1.006_dp, 0.5_dp]
+        step_error = 0
+        call validate_rk_state(z_before, z_after, step_error, 1.0_dp)
+        if (step_error /= 2 .or. any(z_after /= z_before)) then
+            error stop 'excessive adaptive-RK momentum drift was committed'
+        end if
 
         z_after = [0.21_dp, 0.4_dp, 0.5_dp, 1.1_dp, 2.0_dp]
         step_error = 0

--- a/test/tests/test_sympl_testfield.f90
+++ b/test/tests/test_sympl_testfield.f90
@@ -40,6 +40,7 @@ program test_sympl_testfield
     use classification, only: classify_classifier_exit
     use simple_main, only : classify_orbit_exit, init_field, locate_linear_lcfs, &
         locate_validated_lcfs, macrostep, macrostep_with_wall_check, &
+        recovery_state_has_valid_phase_space, recovery_state_is_physical, &
         rk_recovery_state_t, validate_rk_state, &
         activate_rk_recovery, should_resume_symplectic
     use simple, only : tracer_t, init_sympl, reseed_sympl, ORBIT_FO_LOSS, &
@@ -103,6 +104,7 @@ program test_sympl_testfield
     call test_fo_lcfs_location
     call test_validated_rk_lcfs_location
     call test_rk_state_validation
+    call test_recovery_state_validation
     call test_reseed_momentum_reference
 
     print *, 'TEST field symplectic step succeeded'
@@ -391,10 +393,12 @@ contains
     subroutine test_validated_rk_lcfs_location
         real(dp), parameter :: z_before(5) = [0.9_dp, 0.2_dp, 0.3_dp, 1.0_dp, &
             -0.5_dp]
-        real(dp), parameter :: z_after(5) = [1.1_dp, 0.4_dp, 0.5_dp, 2.0_dp, &
+        real(dp), parameter :: z_after(5) = [1.1_dp, 0.4_dp, 0.5_dp, 1.004_dp, &
             0.5_dp]
-        real(dp), parameter :: z_gross_jump(5) = [100.0_dp, 0.4_dp, 0.5_dp, &
+        real(dp), parameter :: z_no_crossing(5) = [0.8_dp, 0.4_dp, 0.5_dp, &
             2.0_dp, 0.5_dp]
+        real(dp), parameter :: z_invalid_event(5) = [1.1_dp, 0.4_dp, 0.5_dp, &
+            1.0_dp, 4.0_dp]
         real(dp), parameter :: tolerance = 32.0_dp*epsilon(1.0_dp)
         real(dp) :: z_event(5), event_fraction
         integer :: step_error
@@ -408,11 +412,19 @@ contains
         end if
 
         step_error = 1
-        call locate_validated_lcfs(z_before, z_gross_jump, 6.0_dp, z_event, &
+        call locate_validated_lcfs(z_before, z_no_crossing, 6.0_dp, z_event, &
             event_fraction, step_error)
         if (step_error /= 2 .or. event_fraction /= 0.0_dp .or. &
             any(z_event /= z_before)) then
-            error stop 'gross adaptive-RK jump was classified as a physical loss'
+            error stop 'adaptive-RK chamber flag without a crossing became a loss'
+        end if
+
+        step_error = 1
+        call locate_validated_lcfs(z_before, z_invalid_event, 6.0_dp, z_event, &
+            event_fraction, step_error)
+        if (step_error /= 2 .or. event_fraction /= 0.0_dp .or. &
+            any(z_event /= z_before)) then
+            error stop 'unphysical adaptive-RK chamber event became a loss'
         end if
     end subroutine test_validated_rk_lcfs_location
 
@@ -453,5 +465,31 @@ contains
             error stop 'invalid adaptive-RK state was committed'
         end if
     end subroutine test_rk_state_validation
+
+    subroutine test_recovery_state_validation
+        real(dp) :: z(5)
+
+        z = [0.2_dp, 0.3_dp, 0.4_dp, 1.0_dp, 0.5_dp]
+        if (.not. recovery_state_has_valid_phase_space(z)) then
+            error stop 'physical recovery state was rejected'
+        end if
+        if (.not. recovery_state_is_physical(z, 1.0_dp)) then
+            error stop 'recovery state on the momentum shell was rejected'
+        end if
+
+        z(5) = 2.0_dp
+        if (recovery_state_has_valid_phase_space(z)) then
+            error stop 'recovery state with impossible pitch was accepted'
+        end if
+
+        z = [0.2_dp, 0.3_dp, 0.4_dp, 1.004_dp, 0.5_dp]
+        if (.not. recovery_state_is_physical(z, 1.0_dp)) then
+            error stop 'bounded recovery momentum drift was rejected'
+        end if
+        z(4) = 1.006_dp
+        if (recovery_state_is_physical(z, 1.0_dp)) then
+            error stop 'excessive recovery momentum drift was accepted'
+        end if
+    end subroutine test_recovery_state_validation
 
 end program test_sympl_testfield

--- a/test/tests/test_sympl_testfield.f90
+++ b/test/tests/test_sympl_testfield.f90
@@ -97,7 +97,6 @@ program test_sympl_testfield
     call test_macrostep_lcfs_event
     call test_failed_step_preserves_state
     call test_rk_recovery_regions
-    call test_both_methods_failed_hold
     call test_exit_classification
     call test_fo_lcfs_location
     call test_validated_rk_lcfs_location
@@ -167,23 +166,13 @@ contains
         symplectic_newton_warning_mode = .true.
         call macrostep(norb, z, kt, step_error, 1, hold_streak=hold_streak, &
             numerical_hold_any=numerical_hold)
-        if (step_error /= 0) error stop 'warning mode stopped a failed step'
-        if (kt /= 1_int64) error stop 'warning mode did not consume the failed step'
-        if (.not. numerical_hold .or. hold_streak == 0) &
-            error stop 'warning mode did not report the held interval'
+        if (step_error == 0) error stop 'warning mode hid exhausted recovery'
+        if (kt /= 0_int64) error stop 'warning mode consumed a failed step'
+        if (numerical_hold .or. hold_streak == 0) &
+            error stop 'warning mode misreported exhausted recovery'
         if (any(z /= initial_state)) then
-            error stop 'warning-mode skip changed the last accepted state'
+            error stop 'warning-mode failure changed the last accepted state'
         end if
-        call macrostep(norb, z, kt, step_error, 1, hold_streak=hold_streak, &
-            numerical_hold_any=numerical_hold)
-        if (step_error /= 0) &
-            error stop 'repeated warning failure stopped the orbit'
-        if (kt /= 2_int64) &
-            error stop 'repeated warning failure did not consume one interval'
-        if (.not. numerical_hold .or. hold_streak == 0) &
-            error stop 'repeated warning failure lost its diagnostic status'
-        if (any(z /= initial_state)) &
-            error stop 'repeated warning hold changed the accepted state'
 
         z = initial_state
         x_previous = 0.0_dp
@@ -191,24 +180,13 @@ contains
         hold_streak = 0
         call macrostep_with_wall_check(norb, z, kt, step_error, 1, 1, x_previous, &
             hold_streak=hold_streak, numerical_hold_any=numerical_hold)
-        if (step_error /= 0) error stop 'warning-mode wall path stopped a failed step'
-        if (kt /= 1_int64) &
-            error stop 'warning-mode wall path did not consume the failed step'
-        if (.not. numerical_hold .or. hold_streak == 0) &
-            error stop 'warning-mode wall path did not latch the failure'
+        if (step_error == 0) error stop 'warning wall path hid exhausted recovery'
+        if (kt /= 0_int64) error stop 'warning wall path consumed a failed step'
+        if (numerical_hold .or. hold_streak == 0) &
+            error stop 'warning wall path misreported exhausted recovery'
         if (any(z /= initial_state)) then
-            error stop 'warning-mode wall skip changed the last accepted state'
+            error stop 'warning wall failure changed the last accepted state'
         end if
-        call macrostep_with_wall_check(norb, z, kt, step_error, 1, 1, x_previous, &
-            hold_streak=hold_streak, numerical_hold_any=numerical_hold)
-        if (step_error /= 0) &
-            error stop 'repeated wall warning failure stopped the orbit'
-        if (kt /= 2_int64) &
-            error stop 'repeated wall warning did not consume one interval'
-        if (.not. numerical_hold .or. hold_streak == 0) &
-            error stop 'repeated wall warning lost its diagnostic status'
-        if (any(z /= initial_state)) &
-            error stop 'repeated wall warning changed the accepted state'
     end subroutine test_failed_step_preserves_state
 
     subroutine test_rk_recovery_regions
@@ -253,88 +231,61 @@ contains
         end if
     end subroutine test_rk_recovery_regions
 
-    subroutine test_both_methods_failed_hold
-        real(dp), parameter :: initial_state(5) = [0.2_dp, 1.0_dp, 2.0_dp, &
-            1.0_dp, 0.25_dp]
-        type(rk_recovery_state_t) :: recovery
-        real(dp) :: z(5), x_previous(3)
-        integer(int64) :: kt
-        integer :: step_error
-        logical :: numerical_hold
-
-        recovery%active = .true.
-        recovery%both_methods_failed = .true.
-        z = initial_state
-        kt = 0_int64
-        call macrostep(norb, z, kt, step_error, 2, &
-            numerical_hold_any=numerical_hold, rk_recovery=recovery)
-        if (step_error /= 0) error stop 'latched recovery hold stopped the orbit'
-        if (kt /= 2_int64) error stop 'latched recovery did not consume intervals'
-        if (.not. numerical_hold) error stop 'latched recovery lost held status'
-        if (any(z /= initial_state)) &
-            error stop 'latched recovery changed the accepted state'
-        if (.not. recovery%both_methods_failed) &
-            error stop 'latched recovery state was cleared'
-
-        recovery%active = .true.
-        recovery%both_methods_failed = .true.
-        z = initial_state
-        x_previous = 0.0_dp
-        kt = 0_int64
-        call macrostep_with_wall_check(norb, z, kt, step_error, 2, 1, &
-            x_previous, numerical_hold_any=numerical_hold, &
-            rk_recovery=recovery)
-        if (step_error /= 0) error stop 'latched wall hold stopped the orbit'
-        if (kt /= 2_int64) error stop 'latched wall hold did not consume intervals'
-        if (.not. numerical_hold) error stop 'latched wall hold lost held status'
-        if (any(z /= initial_state)) &
-            error stop 'latched wall hold changed the accepted state'
-        if (.not. recovery%both_methods_failed) &
-            error stop 'latched wall recovery state was cleared'
-    end subroutine test_both_methods_failed_hold
-
     subroutine test_exit_classification
         logical :: classifier_lost
         integer :: classifier_exit
 
-        if (classify_orbit_exit(SYMPLECTIC_STEP_BOUNDARY, ORBIT_GC, 3, .true.) /= &
+        if (classify_orbit_exit(SYMPLECTIC_STEP_BOUNDARY, ORBIT_GC, 3, &
+            ORBIT_EXIT_LCFS) /= &
             ORBIT_EXIT_LCFS) then
             error stop 'converged LCFS event was not classified as physical'
         end if
-        if (classify_orbit_exit(SYMPLECTIC_STEP_BOUNDARY, ORBIT_GC, 3, .false.) /= &
+        if (classify_orbit_exit(SYMPLECTIC_STEP_BOUNDARY, ORBIT_GC, 3, &
+            ORBIT_EXIT_NUMERICAL_DOMAIN) /= &
             ORBIT_EXIT_NUMERICAL_DOMAIN) then
             error stop 'extended map boundary was classified as physical LCFS'
         end if
-        if (classify_orbit_exit(77, ORBIT_GC, 3, .true.) /= ORBIT_EXIT_WALL) then
+        if (classify_orbit_exit(SYMPLECTIC_STEP_BOUNDARY, ORBIT_GC, 3, &
+            ORBIT_EXIT_WALL) /= ORBIT_EXIT_WALL) then
+            error stop 'coordinate wall was not classified as physical'
+        end if
+        if (classify_orbit_exit(77, ORBIT_GC, 3, ORBIT_EXIT_LCFS) /= &
+            ORBIT_EXIT_WALL) then
             error stop 'wall event was not classified as physical'
         end if
-        if (classify_orbit_exit(77, ORBIT_GC, 0, .true.) /= ORBIT_EXIT_WALL) then
+        if (classify_orbit_exit(77, ORBIT_GC, 0, ORBIT_EXIT_LCFS) /= &
+            ORBIT_EXIT_WALL) then
             error stop 'axis wall event was not classified as physical'
         end if
-        if (classify_orbit_exit(1, ORBIT_GC, 3, .true.) /= &
+        if (classify_orbit_exit(1, ORBIT_GC, 3, ORBIT_EXIT_LCFS) /= &
             ORBIT_EXIT_NUMERICAL_DOMAIN) then
             error stop 'exterior Newton iterate was classified as physical'
         end if
-        if (classify_orbit_exit(ORBIT_FO_LOSS, ORBIT_FULL_ORBIT, 3, .true.) /= &
+        if (classify_orbit_exit(ORBIT_FO_LOSS, ORBIT_FULL_ORBIT, 3, &
+            ORBIT_EXIT_LCFS) /= &
             ORBIT_EXIT_LCFS) then
             error stop 'full-orbit LCFS exit was not classified as physical'
         end if
-        if (classify_orbit_exit(ORBIT_FO_LOSS, ORBIT_FULL_ORBIT, 3, .false.) /= &
+        if (classify_orbit_exit(ORBIT_FO_LOSS, ORBIT_FULL_ORBIT, 3, &
+            ORBIT_EXIT_NUMERICAL_DOMAIN) /= &
             ORBIT_EXIT_NUMERICAL_DOMAIN) then
             error stop 'extended full-orbit map boundary was classified as physical'
         end if
-        if (classify_orbit_exit(ORBIT_FO_NUMERICAL, ORBIT_FULL_ORBIT, 3, .true.) /= &
+        if (classify_orbit_exit(ORBIT_FO_NUMERICAL, ORBIT_FULL_ORBIT, 3, &
+            ORBIT_EXIT_LCFS) /= &
             ORBIT_EXIT_NUMERICAL_FULL_ORBIT) then
             error stop 'full-orbit locate failure was classified as physical'
         end if
-        if (classify_orbit_exit(1, ORBIT_GC, 0, .true.) /= ORBIT_EXIT_LCFS) then
+        if (classify_orbit_exit(1, ORBIT_GC, 0, ORBIT_EXIT_LCFS) /= &
+            ORBIT_EXIT_LCFS) then
             error stop 'RK LCFS exit was classified as numerical'
         end if
-        if (classify_orbit_exit(1, ORBIT_GC, 0, .false.) /= &
+        if (classify_orbit_exit(1, ORBIT_GC, 0, &
+            ORBIT_EXIT_NUMERICAL_DOMAIN) /= &
             ORBIT_EXIT_NUMERICAL_DOMAIN) then
             error stop 'RK extended-map boundary was classified as physical'
         end if
-        if (classify_orbit_exit(2, ORBIT_GC, 0, .true.) /= &
+        if (classify_orbit_exit(2, ORBIT_GC, 0, ORBIT_EXIT_LCFS) /= &
             ORBIT_EXIT_NUMERICAL_EVENT) then
             error stop 'RK integration fault was classified as physical'
         end if

--- a/test/tests/test_sympl_testfield.f90
+++ b/test/tests/test_sympl_testfield.f90
@@ -166,12 +166,22 @@ contains
         symplectic_newton_warning_mode = .true.
         call macrostep(norb, z, kt, step_error, 1, hold_streak=hold_streak, &
             numerical_hold_any=numerical_hold)
-        if (step_error == 0) error stop 'warning mode hid exhausted recovery'
-        if (kt /= 0_int64) error stop 'warning mode consumed a failed step'
-        if (numerical_hold .or. hold_streak == 0) &
-            error stop 'warning mode misreported exhausted recovery'
+        if (step_error /= 0) error stop 'isolated warning failure stopped orbit'
+        if (kt /= 1_int64) error stop 'isolated warning hold lost its interval'
+        if (.not. numerical_hold .or. hold_streak /= 1) &
+            error stop 'isolated warning hold was not reported'
         if (any(z /= initial_state)) then
-            error stop 'warning-mode failure changed the last accepted state'
+            error stop 'isolated warning hold changed the last accepted state'
+        end if
+
+        call macrostep(norb, z, kt, step_error, 1, hold_streak=hold_streak, &
+            numerical_hold_any=numerical_hold)
+        if (step_error == 0) error stop 'repeated warning failure was hidden'
+        if (kt /= 1_int64) error stop 'repeated failure consumed another interval'
+        if (numerical_hold .or. hold_streak /= 1) &
+            error stop 'repeated warning failure was misreported'
+        if (any(z /= initial_state)) then
+            error stop 'repeated warning failure changed the last accepted state'
         end if
 
         z = initial_state
@@ -180,12 +190,22 @@ contains
         hold_streak = 0
         call macrostep_with_wall_check(norb, z, kt, step_error, 1, 1, x_previous, &
             hold_streak=hold_streak, numerical_hold_any=numerical_hold)
-        if (step_error == 0) error stop 'warning wall path hid exhausted recovery'
-        if (kt /= 0_int64) error stop 'warning wall path consumed a failed step'
-        if (numerical_hold .or. hold_streak == 0) &
-            error stop 'warning wall path misreported exhausted recovery'
+        if (step_error /= 0) error stop 'isolated wall warning stopped orbit'
+        if (kt /= 1_int64) error stop 'isolated wall hold lost its interval'
+        if (.not. numerical_hold .or. hold_streak /= 1) &
+            error stop 'isolated wall hold was not reported'
         if (any(z /= initial_state)) then
-            error stop 'warning wall failure changed the last accepted state'
+            error stop 'isolated wall hold changed the last accepted state'
+        end if
+
+        call macrostep_with_wall_check(norb, z, kt, step_error, 1, 1, x_previous, &
+            hold_streak=hold_streak, numerical_hold_any=numerical_hold)
+        if (step_error == 0) error stop 'repeated wall failure was hidden'
+        if (kt /= 1_int64) error stop 'repeated wall failure consumed another interval'
+        if (numerical_hold .or. hold_streak /= 1) &
+            error stop 'repeated wall failure was misreported'
+        if (any(z /= initial_state)) then
+            error stop 'repeated wall failure changed the last accepted state'
         end if
     end subroutine test_failed_step_preserves_state
 

--- a/test/tests/test_sympl_testfield.f90
+++ b/test/tests/test_sympl_testfield.f90
@@ -391,6 +391,18 @@ contains
         call validate_rk_state(z_before, z_after, step_error)
         if (step_error /= 0) error stop 'valid adaptive-RK state was rejected'
 
+        z_after = [0.21_dp, 0.4_dp, 0.5_dp, 1.1_dp, 0.5_dp]
+        step_error = 0
+        call validate_rk_state(z_before, z_after, step_error, 1.0_dp)
+        if (step_error /= 2 .or. any(z_after /= z_before)) then
+            error stop 'wrong-energy adaptive-RK branch was committed'
+        endif
+
+        z_after = [0.21_dp, 0.4_dp, 0.5_dp, 1.01_dp, 0.5_dp]
+        step_error = 0
+        call validate_rk_state(z_before, z_after, step_error, 1.0_dp)
+        if (step_error /= 0) error stop 'bounded adaptive-RK momentum drift was rejected'
+
         z_after = [0.21_dp, 0.4_dp, 0.5_dp, 1.1_dp, 2.0_dp]
         step_error = 0
         call validate_rk_state(z_before, z_after, step_error)


### PR DESCRIPTION
## What changed

- Keep recursive symplectic retries transactional and retain the intentional
  historical warning-level default with one bounded isolated hold.
- Try the unchanged adaptive-RK guiding-centre interval first. If the
  conventional `B_parallel_star` denominator is singular, continue only that
  interval through the established toroidally regularized, axis-local, and
  co-rotating Cartesian recovery cascade.
- Reject nominally successful recovery states with non-finite phase space,
  impossible pitch, non-positive momentum, or more than 0.5% collisionless
  momentum drift.
- Return to the requested symplectic method after 256 consecutive safe
  conventional-RK intervals outside the axis/edge hysteresis region.
- Classify a marker as `ORBIT_EXIT_NUMERICAL_CONFINED` (code 4) only after all
  recovery paths are exhausted, and only for collisionless guiding-centre
  tracing in warning mode when its last validated normalized toroidal flux is
  below `s=0.01`. VMEC coordinates already store `s`; chartmap radii are
  converted as `s=rho^2`.
- Keep code 4 unavailable to SPECTRE, W7-X acceptance, collisions, full-orbit
  tracing, strict mode, and every other exit cause. Record it separately in
  NetCDF/results accounting and restart state.

Successful legacy RK intervals, the source ensemble, field, wall, boundary
conditions, symmetry, units, and ordinary Meiss/Boozer symplectic paths remain
unchanged. Intentional deep-passing source screens also remain code 3.

## Root cause and bounded fallback

The SQUID failures occur when the conventional guiding-centre factor

`B_parallel_star = B + (m/e) p_parallel b dot curl(b)`

crosses zero. The release warning policy could leave such a marker frozen
indefinitely; a bounded warning policy exposes the exhausted recovery. Axis
smoothing, denser near-axis reconstruction, Zernike continuation, and naive
curl rescaling do not remove this physical coordinate singularity.

The broad experiment that accepted every finite Newton iterate was rejected:
the exact three-marker SQUID diagnostic exceeded ten minutes instead of the
bounded policy's 43.4 seconds. The final fallback therefore does not advance an
unvalidated state. It closes only an already core-confined marker after all
physical recovery attempts fail, with a separate auditable exit code.

## Local validation

- Candidate: SIMPLE `5a0b7e5de17d154380e68717832c28a7cbf9ffeb` and current
  libneo main `e2b281b1bc9f9f48f9526622445e0b2c0f8a4984`.
- The full bare `fo` pipeline passed static analysis, build, the default test
  suite, and lint twice; the final run completed in 314.9 s. No golden record
  changed.
- Exact W7-X marker 5557 completed 0.1 s with code 0.
- The exact SQUID diagnostic completed in 43.4 s with codes `4, 4, 2` and zero
  unresolved markers. The code-4 endpoints are at chartmap `rho=0.0204` and
  `0.0930`, hence `s=0.00042` and `0.00864`; the third marker retains its
  physical wall code 2. Recovery counters match the bounded baseline.
- The paired 1,024-marker historical runs have zero numerical exits and are
  byte-identical to the preceding physical-recovery candidate: Albert has 958
  physical losses and 66 completions; Meiss--Hazeltine has 966 losses and 58
  completions. Albert differs from the release loss fraction by 1.17 percentage
  points. The larger old Meiss/old-libneo difference predates this patch and the
  old endpoints include severe invariant corruption, so no golden was rewritten
  to conceal it.

## Cluster acceptance in progress

The complete paired rerun is live from clean immutable roots with the same
SIMPLE/libneo revisions:

- JNME on sCluster: build `735896`, exact diagnostics `735897`, diagnostic gate
  `735898`, all-case smoke `735899`, smoke gate `735900`, production array
  `735901`, and final acceptance `735902`. Build, exact diagnostics, and all 14
  smoke cases have passed; full production is running. Each orbit job uses 48
  CPUs and 96 GiB.
- SPECTRE on institute HTCondor: DAG `156`, smoke cluster `157`, then all five
  256-marker, 0.3 s production cases. The GNU 14.2 Release binary SHA-256 is
  `33f4c760ba4465ce94dc449a9679185776f99cbb2714cc0200cb874b8f1550a5`.

Final acceptance requires zero code-102 exits, zero unresolved markers,
unchanged intentional deep-passing screens, the established SPECTRE
populations, and physical loss fractions within one percentage point of the
applicable release or paper reference. This PR remains draft until both full
campaigns pass and the retained historical comparison is explicitly judged.
